### PR TITLE
Fix BruteForceNNPS and ZOrderGPUNNPS for multiple particle arrays

### DIFF
--- a/pysph/base/gpu_nnps_base.pyx
+++ b/pysph/base/gpu_nnps_base.pyx
@@ -293,6 +293,8 @@ cdef class BruteForceNNPS(GPUNNPS):
         self.dst = self.pa_wrappers[ dst_index ]
 
     cdef void find_neighbor_lengths(self, nbr_lengths):
+        # IMPORTANT NOTE: pyopencl uses the length of the first argument
+        # to determine the global work size
         arguments = \
                 """%(data_t)s* d_x, %(data_t)s* d_y, %(data_t)s* d_z,
                 %(data_t)s* d_h, %(data_t)s* s_x, %(data_t)s* s_y,

--- a/pysph/base/gpu_nnps_helper.py
+++ b/pysph/base/gpu_nnps_helper.py
@@ -6,7 +6,7 @@ import os
 
 
 class GPUNNPSHelper(object):
-    def __init__(self, ctx, tpl_filename, use_double=True):
+    def __init__(self, ctx, tpl_filename, use_double=False):
         self.src_tpl = Template(
             filename=os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),

--- a/pysph/base/tests/test_nnps.py
+++ b/pysph/base/tests/test_nnps.py
@@ -390,7 +390,7 @@ class ZOrderGPUDoubleNNPSTestCase(DictBoxSortNNPSTestCase):
         cfg.use_double = True
         self.nps = gpu_nnps.ZOrderGPUNNPS(
             dim=3, particles=self.particles, radius_scale=2.0,
-            ctx=ctx
+            ctx=ctx, use_double=True
         )
 
     def tearDown(self):

--- a/pysph/base/tests/test_nnps.py
+++ b/pysph/base/tests/test_nnps.py
@@ -237,6 +237,12 @@ class DictBoxSortNNPSTestCase(NNPSTestCase):
         self._test_neighbors_by_particle(src_index=1, dst_index=1,
                                          dst_numPoints=self.numPoints2)
 
+    def test_repeated(self):
+        self.test_neighbors_aa()
+        self.test_neighbors_ab()
+        self.test_neighbors_ba()
+        self.test_neighbors_bb()
+
 
 class BoxSortNNPSTestCase(DictBoxSortNNPSTestCase):
     """Test for the original box-sort algorithm"""
@@ -348,6 +354,27 @@ class ZOrderGPUNNPSTestCase(DictBoxSortNNPSTestCase):
 
     def tearDown(self):
         super(ZOrderGPUNNPSTestCase, self).tearDown()
+        get_config().use_double = self._orig_use_double
+
+
+class BruteForceNNPSTestCase(DictBoxSortNNPSTestCase):
+    """Test for OpenCL brute force algorithm"""
+    def setUp(self):
+        NNPSTestCase.setUp(self)
+        cl = importorskip("pyopencl")
+        from pysph.base import gpu_nnps
+        ctx = cl.create_some_context(interactive=False)
+        cfg = get_config()
+        self._orig_use_double = cfg.use_double
+        cfg.use_double = False
+
+        self.nps = gpu_nnps.BruteForceNNPS(
+            dim=3, particles=self.particles, radius_scale=2.0,
+            ctx=ctx
+        )
+
+    def tearDown(self):
+        super(BruteForceNNPSTestCase, self).tearDown()
         get_config().use_double = self._orig_use_double
 
 

--- a/pysph/base/z_order_gpu_nnps.mako
+++ b/pysph/base/z_order_gpu_nnps.mako
@@ -1,3 +1,7 @@
+//CL//
+
+// IMPORTANT NOTE: pyopencl uses the length of the first argument
+// to determine the global work size
 
 <%def name="preamble()" cached="True">
 </%def>

--- a/pysph/base/z_order_gpu_nnps.mako
+++ b/pysph/base/z_order_gpu_nnps.mako
@@ -1,4 +1,3 @@
-//CL//
 
 <%def name="preamble()" cached="True">
 </%def>
@@ -150,7 +149,7 @@
     }
 </%def>
 
-<%def name="z_order_nbrs_prep(data_t, sorted, dst_src)", cached="True">
+<%def name="z_order_nbrs_prep(data_t, sorted, dst_src)", cached="False">
      unsigned int qid;
 
     % if sorted:
@@ -184,6 +183,7 @@
     __global int* nbr_boxes = cid_to_idx;
     unsigned int start_id_nbr_boxes;
 
+
     % if dst_src:
         cid = dst_to_src[cid];
         start_id_nbr_boxes = 27*cid;
@@ -209,7 +209,7 @@
     ${data_t} cell_size
 </%def>
 
-<%def name="z_order_nbr_lengths_src(data_t, sorted, dst_src)" cached="True">
+<%def name="z_order_nbr_lengths_src(data_t, sorted, dst_src)" cached="False">
     ${z_order_nbrs_prep(data_t, sorted, dst_src)}
 
     #pragma unroll
@@ -235,7 +235,7 @@
 </%def>
 
 
-<%def name="z_order_nbrs_args(data_t)" cached="True">
+<%def name="z_order_nbrs_args(data_t)" cached="False">
     ${data_t}* d_x, ${data_t}* d_y, ${data_t}* d_z,
     ${data_t}* d_h, ${data_t}* s_x, ${data_t}* s_y,
     ${data_t}* s_z, ${data_t}* s_h,
@@ -246,7 +246,7 @@
     ${data_t} radius_scale2, ${data_t} cell_size
 </%def>
 
-<%def name="z_order_nbrs_src(data_t, sorted, dst_src)" cached="True">
+<%def name="z_order_nbrs_src(data_t, sorted, dst_src)" cached="False">
     ${z_order_nbrs_prep(data_t, sorted, dst_src)}
 
     unsigned long start_idx = (unsigned long) start_indices[qid];

--- a/pysph/base/z_order_gpu_nnps.pyx
+++ b/pysph/base/z_order_gpu_nnps.pyx
@@ -36,11 +36,13 @@ IF UNAME_SYSNAME == "Windows":
 cdef class ZOrderGPUNNPS(GPUNNPS):
     def __init__(self, int dim, list particles, double radius_scale=2.0,
             int ghost_layers=1, domain=None, bint fixed_h=False,
-            bint cache=True, bint sort_gids=False, ctx=None):
+            bint cache=True, bint sort_gids=False, ctx=None,
+            bint use_double=False):
         GPUNNPS.__init__(
             self, dim, particles, radius_scale, ghost_layers, domain,
             cache, sort_gids, ctx
         )
+        self.use_double = use_double
 
         self.radius_scale2 = radius_scale*radius_scale
         self.radix_sort = None


### PR DESCRIPTION
I've added a test for finding neighbors multiple times.
The tests will fail because of ZOrderGPUNNPS