### PR TITLE
Opencl improvements round 1

### DIFF
--- a/pysph/base/tests/test_translator.py
+++ b/pysph/base/tests/test_translator.py
@@ -221,6 +221,33 @@ def test_subscript():
     assert code == expect.strip()
 
 
+def test_known_math_constants():
+    # Given
+    src = dedent('''
+    x = M_E + M_LOG2E + M_LOG10E + M_LN2 + M_LN10
+    x += M_PI + M_PI_2 + M_PI_4 + M_1_PI * M_2_PI
+    x += M_2_SQRTPI * M_SQRT2 * M_SQRT1_2 * pi
+    x = INFINITY
+    x = NAN
+    x = HUGE_VALF
+    ''')
+
+    # When
+    code = py2c(src)
+
+    # Then
+    expect = dedent('''
+    double x;
+    x = ((((M_E + M_LOG2E) + M_LOG10E) + M_LN2) + M_LN10);
+    x += (((M_PI + M_PI_2) + M_PI_4) + (M_1_PI * M_2_PI));
+    x += (((M_2_SQRTPI * M_SQRT2) * M_SQRT1_2) * pi);
+    x = INFINITY;
+    x = NAN;
+    x = HUGE_VALF;
+    ''')
+    assert code == expect.strip()
+
+
 def test_simple_function_with_return():
     # Given
     src = dedent('''

--- a/pysph/base/tests/test_translator.py
+++ b/pysph/base/tests/test_translator.py
@@ -262,7 +262,8 @@ def test_simple_function_with_return():
 
     # Then
     expect = dedent('''
-    double f(double x) {
+    double f(double x)
+    {
         double y;
         y = (x + 1);
         return y;
@@ -284,7 +285,8 @@ def test_simple_function_without_return():
 
     # Then
     expect = dedent('''
-    void f(double y, double x) {
+    void f(double y, double x)
+    {
         double z;
         z = (y + x);
         y = z;
@@ -305,9 +307,11 @@ def test_function_argument_types():
 
     # Then
     expect = dedent('''
-    void f(long s_idx, double* s_p, long d_idx, double* d_p, long J, double t, double* l, double* xx) {
-        ;
-    }
+void f(long s_idx, double* s_p, long d_idx, double* d_p, long J, double t,
+    double* l, double* xx)
+{
+    ;
+}
     ''')
     assert code.strip() == expect.strip()
 
@@ -325,7 +329,8 @@ def test_known_types_in_funcargs():
 
     # Then
     expect = dedent('''
-    void f(float32 x, foo* xx, int cond) {
+    void f(float32 x, foo* xx, int cond)
+    {
         ;
     }
     ''')
@@ -380,7 +385,8 @@ def test_user_supplied_detect_type():
 
     # Then
     expect = dedent('''
-    void f(double x, double xx, double cond) {
+    void f(double x, double xx, double cond)
+    {
         ;
     }
     ''')
@@ -708,11 +714,13 @@ def test_class():
 
     # Then
     expect = dedent('''
-    void Foo_g(Foo* self, double x) {
+    void Foo_g(Foo* self, double x)
+    {
         ;
     }
 
-    void Foo_f(Foo* self, double x) {
+    void Foo_f(Foo* self, double x)
+    {
         double y;
         y = (x + 1);
         do(self->a, x);
@@ -822,7 +830,8 @@ def test_wrapping_class():
     } Dummy;
 
 
-    void Dummy_method(Dummy* self) {
+    void Dummy_method(Dummy* self)
+    {
         ;
     }
     ''')
@@ -849,9 +858,11 @@ def test_opencl_conversion():
 
     # Then
     expect = dedent('''
-    void f(long s_idx, __global double* s_p, long d_idx, __global double* d_p, long J, double t, double* l, double* xx) {
-        ;
-    }
+void f(long s_idx, __global double* s_p, long d_idx, __global double* d_p,
+    long J, double t, double* l, double* xx)
+{
+    ;
+}
     ''')
     assert code.strip() == expect.strip()
 
@@ -869,7 +880,8 @@ def test_opencl_class():
 
     # Then
     expect = dedent('''
-    void Foo_g(__global Foo* self, double x) {
+    void Foo_g(__global Foo* self, double x)
+    {
         ;
     }
     ''')

--- a/pysph/base/translator.py
+++ b/pysph/base/translator.py
@@ -119,7 +119,12 @@ class CStructHelper(object):
 class CConverter(ast.NodeVisitor):
     def __init__(self, detect_type=detect_type, known_types=None):
         self._declares = {}
-        self._known = set(('M_PI', 'M_PI_2', 'M_PI_4', 'M_1_PI', 'M_2_PI'))
+        self._known = set((
+            'M_E', 'M_LOG2E', 'M_LOG10E', 'M_LN2', 'M_LN10',
+            'M_PI', 'M_PI_2', 'M_PI_4', 'M_1_PI', 'M_2_PI',
+            'M_2_SQRTPI', 'M_SQRT2', 'M_SQRT1_2',
+            'INFINITY', 'NAN', 'HUGE_VALF', 'pi'
+        ))
         self._name_ctx = (ast.Load, ast.Store)
         self._indent = ''
         self._detect_type = detect_type

--- a/pysph/base/translator.py
+++ b/pysph/base/translator.py
@@ -13,7 +13,7 @@ import ast
 import inspect
 import re
 import sys
-from textwrap import dedent
+from textwrap import dedent, wrap
 
 import numpy as np
 from mako.template import Template
@@ -359,17 +359,18 @@ class CConverter(ast.NodeVisitor):
         else:
             func_name = node.name
         if self._body_has_return(body):
-            sig = 'double %s(%s) {\n' % (func_name, args)
+            sig = 'double %s(%s)' % (func_name, args)
         else:
-            sig = 'void %s(%s) {\n' % (func_name, args)
+            sig = 'void %s(%s)' % (func_name, args)
 
         declares = self._indent_block(self.get_declarations())
         if len(declares) > 0:
             declares += '\n'
 
+        sig = '\n'.join(wrap(sig, width=78, subsequent_indent=' '*4))
         self._known = orig_known
         self._declares = orig_declares
-        return sig + declares + body + '\n}\n'
+        return sig + '\n{\n' + declares + body + '\n}\n'
 
     def visit_Gt(self, node):
         return '>'

--- a/pysph/sph/acceleration_eval_cython.mako
+++ b/pysph/sph/acceleration_eval_cython.mako
@@ -112,6 +112,7 @@ nnps.update()
 % endfor
 </%def>
 
+from libc.stdio cimport printf
 from libc.math cimport *
 from libc.math cimport fabs as abs
 from libc.math cimport M_PI as pi

--- a/pysph/sph/acceleration_eval_opencl.mako
+++ b/pysph/sph/acceleration_eval_opencl.mako
@@ -1,14 +1,16 @@
 <%def name="do_group(helper, g_idx, group)" buffered="True">
-% for dest, (eqs_with_no_source, sources, all_eqs) in group.data.items():
-% if all_eqs.has_initialize():
 // ------------------------------------------------------------------
+// Group${g_idx}
+% for dest, (eqs_with_no_source, sources, all_eqs) in group.data.items():
+// Destination ${dest}
+% if all_eqs.has_initialize():
 // Initialization for destination ${dest}
 ${helper.get_initialize_kernel(g_idx, dest, all_eqs)}
 % endif
 
 % if len(eqs_with_no_source.equations) > 0:
 % if eqs_with_no_source.has_loop():
-// SPH Equations with no sources.
+// Equations with no sources.
 ${helper.get_simple_loop_kernel(g_idx, dest, all_eqs)}
 % endif
 % endif
@@ -25,8 +27,9 @@ ${helper.get_loop_kernel(g_idx, dest, source, eq_group)}
 ${helper.get_post_loop_kernel(g_idx, dest, all_eqs)}
 % endif
 // Finished destination ${dest}.
-// ------------------------------------------------------------------
 % endfor
+// Finished Group${g_idx}
+// ------------------------------------------------------------------
 </%def>
 
 #define abs fabs

--- a/pysph/sph/acceleration_eval_opencl.mako
+++ b/pysph/sph/acceleration_eval_opencl.mako
@@ -5,28 +5,31 @@
 // Destination ${dest}
 % if all_eqs.has_initialize():
 // Initialization for destination ${dest}
-${helper.get_initialize_kernel(g_idx, dest, all_eqs)}
+${helper.get_initialize_kernel(g_idx, group, dest, all_eqs)}
 % endif
 
 % if len(eqs_with_no_source.equations) > 0:
 % if eqs_with_no_source.has_loop():
 // Equations with no sources.
-${helper.get_simple_loop_kernel(g_idx, dest, all_eqs)}
+${helper.get_simple_loop_kernel(g_idx, group, dest, all_eqs)}
 % endif
 % endif
 
 % for source, eq_group in sources.items():
 // Source ${source}.
 % if eq_group.has_loop():
-${helper.get_loop_kernel(g_idx, dest, source, eq_group)}
+${helper.get_loop_kernel(g_idx, group, dest, source, eq_group)}
 % endif
 % endfor
 
 % if all_eqs.has_post_loop():
 // post_loop for destination ${dest}
-${helper.get_post_loop_kernel(g_idx, dest, all_eqs)}
+${helper.get_post_loop_kernel(g_idx, group, dest, all_eqs)}
 % endif
 // Finished destination ${dest}.
+% if group.update_nnps:
+<% helper.call_update_nnps(group) %>
+% endif
 % endfor
 // Finished Group${g_idx}
 // ------------------------------------------------------------------

--- a/pysph/sph/acceleration_eval_opencl.mako
+++ b/pysph/sph/acceleration_eval_opencl.mako
@@ -30,6 +30,7 @@ ${helper.get_post_loop_kernel(g_idx, dest, all_eqs)}
 </%def>
 
 #define abs fabs
+#define pi M_PI
 ${helper.get_header()}
 
 % for g_idx, group in enumerate(helper.object.mega_groups):

--- a/pysph/sph/acceleration_eval_opencl_helper.py
+++ b/pysph/sph/acceleration_eval_opencl_helper.py
@@ -372,7 +372,7 @@ class AccelerationEvalOpenCLHelper(object):
         pre = []
         for p, cb in eq_group.precomputed.items():
             src = cb.code.strip().splitlines()
-            pre.append('\n'.join([' '*4 + x + ';' for x in src]))
+            pre.extend([' '*4 + x + ';' for x in src])
         if len(pre) > 0:
             pre.append('')
         code.extend(pre)


### PR DESCRIPTION
First round of multiple improvements to OpenCL support.

- Prettify the generated code a bit.
- Add more math constants.
- Support printf in cython (works with openmp!)
- Support for real=True and update_nnps in OpenCL.