### PR TITLE
Fix a few miscellaneous issues.

### DIFF
--- a/pysph/sph/acceleration_eval_opencl.mako
+++ b/pysph/sph/acceleration_eval_opencl.mako
@@ -54,7 +54,7 @@ ${helper.get_post_loop_kernel(g_idx, sg_idx, group, dest, all_eqs)}
 </%def>
 
 #define abs fabs
-#define pi M_PI
+__constant double pi=M_PI;
 ${helper.get_header()}
 
 #######################################################################

--- a/pysph/sph/acceleration_eval_opencl_helper.py
+++ b/pysph/sph/acceleration_eval_opencl_helper.py
@@ -284,7 +284,9 @@ class AccelerationEvalOpenCLHelper(object):
         with open(fname, 'w') as fp:
             fp.write(code)
             print("OpenCL code written to %s" % fname)
-        self.program = cl.Program(self._ctx, code.encode('ascii')).build()
+        self.program = cl.Program(self._ctx, code.encode('ascii')).build(
+            options=['-w']
+        )
         return self.program
 
     ##########################################################################

--- a/pysph/sph/wc/edac.py
+++ b/pysph/sph/wc/edac.py
@@ -252,10 +252,10 @@ class MomentumEquation(Equation):
 
         rhoi = d_rho[d_idx]
         rhoj = s_rho[s_idx]
-        pi = d_p[d_idx]
-        pj = s_p[s_idx]
+        p_i = d_p[d_idx]
+        p_j = s_p[s_idx]
 
-        pij = rhoj * pi + rhoi * pj
+        pij = rhoj * p_i + rhoi * p_j
         pij /= (rhoj + rhoi)
 
         Vi = 1./d_V[d_idx]


### PR DESCRIPTION
- The edac equation was using the variable pi which will not work with
  OpenCL as pi is already defined.  Fixing this.
- Defining pi as __constant in OpenCL.
- Turn off warnings in OpenCL compilation as it makes it very hard to
  find the real errors.