### PR TITLE
OpenCL support part 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+1.0b1
+-----
+
+* Release date: not yet released, still under development.
+* Preliminary support for using OpenCL transparently.
+
+
+
 1.0a5
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -8,12 +8,12 @@ PySPH: a Python-based SPH framework
 PySPH is an open source framework for Smoothed Particle Hydrodynamics
 (SPH) simulations. It is implemented in
 `Python <http://www.python.org>`_ and the performance critical parts
-are implemented in `Cython <http://www.cython.org>`_.
+are implemented in `Cython <http://www.cython.org>`_ and PyOpenCL_.
 
-PySPH allows users to write their high-level code in pure Python.  This
-Python code is automatically converted to high-performance Cython which
-is compiled and executed.  PySPH can also be configured to work
-seamlessly with OpenMP and MPI.
+PySPH allows users to write their high-level code in pure Python. This Python
+code is automatically converted to high-performance Cython or OpenCL which is
+compiled and executed. PySPH can also be configured to work seamlessly with
+OpenMP, OpenCL, and MPI.
 
 The latest documentation for PySPH is available at
 `pysph.readthedocs.org <http://pysph.readthedocs.org>`_.
@@ -32,6 +32,8 @@ Here are `videos
 of some example problems solved using PySPH.
 
 
+.. _PyOpenCL: https://documen.tician.de/pyopencl/
+
 Features
 --------
 
@@ -41,6 +43,7 @@ Features
 - High-performance: our performance is comparable to hand-written
   solvers implemented in FORTRAN.
 - Seamless multi-core support with OpenMP.
+- Seamless GPU support with PyOpenCL_.
 - Seamless parallel support using
   `Zoltan <http://www.cs.sandia.gov/zoltan/>`_.
 
@@ -155,12 +158,11 @@ to IIT Bombay for their support.  Our primary goal is to build a
 powerful SPH based tool for both application and research. We hope that
 this makes it easy to perform reproducible computational research.
 
-Lead developers:
+To see the list of contributors the see `github contributors page
+<https://github.com/pypr/pysph/graphs/contributors>`_
 
-- `Prabhu Ramachandran <http://www.aero.iitb.ac.in/~prabhu>`_
-- Kunal Puri
 
-Earlier developers:
+Some earlier developers not listed on the above are:
 
 - Pankaj Pandey (stress solver and improved load balancing, 2011)
 - Chandrashekhar Kaushik (original parallel and serial implementation in 2009)

--- a/docs/source/design/overview.rst
+++ b/docs/source/design/overview.rst
@@ -570,12 +570,6 @@ precomputed quantites are available and may be passed into any equation:
 
     - ``EPS = 0.01 * HIJ * HIJ``
 
-    - ``DT_ADAPT``: is an array of three doubles that stores an adaptive
-      time-step, the first element is the CFL based time-step limit, the
-      second is the force-based limit and the third a viscosity based limit.
-      See :py:class:`pysph.sph.wc.basic.MomentumEquation` for an example of
-      how this is used.
-
 
 In addition if one requires the current time or the timestep in an equation,
 the following may be passed into any of the methods of an equation:
@@ -622,16 +616,14 @@ equation:
 
     class FindMaxU(Equation):
         def reduce(self, dst):
-            m = serial_reduce_array(dst.array.m, 'sum')
-            max_u = serial_reduce_array(dst.array.u, 'max')
+            m = serial_reduce_array(dst.m, 'sum')
+            max_u = serial_reduce_array(dst.u, 'max')
             dst.total_mass[0] = parallel_reduce_array(m, 'sum')
             dst.max_u[0] = parallel_reduce_array(u, 'max')
 
 where:
 
-    - ``dst``: refers to a destination ``ParticleArrayWrapper``.
-
-    - ``src``: refers to a the source ``ParticleArrayWrapper``.
+    - ``dst``: refers to a destination ``ParticleArray``.
 
     - ``serial_reduce_array``: is a special function provided that performs
       reductions correctly in serial. It currently supports ``sum, prod, max``
@@ -642,13 +634,6 @@ where:
       ``parallel_reduce_array`` is expensive as it is an all-to-all
       communication.  One can reduce these by using a single array and use
       that to reduce the communication.
-
-The ``ParticleArrayWrapper``, wraps a ``ParticleArray`` into a
-high-performance Cython object.  It has an ``array`` attribute which is a
-reference the the underlying ``ParticleArray`` and also attributes
-corresponding to each property that are ``DoubleArrays``.  For example in the
-Cython code one may access ``dst.x`` to get the raw arrays used by the
-particle array.  This is mainly done for performance reasons.
 
 Note that in the above example,
 :py:func:`pysph.base.reduce_array.serial_reduce_array` is passed a
@@ -667,6 +652,12 @@ any SPH problem.  A user can easily define a new equation and instantiate the
 equation in the list of equations to be passed to the application.  It is
 often easiest to look at the many existing equations in PySPH and learn the
 general patterns.
+
+If you wish to use adaptive time stepping, see the code
+:py:class:`pysph.sph.integrator.Integrator`. The integrator uses information
+from the arrays ``dt_cfl``, ``dt_force``, and ``dt_visc`` in each of the
+particle arrays to determine the most suitable time step.
+
 
 
 Writing the Integrator

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -114,6 +114,9 @@ The optional dependencies are:
  - OpenMP_: PySPH can use OpenMP if it is available.  Installation instructions
    are available below.
 
+ - PyOpenCL_: PySPH can use OpenCL if it is available. This requires
+   installing PyOpenCL_.
+
  - Mayavi_: PySPH provides a convenient viewer to visualize the output
    of simulations. This viewer can be launched using the command
    ``pysph view`` and requires Mayavi_ to be installed.  Since this is
@@ -133,6 +136,8 @@ Zoltan_ is very unlikely to be already packaged and will need to be compiled.
 .. _mpi4py: http://mpi4py.scipy.org/
 .. _Zoltan: http://www.cs.sandia.gov/zoltan/
 .. _OpenMP: http://openmp.org/
+.. _PyOpenCL: https://documen.tician.de/pyopencl/
+.. _OpenCL: https://www.khronos.org/opencl/
 
 Building and linking PyZoltan on OSX/Linux
 -------------------------------------------
@@ -818,6 +823,32 @@ requires access to the location of the script.  For example, if a script
 
 The ``pysph run`` command is just a convenient way to run the
 pre-installed examples that ship with PySPH.
+
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Running the examples with OpenCL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you have PyOpenCL_ installed and working with an appropriate device setup,
+then you can transparently use OpenCL as well with PySPH. This feature is very
+new and still fairly experimental. You may run into issues but using it is
+simple. You may run any of the supported examples as follows::
+
+    $ pysph run elliptical_drop --opencl
+
+Yes, thats it, just use the ``--opencl`` option and code will be
+auto-generated and run for you. By default it uses single-precision but you
+can also run the code with double precision using::
+
+    $ pysph run elliptical_drop --opencl --use-double
+
+Currently inlets and outlets are not supported, periodicity is slow and many
+optimizations still need to be made but this is rapidly improving. If you want
+to see an example that runs pretty fast, try the cube example::
+
+    $ pysph run cube --disable-output --np 1e6 --opencl
+
+You may compare the execution time with that of OpenMP.
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -5,14 +5,15 @@ Overview
 
 PySPH is an open source framework for Smoothed Particle Hydrodynamics (SPH)
 simulations.  It is implemented in Python_ and the performance critical parts
-are implemented in Cython_.
+are implemented in Cython_ and PyOpenCL_.
 
 PySPH is implemented in a way that allows a user to specify the entire SPH
 simulation in pure Python. High-performance code is generated from this
-high-level Python code, compiled on the fly and executed.  PySPH can use OpenMP
-to utilize multi-core CPUs effectively.  PySPH also features optional automatic
-parallelization (multi-CPU) using mpi4py_ and Zoltan_.  If you wish to use the
-parallel capabilities you will need to have these installed.
+high-level Python code, compiled on the fly and executed. PySPH can use OpenMP
+to utilize multi-core CPUs effectively. PySPH can work with OpenCL and use
+your GPGPUs. PySPH also features optional automatic parallelization
+(multi-CPU) using mpi4py_ and Zoltan_. If you wish to use the parallel
+capabilities you will need to have these installed.
 
 Here are videos of simulations made with PySPH.
 
@@ -31,6 +32,7 @@ site for development details.
 
 .. _Python: http://www.python.org
 .. _Cython: http://www.cython.org
+.. _PyOpenCL: https://documen.tician.de/pyopencl/
 .. _mpi4py: http://mpi4py.scipy.org
 .. _Zoltan: http://www.cs.sandia.gov/zoltan/
 
@@ -45,6 +47,7 @@ Features
   - High-performance: our performance is comparable to hand-written solvers
     implemented in FORTRAN.
   - Seamless multi-core support with OpenMP.
+  - Seamless GPU support with PyOpenCL_.
   - Seamless parallel integration using Zoltan_.
   - `BSD license <https://github.com/pypr/pysph/tree/master/LICENSE.txt>`_.
 
@@ -104,19 +107,15 @@ to IIT Bombay for the support.  Our primary goal is to build a
 powerful SPH-based tool for both application and research. We hope that
 this makes it easy to perform reproducible computational research.
 
-Lead developers:
+To see the list of contributors the see `github contributors page
+<https://github.com/pypr/pysph/graphs/contributors>`_
 
-- `Prabhu Ramachandran <http://www.aero.iitb.ac.in/~prabhu>`__
-- Kunal Puri
 
-Earlier developers:
+Some earlier developers not listed on the above are:
 
 - Pankaj Pandey (stress solver and improved load balancing, 2011)
 - Chandrashekhar Kaushik (original parallel and serial implementation in 2009)
 
-The following have contributed bug-fixes, features, documentation etc.
-
-- Arkopal Dutt, Arpit Agarwal, Sarang Minhas, S Saravanan, Vishnu Sivadasan
 
 -------------
 Citing PySPH

--- a/pysph/base/gpu_nnps_base.pyx
+++ b/pysph/base/gpu_nnps_base.pyx
@@ -257,11 +257,10 @@ cdef class GPUNNPS(NNPSBase):
 cdef class BruteForceNNPS(GPUNNPS):
     def __init__(self, int dim, list particles, double radius_scale=2.0,
             int ghost_layers=1, domain=None, bint cache=True,
-            bint sort_gids=False, bint use_double=False, ctx=None):
+            bint sort_gids=False, ctx=None):
         GPUNNPS.__init__(self, dim, particles, radius_scale, ghost_layers,
                 domain, cache, sort_gids, ctx)
 
-        self.use_double = use_double
         self.radius_scale2 = radius_scale*radius_scale
         self.src_index = -1
         self.dst_index = -1

--- a/pysph/base/opencl.py
+++ b/pysph/base/opencl.py
@@ -36,21 +36,28 @@ def set_queue(q):
 
 
 class DeviceHelper(object):
+    """Manages the arrays contained in a particle array on the device.
+
+    Note that it converts the data to a suitable type depending on the value of
+    get_config().use_double. Further, note that it assumes that the names of
+    constants and properties do not clash.
+
+    """
     def __init__(self, particle_array):
         self._particle_array = pa = particle_array
-        self._queue = q = get_queue()
-        self._props = []
+        self._queue = get_queue()
         use_double = get_config().use_double
         self._dtype = np.float64 if use_double else np.float32
+        self._data = {}
+        self._props = []
+        self._alloc = 0
 
         for prop, ary in pa.properties.items():
-            a_gpu = cl.array.to_device(q, self._get_array(ary))
-            setattr(self, prop, a_gpu)
-            self._props.append(prop)
+            self.add_prop(prop, ary)
         for prop, ary in pa.constants.items():
-            a_gpu = cl.array.to_device(q, self._get_array(ary))
-            setattr(self, prop, a_gpu)
-            self._props.append(prop)
+            self.add_prop(prop, ary)
+        if self._data:
+            self._alloc = len(self._data['x'])
 
     def _get_array(self, ary):
         ctype = ary.get_c_type()
@@ -63,21 +70,57 @@ class DeviceHelper(object):
         pa = self._particle_array
         return pa.properties.get(prop, pa.constants.get(prop))
 
-    def push(self, *args):
-        if len(args) == 0:
-            args = self._props
-        for arg in args:
-            getattr(self, arg).set(
-                self._get_array(self._get_prop_or_const(arg))
-            )
+    def add_prop(self, name, carray):
+        """Add a new property or constant given the name and carray, note
+        that this assumes that this property is already added to the
+        particle array.
+        """
+        np_array = self._get_array(carray)
+        g_ary = cl.array.empty(self._queue, carray.alloc, np_array.dtype)
+        view = g_ary[:carray.length]
+        view.set(np_array)
+        self._data[name] = g_ary
+        setattr(self, name, view)
+        if name in self._particle_array.properties:
+            self._props.append(name)
+
+    def max(self, arg):
+        return float(cl.array.max(getattr(self, arg)).get())
 
     def pull(self, *args):
         if len(args) == 0:
-            args = self._props
+            args = self._data.keys()
         for arg in args:
             self._get_prop_or_const(arg).set_data(
                 getattr(self, arg).get()
             )
 
-    def max(self, arg):
-        return float(cl.array.max(getattr(self, arg)).get())
+    def push(self, *args):
+        if len(args) == 0:
+            args = self._data.keys()
+        for arg in args:
+            getattr(self, arg).set(
+                self._get_array(self._get_prop_or_const(arg))
+            )
+
+    def remove_prop(self, name):
+        if name in self._props:
+            self._props.remove(name)
+        if name in self._data:
+            del self._data[name]
+            delattr(self, name)
+
+    def resize(self, new_size):
+        if new_size > self._alloc:
+            for prop in self._props:
+                old_prop = self._data[prop]
+                new_prop = cl.array.empty(
+                    self._queue, new_size, dtype=old_prop.dtype
+                )
+                sz = min(len(old_prop), new_size)
+                new_prop[:sz] = old_prop[:sz]
+                self._data[prop] = new_prop
+            self._alloc = new_size
+
+        for prop in self._props:
+            setattr(self, prop, self._data[prop][:new_size])

--- a/pysph/base/opencl.py
+++ b/pysph/base/opencl.py
@@ -78,3 +78,6 @@ class DeviceHelper(object):
             self._get_prop_or_const(arg).set_data(
                 getattr(self, arg).get()
             )
+
+    def max(self, arg):
+        return float(cl.array.max(getattr(self, arg)).get())

--- a/pysph/base/particle_array.pyx
+++ b/pysph/base/particle_array.pyx
@@ -802,6 +802,8 @@ cdef class ParticleArray:
 
         array_data = numpy.ravel(data)
         self.constants[name] = self._create_c_array_from_npy_array(array_data)
+        if self.gpu is not None:
+            self.gpu.add_prop(name, self.constants[name])
 
     cpdef add_property(self, str name, str type='double', default=None, data=None):
         """Add a new property to the particle array.
@@ -953,7 +955,8 @@ cdef class ParticleArray:
                         np_arr = arr.get_npy_array()
                         arr.get_npy_array()[:] = numpy.asarray(data)
                         self.properties[prop_name] = arr
-
+        if self.gpu is not None:
+            self.gpu.add_prop(prop_name, self.properties[prop_name])
 
     ######################################################################
     # Non-public interface
@@ -1302,6 +1305,8 @@ cdef class ParticleArray:
             self.default_values.pop(prop_name)
         if prop_name in self.output_property_arrays:
             self.output_property_arrays.remove(prop_name)
+        if self.gpu is not None:
+            self.gpu.remove_prop(prop_name)
 
     def update_min_max(self, props=None):
         """Update the min,max values of all properties """

--- a/pysph/base/tests/test_nnps.py
+++ b/pysph/base/tests/test_nnps.py
@@ -390,7 +390,7 @@ class ZOrderGPUDoubleNNPSTestCase(DictBoxSortNNPSTestCase):
         cfg.use_double = True
         self.nps = gpu_nnps.ZOrderGPUNNPS(
             dim=3, particles=self.particles, radius_scale=2.0,
-            ctx=ctx, use_double=True
+            ctx=ctx
         )
 
     def tearDown(self):

--- a/pysph/base/tests/test_opencl.py
+++ b/pysph/base/tests/test_opencl.py
@@ -1,0 +1,167 @@
+from unittest import TestCase
+import pytest
+import numpy as np
+
+pytest.importorskip("pysph.base.opencl")
+
+from pysph.base.utils import get_particle_array  # noqa: E402
+from pysph.base.opencl import DeviceHelper  # noqa: E402
+
+
+class TestDeviceHelper(TestCase):
+    def setUp(self):
+        self.pa = get_particle_array(name='f', x=[0.0, 1.0], m=1.0, rho=2.0)
+
+    def test_simple(self):
+        # Given
+        pa = self.pa
+        h = DeviceHelper(pa)
+
+        # When
+        pa.set_device_helper(h)
+
+        # Then
+        self.assertTrue(np.allclose(pa.x, h.x.get()))
+        self.assertTrue(np.allclose(pa.y, h.y.get()))
+        self.assertTrue(np.allclose(pa.m, h.m.get()))
+        self.assertTrue(np.allclose(pa.rho, h.rho.get()))
+        self.assertTrue(np.allclose(pa.tag, h.tag.get()))
+
+    def test_push_correctly_sets_values_with_args(self):
+        # Given
+        pa = self.pa
+        h = DeviceHelper(pa)
+        self.assertEqual(pa.tag[0], 0)
+
+        # When
+        pa.set_device_helper(h)
+        pa.x[:] = [2.0, 3.0]
+        pa.rho[0] = 1.0
+        pa.tag[:] = 1
+        h.push('x', 'rho', 'tag')
+
+        # Then
+        self.assertTrue(np.allclose(pa.x, h.x.get()))
+        self.assertTrue(np.allclose(pa.y, h.y.get()))
+        self.assertTrue(np.allclose(pa.m, h.m.get()))
+        self.assertTrue(np.allclose(pa.rho, h.rho.get()))
+        self.assertTrue(np.allclose(pa.tag, h.tag.get()))
+
+    def test_push_correctly_sets_values_with_no_args(self):
+        # Given
+        pa = self.pa
+        h = DeviceHelper(pa)
+
+        # When
+        pa.set_device_helper(h)
+        pa.x[:] = 1.0
+        pa.rho[:] = 1.0
+        pa.m[:] = 1.0
+        pa.tag[:] = [1, 2]
+        h.push()
+
+        # Then
+        self.assertTrue(np.allclose(pa.x, h.x.get()))
+        self.assertTrue(np.allclose(pa.y, h.y.get()))
+        self.assertTrue(np.allclose(pa.m, h.m.get()))
+        self.assertTrue(np.allclose(pa.rho, h.rho.get()))
+        self.assertTrue(np.allclose(pa.tag, h.tag.get()))
+
+    def test_pull_correctly_sets_values_with_args(self):
+        # Given
+        pa = self.pa
+        h = DeviceHelper(pa)
+        self.assertEqual(pa.tag[0], 0)
+
+        # When
+        pa.set_device_helper(h)
+        h.x.set(np.array([2.0, 3.0], h.x.dtype))
+        h.rho[0] = 1.0
+        h.tag[:] = 1
+        h.pull('x', 'rho', 'tag')
+
+        # Then
+        self.assertTrue(np.allclose(pa.x, h.x.get()))
+        self.assertTrue(np.allclose(pa.y, h.y.get()))
+        self.assertTrue(np.allclose(pa.m, h.m.get()))
+        self.assertTrue(np.allclose(pa.rho, h.rho.get()))
+        self.assertTrue(np.allclose(pa.tag, h.tag.get()))
+
+    def test_pull_correctly_sets_values_with_no_args(self):
+        # Given
+        pa = self.pa
+        h = DeviceHelper(pa)
+
+        # When
+        pa.set_device_helper(h)
+        h.x[:] = 1.0
+        h.rho[:] = 1.0
+        h.m[:] = 1.0
+        h.tag[:] = np.array([1, 2], h.tag.dtype)
+        h.pull()
+
+        # Then
+        self.assertTrue(np.allclose(pa.x, h.x.get()))
+        self.assertTrue(np.allclose(pa.y, h.y.get()))
+        self.assertTrue(np.allclose(pa.m, h.m.get()))
+        self.assertTrue(np.allclose(pa.rho, h.rho.get()))
+        self.assertTrue(np.allclose(pa.tag, h.tag.get()))
+
+    def test_max_provides_maximum(self):
+        # Given/When
+        pa = self.pa
+        h = DeviceHelper(pa)
+
+        # Then
+        self.assertEqual(h.max('x'), 1.0)
+
+    def test_that_adding_removing_prop_to_array_updates_gpu(self):
+        # Given
+        pa = self.pa
+        h = DeviceHelper(pa)
+
+        # When
+        pa.set_device_helper(h)
+        pa.add_property('test', data=[3.0, 4.0])
+
+        # Then
+        self.assertTrue(np.allclose(pa.test, h.test.get()))
+
+        # When
+        pa.remove_property('test')
+
+        # Then
+        self.assertFalse(hasattr(h, 'test'))
+        self.assertFalse('test' in h._data)
+        self.assertFalse('test' in h._props)
+
+    def test_resize_works(self):
+        # Given
+        pa = self.pa
+        h = DeviceHelper(pa)
+
+        # When
+        pa.set_device_helper(h)
+        pa.extend(2)
+        pa.align_particles()
+        h.resize(4)
+
+        # Then
+        self.assertTrue(np.allclose(pa.x[:2], h.x[:2].get()))
+        self.assertTrue(np.allclose(pa.m[:2], h.m[:2].get()))
+        self.assertTrue(np.allclose(pa.rho[:2], h.rho[:2].get()))
+        self.assertTrue(np.allclose(pa.tag[:2], h.tag[:2].get()))
+
+        # When
+        pa.remove_particles([2, 3])
+        pa.align_particles()
+        old_x = h.x.data
+        h.resize(2)
+
+        # Then
+        self.assertEqual(old_x, h.x.data)
+        self.assertTrue(np.allclose(pa.x, h.x.get()))
+        self.assertTrue(np.allclose(pa.y, h.y.get()))
+        self.assertTrue(np.allclose(pa.m, h.m.get()))
+        self.assertTrue(np.allclose(pa.rho, h.rho.get()))
+        self.assertTrue(np.allclose(pa.tag, h.tag.get()))

--- a/pysph/base/tests/test_translator.py
+++ b/pysph/base/tests/test_translator.py
@@ -887,13 +887,14 @@ def test_opencl_conversion():
     ''')
 
     # When
-    converter = OpenCLConverter()
+    known_types = {'d_p': KnownType('__global int*')}
+    converter = OpenCLConverter(known_types=known_types)
     code = converter.convert(src)
 
     # Then
     expect = dedent('''
-void f(long s_idx, __global double* s_p, long d_idx, __global double* d_p,
-    long J, double t, double* l, double* xx)
+void f(long s_idx, __global double* s_p, long d_idx, __global int* d_p, long
+    J, double t, double* l, double* xx)
 {
     ;
 }

--- a/pysph/base/tests/test_translator.py
+++ b/pysph/base/tests/test_translator.py
@@ -851,6 +851,35 @@ def test_wrapping_class():
     assert h.get_array() == expect
 
 
+def test_wrapping_class_with_ignore_methods():
+    # Given
+    class Dummy1(object):
+        '''Class Docstring'''
+        def f(self):
+            pass
+
+        def not_me(self):
+            pass
+
+    obj = Dummy1()
+
+    # When
+    c = CConverter()
+    result = c.parse_instance(obj, ignore_methods=['not_me'])
+
+    # Then
+    expect = dedent('''
+    typedef struct Dummy1 {
+    } Dummy1;
+
+    void Dummy1_f(Dummy1* self)
+    {
+        ;
+    }
+    ''')
+    assert result.strip() == expect.strip()
+
+
 def test_opencl_conversion():
     src = dedent('''
     def f(s_idx, s_p, d_idx, d_p, J=0, t=0.0, l=[0,0], xx=(0, 0)):

--- a/pysph/base/tests/test_translator.py
+++ b/pysph/base/tests/test_translator.py
@@ -891,3 +891,40 @@ def test_opencl_class():
     }
     ''')
     assert code.strip() == expect.strip()
+
+
+def test_handles_parsing_functions():
+    # Given
+    def f(x=1.0):
+        return x + 1
+
+    # When
+    t = CConverter()
+    code = t.parse_function(f)
+
+    # Then
+    expect = dedent('''
+    double f(double x)
+    {
+        return (x + 1);
+    }
+    ''')
+    assert code.strip() == expect.strip()
+
+    # Given
+    class A(object):
+        def f(self, x=1.0):
+            return x + 1.0
+
+    # When
+    t = CConverter()
+    code = t.parse_function(A)
+
+    # Then
+    expect = dedent('''
+    double A_f(A* self, double x)
+    {
+        return (x + 1.0);
+    }
+    ''')
+    assert code.strip() == expect.strip()

--- a/pysph/base/translator.py
+++ b/pysph/base/translator.py
@@ -377,7 +377,9 @@ class CConverter(ast.NodeVisitor):
         if len(declares) > 0:
             declares += '\n'
 
-        sig = '\n'.join(wrap(sig, width=78, subsequent_indent=' '*4))
+        sig = '\n'.join(wrap(
+            sig, width=78, subsequent_indent=' '*4, break_long_words=False
+        ))
         self._known = orig_known
         self._declares = orig_declares
         return sig + '\n{\n' + declares + body + '\n}\n'

--- a/pysph/base/translator.py
+++ b/pysph/base/translator.py
@@ -224,6 +224,10 @@ class CConverter(ast.NodeVisitor):
         code += self.convert(src)
         return code
 
+    def parse_function(self, obj):
+        src = dedent(inspect.getsource(obj))
+        return self.convert(src)
+
     def visit_Add(self, node):
         return '+'
 

--- a/pysph/base/translator.py
+++ b/pysph/base/translator.py
@@ -494,7 +494,9 @@ class CConverter(ast.NodeVisitor):
 
 
 def ocl_detect_type(name, value):
-    if name.startswith(('s_', 'd_')) and name not in ['s_idx', 'd_idx']:
+    if isinstance(value, KnownType):
+        return value.type
+    elif name.startswith(('s_', 'd_')) and name not in ['s_idx', 'd_idx']:
         return '__global double*'
     else:
         return detect_type(name, value)

--- a/pysph/base/utils.py
+++ b/pysph/base/utils.py
@@ -173,7 +173,7 @@ def get_particle_array_wcsph(constants=None, **props):
     """
 
     wcsph_props = ['cs', 'ax', 'ay', 'az', 'arho', 'x0', 'y0', 'z0',
-                   'u0', 'v0', 'w0', 'rho0', 'div']
+                   'u0', 'v0', 'w0', 'rho0', 'div', 'dt_cfl', 'dt_force']
 
     pa = get_particle_array(
         constants=constants, additional_props=wcsph_props, **props
@@ -216,7 +216,7 @@ def get_particle_array_iisph(constants=None, **props):
     """
     iisph_props = ['uadv', 'vadv', 'wadv', 'rho_adv',
                    'au', 'av', 'aw', 'ax', 'ay', 'az',
-                   'dii0', 'dii1', 'dii2', 'V',
+                   'dii0', 'dii1', 'dii2', 'V', 'dt_cfl', 'dt_force',
                    'aii', 'dijpj0', 'dijpj1', 'dijpj2', 'p', 'p0', 'piter',
                    'compression']
     # Used to calculate the total compression first index is count and second
@@ -376,7 +376,7 @@ def get_particle_array_gasd(constants=None, **props):
     required_props = [
         'x', 'y', 'z', 'u', 'v', 'w', 'rho', 'h', 'm', 'cs', 'p', 'e',
         'au', 'av', 'aw', 'arho', 'ae', 'am', 'ah', 'x0', 'y0', 'z0',
-        'u0', 'v0', 'w0', 'rho0', 'e0', 'h0', 'div',
+        'u0', 'v0', 'w0', 'rho0', 'e0', 'h0', 'div', 'dt_cfl',
         'grhox', 'grhoy', 'grhoz', 'dwdh', 'omega', 'converged',
         'alpha1', 'alpha10', 'aalpha1', 'alpha2', 'alpha20', 'aalpha2',
         'del2e'

--- a/pysph/base/z_order_gpu_nnps.pyx
+++ b/pysph/base/z_order_gpu_nnps.pyx
@@ -36,13 +36,11 @@ IF UNAME_SYSNAME == "Windows":
 cdef class ZOrderGPUNNPS(GPUNNPS):
     def __init__(self, int dim, list particles, double radius_scale=2.0,
             int ghost_layers=1, domain=None, bint fixed_h=False,
-            bint cache=True, bint sort_gids=False, ctx=None,
-            bint use_double=False):
+            bint cache=True, bint sort_gids=False, ctx=None):
         GPUNNPS.__init__(
             self, dim, particles, radius_scale, ghost_layers, domain,
             cache, sort_gids, ctx
         )
-        self.use_double = use_double
 
         self.radius_scale2 = radius_scale*radius_scale
         self.radix_sort = None

--- a/pysph/parallel/tests/simple_reduction.py
+++ b/pysph/parallel/tests/simple_reduction.py
@@ -9,6 +9,8 @@ from pysph.sph.integrator_step import IntegratorStep
 from pysph.sph.integrator import EulerIntegrator
 from pysph.solver.application import Application
 from pysph.solver.solver import Solver
+from pysph.base.reduce_array import parallel_reduce_array, serial_reduce_array
+
 
 def create_particles():
     x = np.linspace(0, 10, 10)
@@ -21,13 +23,12 @@ def create_particles():
     fluid.add_constant('total_mass', 0.0)
     return [fluid]
 
+
 class TotalMass(Equation):
     def reduce(self, dst):
-        # Use the dst.array as we want to pass the real particles to do the sum
-        # passing the carray will send all the particles including ghosts
-        # which is incorrect.
-        m = serial_reduce_array(dst.array.m, op='sum')
+        m = serial_reduce_array(dst.m, op='sum')
         dst.total_mass[0] = parallel_reduce_array(m, op='sum')
+
 
 class DummyStepper(IntegratorStep):
     def initialize(self):

--- a/pysph/sph/acceleration_eval_cython.mako
+++ b/pysph/sph/acceleration_eval_cython.mako
@@ -61,7 +61,6 @@ nnps.set_context(src_array_index, dst_array_index)
 
 ${helper.get_parallel_block()}
     thread_id = threadid()
-    DT_ADAPT = &_DT_ADAPT.data[thread_id*aligned(3, 8)]
     ${indent(eq_group.get_variable_array_setup(), 1)}
     for d_idx in prange(NP_DEST):
         ###############################################################
@@ -85,7 +84,6 @@ ${helper.get_parallel_block()}
 ###################################################################
 % if all_eqs.has_post_loop():
 # Post loop for destination ${dest}.
-DT_ADAPT = _DT_ADAPT.data
 for d_idx in range(NP_DEST):
     ${indent(all_eqs.get_post_loop_code(helper.object.kernel), 1)}
 % endif
@@ -202,31 +200,6 @@ cdef class AccelerationEval:
     def __dealloc__(self):
         aligned_free(self.nbrs)
 
-    cdef _initialize_dt_adapt(self, double* DT_ADAPT):
-        self.dt_cfl = self.dt_force = self.dt_viscous = -1e20
-        cdef int i, _idx, offset
-        cdef double* dta = DT_ADAPT
-        offset = aligned(3, sizeof(double))
-        for i in range(self.n_threads):
-            _idx = i*offset
-            dta[_idx + 0] = self.dt_cfl
-            dta[_idx + 1] = self.dt_force
-            dta[_idx + 2] = self.dt_viscous
-
-    cdef _set_dt_adapt(self, double* DT_ADAPT):
-        cdef int i, _idx, offset
-        cdef double* dta = DT_ADAPT
-        offset = aligned(3, sizeof(double))
-        for i in range(self.n_threads):
-            _idx = i*offset
-            dta[0] = max(dta[0], dta[_idx + 0])
-            dta[1] = max(dta[1], dta[_idx + 1])
-            dta[2] = max(dta[2], dta[_idx + 2])
-
-        self.dt_cfl = dta[0]
-        self.dt_force = dta[1]
-        self.dt_viscous = dta[2]
-
     def set_nnps(self, NNPS nnps):
         self.nnps = nnps
 
@@ -240,9 +213,6 @@ cdef class AccelerationEval:
         cdef int s_idx, d_idx, thread_id
         cdef NNPS nnps = self.nnps
         cdef ParticleArrayWrapper src, dst
-        cdef DoubleArray _DT_ADAPT = DoubleArray(aligned(3, 8)*self.n_threads)
-        self._initialize_dt_adapt(_DT_ADAPT.data)
-        cdef double* DT_ADAPT = _DT_ADAPT.data
 
         cdef int max_iterations, min_iterations, _iteration_count
 
@@ -302,4 +272,3 @@ cdef class AccelerationEval:
         # ---------------------------------------------------------------------
         % endif # (if len(group.data) > 0)
         % endfor
-        self._set_dt_adapt(_DT_ADAPT.data)

--- a/pysph/sph/acceleration_eval_opencl.mako
+++ b/pysph/sph/acceleration_eval_opencl.mako
@@ -42,7 +42,9 @@ ${helper.get_post_loop_kernel(g_idx, sg_idx, group, dest, all_eqs)}
 ###################################################################
 ## Do any reductions for the destination.
 ###################################################################
-## FIXME
+% if all_eqs.has_reduce():
+<% helper.call_reduce(all_eqs, dest) %>
+% endif
 // Finished destination ${dest}.
 #######################################################################
 ## Update NNPS locally if needed

--- a/pysph/sph/acceleration_eval_opencl_helper.py
+++ b/pysph/sph/acceleration_eval_opencl_helper.py
@@ -27,13 +27,14 @@ def get_kernel_definition(kernel, arg_list):
     sig = '__kernel void\n{kernel}\n({args})'.format(
         kernel=kernel, args=', '.join(arg_list),
     )
-    return '\n'.join(wrap(sig, width=78, subsequent_indent=' '*4))
+    return '\n'.join(wrap(sig, width=78, subsequent_indent=' '*4,
+                          break_long_words=False))
 
 
 def wrap_code(code, indent=' '*4):
     return wrap(
         code, width=74, initial_indent=indent,
-        subsequent_indent=indent + ' '*4
+        subsequent_indent=indent + ' '*4, break_long_words=False
     )
 
 

--- a/pysph/sph/acceleration_eval_opencl_helper.py
+++ b/pysph/sph/acceleration_eval_opencl_helper.py
@@ -4,7 +4,6 @@ TODO:
 Advanced:
 - DT_ADAPT.
 - Reduction.
-- support get_code for helper functions.
 
 General OpenCL issues:
 - Periodicity.
@@ -47,6 +46,21 @@ def wrap_code(code, indent=' '*4):
         code, width=74, initial_indent=indent,
         subsequent_indent=indent + ' '*4
     )
+
+
+def get_code(obj, transpiler=None):
+    """This function looks at the object and gets any additional code to
+    wrap from the `_get_helpers_` method.
+    """
+    result = []
+    if hasattr(obj, '_get_helpers_'):
+        if transpiler is None:
+            transpiler = OpenCLConverter()
+        doc = '\n// Helpers from %s' % obj.__class__.__name__
+        result.append(doc)
+        for helper in obj._get_helpers_():
+            result.append(transpiler.parse_function(helper))
+    return result
 
 
 class OpenCLAccelerationEval(object):
@@ -293,13 +307,15 @@ class AccelerationEvalOpenCLHelper(object):
     # Mako interface.
     ##########################################################################
     def get_header(self):
-        # FIXME
-        # Write the equivalent for get_code in cython where any extra code,
-        # helpers are suitably wrapped as well.
         object = self.object
 
-        headers = []
         transpiler = OpenCLConverter(known_types=self.known_types)
+
+        headers = []
+        headers.extend(get_code(object.kernel, transpiler))
+        for equation in object.all_group.equations:
+            headers.extend(get_code(equation, transpiler))
+
         headers.append(transpiler.parse_instance(object.kernel))
 
         headers.append(object.all_group.get_equation_wrappers(

--- a/pysph/sph/acceleration_eval_opencl_helper.py
+++ b/pysph/sph/acceleration_eval_opencl_helper.py
@@ -1,15 +1,3 @@
-"""
-TODO:
-
-Advanced:
-- DT_ADAPT.
-- Reduction.
-
-General OpenCL issues:
-- Periodicity.
-- Cleanup the code generation
-
-"""
 import inspect
 import os
 import re
@@ -68,6 +56,7 @@ class OpenCLAccelerationEval(object):
     """
     def __init__(self, helper):
         self.helper = helper
+        self.particle_arrays = helper.object.particle_arrays
         self.nnps = None
         self._queue = helper._queue
         self._use_double = get_config().use_double
@@ -370,7 +359,6 @@ class AccelerationEvalOpenCLHelper(object):
         all_args = []
         py_args = []
         code = [
-            'double DT_ADAPT[3];',
             'int d_idx = get_global_id(0);'
         ]
         for eq in all_eqs.equations:
@@ -483,7 +471,6 @@ class AccelerationEvalOpenCLHelper(object):
         )
         context = eq_group.context
         code = self._declare_precomp_vars(context)
-        code.append('double DT_ADAPT[3];')
         code.append('int d_idx = get_global_id(0);')
         code.append('int s_idx, i;')
         code.append('int start = start_idx[d_idx];')

--- a/pysph/sph/acceleration_eval_opencl_helper.py
+++ b/pysph/sph/acceleration_eval_opencl_helper.py
@@ -146,7 +146,7 @@ class OpenCLAccelerationEval(object):
         self.nnps.update_domain()
         self.nnps.update()
 
-    def reduce(self, eqs, dest):
+    def do_reduce(self, eqs, dest):
         for eq in eqs:
             eq.reduce(dest)
 
@@ -265,7 +265,7 @@ class AccelerationEvalOpenCLHelper(object):
                 )
             elif type == 'method':
                 info = dict(item)
-                if info.get('method') == 'reduce':
+                if info.get('method') == 'do_reduce':
                     args = info.get('args')
                     grp = args[0]
                     args[0] = [x for x in grp.equations
@@ -453,7 +453,7 @@ class AccelerationEvalOpenCLHelper(object):
             return code
 
     def call_reduce(self, all_eq_group, dest):
-        self.data.append(dict(method='reduce', type='method',
+        self.data.append(dict(method='do_reduce', type='method',
                               args=[all_eq_group, dest]))
 
     def call_update_nnps(self, group):

--- a/pysph/sph/basic_equations.py
+++ b/pysph/sph/basic_equations.py
@@ -233,7 +233,7 @@ class MonaghanArtificialViscosity(Equation):
         d_aw[d_idx] = 0.0
 
     def loop(self, d_idx, s_idx, d_rho, d_cs, d_au, d_av, d_aw, s_m,
-             s_rho, s_cs, VIJ, XIJ, HIJ, R2IJ, RHOIJ1, EPS, DWIJ, DT_ADAPT):
+             s_rho, s_cs, VIJ, XIJ, HIJ, R2IJ, RHOIJ1, EPS, DWIJ):
 
         vijdotxij = VIJ[0]*XIJ[0] + VIJ[1]*XIJ[1] + VIJ[2]*XIJ[2]
 

--- a/pysph/sph/basic_equations.py
+++ b/pysph/sph/basic_equations.py
@@ -5,6 +5,7 @@ Basic SPH Equations
 
 from pysph.sph.equation import Equation
 
+
 class SummationDensity(Equation):
     r"""Good old Summation density:
 
@@ -16,6 +17,7 @@ class SummationDensity(Equation):
 
     def loop(self, d_idx, d_rho, s_idx, s_m, WIJ):
         d_rho[d_idx] += s_m[s_idx]*WIJ
+
 
 class BodyForce(Equation):
     r"""Add a body force to the particles:
@@ -85,6 +87,7 @@ class VelocityGradient2D(Equation):
         d_v10[d_idx] += tmp * -VIJ[1] * DWIJ[0]
         d_v11[d_idx] += tmp * -VIJ[1] * DWIJ[1]
 
+
 class VelocityGradient3D(Equation):
     r""" Compute the SPH evaluation for the velocity gradient tensor in 2D.
 
@@ -100,7 +103,8 @@ class VelocityGradient3D(Equation):
     component. Thus v_21 is :math:`\frac{\partial v}{\partial x}`
 
     """
-    def initialize(self, d_idx, d_v00, d_v01, d_v02, d_v10, d_v11, d_v12, d_v20, d_v21, d_v22):
+    def initialize(self, d_idx, d_v00, d_v01, d_v02, d_v10, d_v11, d_v12,
+                   d_v20, d_v21, d_v22):
         d_v00[d_idx] = 0.0
         d_v01[d_idx] = 0.0
         d_v02[d_idx] = 0.0
@@ -133,6 +137,7 @@ class VelocityGradient3D(Equation):
         d_v21[d_idx] += tmp * -VIJ[2] * DWIJ[1]
         d_v22[d_idx] += tmp * -VIJ[2] * DWIJ[2]
 
+
 class IsothermalEOS(Equation):
     r""" Compute the pressure using the Isothermal equation of state:
 
@@ -161,6 +166,7 @@ class IsothermalEOS(Equation):
     def loop(self, d_idx, d_rho, d_p):
         d_p[d_idx] = self.p0 + self.c02 * (d_rho[d_idx] - self.rho0)
 
+
 class ContinuityEquation(Equation):
     r"""Density rate:
 
@@ -174,6 +180,7 @@ class ContinuityEquation(Equation):
     def loop(self, d_idx, d_arho, s_idx, s_m, DWIJ, VIJ):
         vijdotdwij = DWIJ[0]*VIJ[0] + DWIJ[1]*VIJ[1] + DWIJ[2]*VIJ[2]
         d_arho[d_idx] += s_m[s_idx]*vijdotdwij
+
 
 class MonaghanArtificialViscosity(Equation):
     r"""Classical Monaghan style artificial viscosity [Monaghan2005]_
@@ -228,9 +235,6 @@ class MonaghanArtificialViscosity(Equation):
     def loop(self, d_idx, s_idx, d_rho, d_cs, d_au, d_av, d_aw, s_m,
              s_rho, s_cs, VIJ, XIJ, HIJ, R2IJ, RHOIJ1, EPS, DWIJ, DT_ADAPT):
 
-        rhoi21 = 1.0/(d_rho[d_idx]*d_rho[d_idx])
-        rhoj21 = 1.0/(s_rho[s_idx]*s_rho[s_idx])
-
         vijdotxij = VIJ[0]*XIJ[0] + VIJ[1]*XIJ[1] + VIJ[2]*XIJ[2]
 
         piij = 0.0
@@ -245,6 +249,7 @@ class MonaghanArtificialViscosity(Equation):
         d_au[d_idx] += -s_m[s_idx] * piij * DWIJ[0]
         d_av[d_idx] += -s_m[s_idx] * piij * DWIJ[1]
         d_aw[d_idx] += -s_m[s_idx] * piij * DWIJ[2]
+
 
 class XSPHCorrection(Equation):
     r"""Position stepping with XSPH correction [Monaghan1992]_

--- a/pysph/sph/equation.py
+++ b/pysph/sph/equation.py
@@ -33,6 +33,10 @@ def camel_to_underscore(name):
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
 
 
+def declare(*args):
+    pass
+
+
 ##############################################################################
 # `Context` class.
 ##############################################################################
@@ -316,7 +320,7 @@ def get_predefined_types(precomp):
     result = {'DT_ADAPT': [0.0, 0.0, 0.0],
               'dt': 0.0,
               't': 0.0,
-              'dst': KnownType('ParticleArrayWrapper'),
+              'dst': KnownType('object'),
               'src': KnownType('ParticleArrayWrapper')}
     for sym, value in precomp.items():
         result[sym] = value.context[sym]
@@ -653,6 +657,8 @@ class CythonGroup(Group):
                 args = inspect.getargspec(meth).args
                 if 'self' in args:
                     args.remove('self')
+                if kind == 'reduce':
+                    args = ['dst.array']
                 call_args = ', '.join(args)
                 c = 'self.{eq_name}.{method}({args})'\
                     .format(eq_name=eq.var_name, method=kind, args=call_args)

--- a/pysph/sph/equation.py
+++ b/pysph/sph/equation.py
@@ -776,7 +776,8 @@ class OpenCLGroup(Group):
         predefined = dict(get_predefined_types(self.pre_comp))
         predefined.update(known_types)
         code_gen = OpenCLConverter(known_types=predefined)
+        ignore = ['reduce']
         for cls in sorted(classes.keys()):
-            src = code_gen.parse_instance(eqs[cls])
+            src = code_gen.parse_instance(eqs[cls], ignore_methods=ignore)
             wrappers.append(src)
         return '\n'.join(wrappers)

--- a/pysph/sph/equation.py
+++ b/pysph/sph/equation.py
@@ -317,8 +317,7 @@ def get_predefined_types(precomp):
     """Return a dictionary that can be used by a CythonGenerator for
     the precomputed symbols.
     """
-    result = {'DT_ADAPT': [0.0, 0.0, 0.0],
-              'dt': 0.0,
+    result = {'dt': 0.0,
               't': 0.0,
               'dst': KnownType('object'),
               'src': KnownType('ParticleArrayWrapper')}

--- a/pysph/sph/gas_dynamics/basic.py
+++ b/pysph/sph/gas_dynamics/basic.py
@@ -359,7 +359,7 @@ class MPMAccelerations(Equation):
         super(MPMAccelerations, self).__init__(dest, sources)
 
     def initialize(self, d_idx, d_au, d_av, d_aw, d_ae, d_am,
-                   d_aalpha1, d_aalpha2, d_del2e):
+                   d_aalpha1, d_aalpha2, d_del2e, d_dt_cfl):
         d_au[d_idx] = 0.0
         d_av[d_idx] = 0.0
         d_aw[d_idx] = 0.0
@@ -369,12 +369,13 @@ class MPMAccelerations(Equation):
         d_aalpha2[d_idx] = 0.0
 
         d_del2e[d_idx] = 0.0
+        d_dt_cfl[d_idx] = 0.0
 
     def loop(self, d_idx, s_idx, d_m, s_m, d_p, s_p, d_cs, s_cs,
              d_e, s_e, d_rho, s_rho, d_au, d_av, d_aw, d_ae,
              d_omega, s_omega, XIJ, VIJ, DWI, DWJ, DWIJ, HIJ,
              d_del2e, d_alpha1, s_alpha1, d_alpha2, s_alpha2,
-             EPS, RIJ, R2IJ, RHOIJ, DT_ADAPT):
+             EPS, RIJ, R2IJ, RHOIJ, d_dt_cfl):
 
         # particle pressure
         pi = d_p[d_idx]
@@ -415,12 +416,12 @@ class MPMAccelerations(Equation):
         Fij = XIJ[0]*DWIJ[0] + XIJ[1]*DWIJ[1] + XIJ[2]*DWIJ[2]
 
         # signal velocities
-        pdiff = abs(pi-pj)
+        pdiff = abs(pi - pj)
         vsig1 = 0.5 * max(cij - self.beta*dot, 0.0)
         vsig2 = sqrt(pdiff/RHOIJ)
 
         # compute the Courant-limited time step factor.
-        DT_ADAPT[0] = max(DT_ADAPT[0], cij + self.beta * dot)
+        d_dt_cfl[d_idx] = max(d_dt_cfl[d_idx], cij + self.beta * dot)
 
         # Artificial viscosity
         if dot <= 0.0:

--- a/pysph/sph/gas_dynamics/basic.py
+++ b/pysph/sph/gas_dynamics/basic.py
@@ -3,6 +3,8 @@
 from pysph.base.reduce_array import serial_reduce_array, parallel_reduce_array
 from pysph.sph.equation import Equation
 from math import sqrt, exp, log
+import numpy
+
 
 class ScaleSmoothingLength(Equation):
     def __init__(self, dest, sources, factor=2.0):
@@ -12,6 +14,7 @@ class ScaleSmoothingLength(Equation):
     def loop(self, d_idx, d_h):
         d_h[d_idx] = d_h[d_idx] * self.factor
 
+
 class UpdateSmoothingLengthFromVolume(Equation):
     def __init__(self, dest, sources, dim, k=1.2):
         super(UpdateSmoothingLengthFromVolume, self).__init__(dest, sources)
@@ -19,7 +22,8 @@ class UpdateSmoothingLengthFromVolume(Equation):
         self.dim1 = 1./dim
 
     def loop(self, d_idx, d_m, d_rho, d_h):
-        d_h[d_idx] = self.k * pow( d_m[d_idx]/d_rho[d_idx], self.dim1)
+        d_h[d_idx] = self.k * pow(d_m[d_idx]/d_rho[d_idx], self.dim1)
+
 
 class SummationDensityADKE(Equation):
     """
@@ -29,7 +33,7 @@ class SummationDensityADKE(Equation):
         2014, Journal of Computational Physics, 256, pp 308 -- 333
             (http://dx.doi.org/10.1016/j.jcp.2013.08.060)
     """
-    def __init__(self,dest, sources, k=1.0,  eps=0.0):
+    def __init__(self, dest, sources, k=1.0,  eps=0.0):
         self.k = k
         self.eps = eps
         super(SummationDensityADKE, self).__init__(dest, sources)
@@ -47,30 +51,24 @@ class SummationDensityADKE(Equation):
         # density accelerations
         d_arho[d_idx] += mj * vijdotdwij
 
-
     def post_loop(self, d_idx, d_rho, d_arho, d_div, d_logrho):
         d_div[d_idx] = -d_arho[d_idx]/d_rho[d_idx]
         d_arho[d_idx] = 0
-        d_logrho[d_idx] = log(d_rho[d_idx]);
+        d_logrho[d_idx] = log(d_rho[d_idx])
 
-    def reduce(self,  d_rho, d_h, d_h0,  dst):
-
-        n = declare('int')
-        k = declare('int')
+    def reduce(self, dst):
         n = len(dst.x)
-        tmp_sum_logrho  = serial_reduce_array(dst.array.logrho, 'sum')
+        tmp_sum_logrho = serial_reduce_array(dst.logrho, 'sum')
         sum_logrho = parallel_reduce_array(tmp_sum_logrho, 'sum')
-        g = exp(sum_logrho/n);
+        g = exp(sum_logrho/n)
 
-        for k in range(n):
-            lamda = self.k*pow(g/d_rho[k],self.eps)
-            d_h[k] = lamda*d_h0[k]
+        lamda = self.k*numpy.power(g/dst.rho, self.eps)
+        dst.h[:] = lamda*dst.h0
 
 
 class SummationDensity(Equation):
-    def __init__(
-        self, dest, sources, dim,
-        density_iterations=False, iterate_only_once=False, k=1.2, htol=1e-6):
+    def __init__(self, dest, sources, dim, density_iterations=False,
+                 iterate_only_once=False, k=1.2, htol=1e-6):
         r"""Summation density with iterative solution of the smoothing lengths.
 
         Parameters:
@@ -102,15 +100,15 @@ class SummationDensity(Equation):
 
         super(SummationDensity, self).__init__(dest, sources)
 
-    def initialize(
-        self, d_idx, d_rho, d_div, d_grhox, d_grhoy, d_arho, d_dwdh):
+    def initialize(self, d_idx, d_rho, d_div, d_grhox, d_grhoy, d_arho,
+                   d_dwdh):
 
         d_rho[d_idx] = 0.0
         d_div[d_idx] = 0.0
 
         d_grhox[d_idx] = 0.0
         d_grhoy[d_idx] = 0.0
-        d_arho[d_idx]  = 0.0
+        d_arho[d_idx] = 0.0
 
         d_dwdh[d_idx] = 0.0
 
@@ -143,17 +141,19 @@ class SummationDensity(Equation):
 
         # iteratively find smoothing length consistent with the
         if self.density_iterations:
-            if not ( d_converged[d_idx] == 1 ):
+            if not (d_converged[d_idx] == 1):
                 # current mass and smoothing length. The initial
                 # smoothing length h0 for this particle must be set
                 # outside the Group (that is, in the integrator)
-                mi = d_m[d_idx]; hi = d_h[d_idx]; hi0 = d_h0[d_idx]
+                mi = d_m[d_idx]
+                hi = d_h[d_idx]
+                hi0 = d_h0[d_idx]
 
                 # density from the mass, smoothing length and kernel
                 # scale factor
                 rhoi = mi/(hi/self.k)**self.dim
 
-                dhdrhoi = -hi/( self.dim*d_rho[d_idx] )
+                dhdrhoi = -hi/(self.dim*d_rho[d_idx])
                 dwdhi = d_dwdh[d_idx]
                 omegai = 1.0 - dhdrhoi*dwdhi
 
@@ -175,19 +175,20 @@ class SummationDensity(Equation):
                 hnew = hi - func/dfdh
 
                 # Nanny control for h
-                if ( hnew > 1.2 * hi ):
+                if (hnew > 1.2 * hi):
                     hnew = 1.2 * hi
-                elif ( hnew < 0.8 * hi ):
+                elif (hnew < 0.8 * hi):
                     hnew = 0.8 * hi
 
                 # overwrite if gone awry
-                if ( (hnew <= 1e-6) or (gradhi < 1e-6) ):
+                if ((hnew <= 1e-6) or (gradhi < 1e-6)):
                     hnew = self.k * (mi/d_rho[d_idx])**(1./self.dim)
 
                 # check for convergence
-                diff = abs( hnew-hi )/hi0
+                diff = abs(hnew - hi)/hi0
 
-                if not ( (diff < self.htol) and (omegai > 0) or self.iterate_only_once):
+                if not ((diff < self.htol) and (omegai > 0) or
+                        self.iterate_only_once):
                     # this particle hasn't converged. This means the
                     # entire group must be repeated until this fellow
                     # has converged, or till the maximum iteration has
@@ -210,6 +211,7 @@ class SummationDensity(Equation):
     def converged(self):
         return self.equation_has_converged
 
+
 class IdealGasEOS(Equation):
     def __init__(self, dest, sources, gamma):
         self.gamma = gamma
@@ -218,7 +220,8 @@ class IdealGasEOS(Equation):
 
     def loop(self, d_idx, d_p, d_rho, d_e, d_cs):
         d_p[d_idx] = self.gamma1 * d_rho[d_idx] * d_e[d_idx]
-        d_cs[d_idx] = sqrt( self.gamma * d_p[d_idx]/d_rho[d_idx] )
+        d_cs[d_idx] = sqrt(self.gamma * d_p[d_idx]/d_rho[d_idx])
+
 
 class Monaghan92Accelerations(Equation):
     def __init__(self, dest, sources, alpha=1.0, beta=2.0):
@@ -260,6 +263,7 @@ class Monaghan92Accelerations(Equation):
 
         d_ae[d_idx] += 0.5 * s_m[s_idx] * (tmpi + tmpj + piij) * vijdotdwij
 
+
 class ADKEAccelerations(Equation):
     """
     Reference
@@ -285,9 +289,9 @@ class ADKEAccelerations(Equation):
         d_aw[d_idx] = 0.0
         d_ae[d_idx] = 0.0
 
-    def loop(self,d_idx, s_idx, d_au, d_av, d_aw, d_ae, d_p, s_p, d_rho, s_rho,
-            d_m, s_m, d_cs, s_cs, s_e, d_e, s_h, d_h, s_div, d_div,
-            DWIJ, HIJ, XIJ, VIJ, R2IJ, EPS, RHOIJ, RHOIJ1):
+    def loop(self, d_idx, s_idx, d_au, d_av, d_aw, d_ae, d_p, s_p, d_rho,
+             s_rho, d_m, s_m, d_cs, s_cs, s_e, d_e, s_h, d_h, s_div, d_div,
+             DWIJ, HIJ, XIJ, VIJ, R2IJ, EPS, RHOIJ, RHOIJ1):
 
         # particle pressure
         pi = d_p[d_idx]
@@ -304,9 +308,7 @@ class ADKEAccelerations(Equation):
         cij = 0.5 * (d_cs[d_idx] + s_cs[s_idx])
 
         # averaged mass
-        mi = d_m[d_idx]
         mj = s_m[s_idx]
-        mij = 0.5 * (mi + mj)
 
         # averaged sound speed
         ci = d_cs[d_idx]
@@ -316,37 +318,35 @@ class ADKEAccelerations(Equation):
         hi = d_h[d_idx]
         hj = s_h[s_idx]
 
-
         divi = d_div[d_idx]
         divj = s_div[s_idx]
 
         ei = d_e[d_idx]
         ej = s_e[s_idx]
 
-        #Themal Conduction
-        Hi = self.g1* hi* ci + self.g2* hi* hi*(abs(divi)-divi)
-        Hj = self.g1* hj* cj + self.g2* hj* hj*(abs(divj)-divj)
+        # Themal Conduction
+        Hi = self.g1 * hi * ci + self.g2 * hi * hi*(abs(divi)-divi)
+        Hj = self.g1 * hj * cj + self.g2 * hj * hj*(abs(divj)-divj)
         Hij = (Hi+Hj)*(ei-ej)/(RHOIJ*(R2IJ+EPS))
 
-        xijdotvij = XIJ[0]*VIJ[0] + XIJ[1]*VIJ[1] +  XIJ[2]*VIJ[2]
+        xijdotvij = XIJ[0]*VIJ[0] + XIJ[1]*VIJ[1] + XIJ[2]*VIJ[2]
         piij = 0.0
         if xijdotvij < 0:
             muij = HIJ*xijdotvij/(R2IJ+EPS)
-            piij =  muij * (self.beta*muij - self.alpha*cij)*RHOIJ1
-        tmpv = pibrhoi2 + pjbrhoj2 +piij
+            piij = muij * (self.beta*muij - self.alpha*cij)*RHOIJ1
+        tmpv = pibrhoi2 + pjbrhoj2 + piij
         d_au[d_idx] += -mj*tmpv * DWIJ[0]
         d_av[d_idx] += -mj*tmpv * DWIJ[1]
         d_aw[d_idx] += -mj*tmpv * DWIJ[2]
         vijdotdwij = VIJ[0]*DWIJ[0] + VIJ[1]*DWIJ[1] + VIJ[2]*DWIJ[2]
         xijdotdwij = XIJ[0]*DWIJ[0] + XIJ[1]*DWIJ[1] + XIJ[2]*DWIJ[2]
-        d_ae[d_idx] += 0.5*mj *(tmpv*vijdotdwij + 2*xijdotdwij*Hij)
+        d_ae[d_idx] += 0.5*mj*(tmpv*vijdotdwij + 2*xijdotdwij*Hij)
+
 
 class MPMAccelerations(Equation):
-    def __init__(
-        self, dest, sources, beta=2.0,
-        update_alpha1=False, update_alpha2=False,
-        alpha1_min=0.1, alpha2_min=0.1, sigma=0.1):
-
+    def __init__(self, dest, sources, beta=2.0, update_alpha1=False,
+                 update_alpha2=False, alpha1_min=0.1, alpha2_min=0.1,
+                 sigma=0.1):
         self.beta = beta
         self.sigma = sigma
 
@@ -391,10 +391,7 @@ class MPMAccelerations(Equation):
         # averaged sound speed
         cij = 0.5 * (d_cs[d_idx] + s_cs[s_idx])
 
-        # averaged mass
-        mi = d_m[d_idx]
         mj = s_m[s_idx]
-        mij = 0.5 * (mi + mj)
 
         # averaged sound speed
         ci = d_cs[d_idx]
@@ -420,10 +417,10 @@ class MPMAccelerations(Equation):
         # signal velocities
         pdiff = abs(pi-pj)
         vsig1 = 0.5 * max(cij - self.beta*dot, 0.0)
-        vsig2 = sqrt( pdiff/RHOIJ )
+        vsig2 = sqrt(pdiff/RHOIJ)
 
         # compute the Courant-limited time step factor.
-        DT_ADAPT[0] = max( DT_ADAPT[0], cij + self.beta * dot )
+        DT_ADAPT[0] = max(DT_ADAPT[0], cij + self.beta * dot)
 
         # Artificial viscosity
         if dot <= 0.0:
@@ -440,7 +437,8 @@ class MPMAccelerations(Equation):
 
         # grad-h correction terms. These will be set to 1.0 by the
         # integrator and thus can be used safely.
-        omegai = d_omega[d_idx]; omegaj = s_omega[s_idx]
+        omegai = d_omega[d_idx]
+        omegaj = s_omega[s_idx]
 
         # gradient terms
         d_au[d_idx] += -mj*(pibrhoi2*omegai*DWI[0] + pjbrhoj2*omegaj*DWJ[0])
@@ -466,10 +464,9 @@ class MPMAccelerations(Equation):
         tau = hi/(self.sigma*d_cs[d_idx])
 
         if self.update_alpha1:
-            S1 = max( -d_div[d_idx], 0.0 )
+            S1 = max(-d_div[d_idx], 0.0)
             d_aalpha1[d_idx] = (self.alpha1_min - d_alpha1[d_idx])/tau + S1
 
         if self.update_alpha2:
-            #S2 = d_h[d_idx] * abs(d_del2e[d_idx])/sqrt(d_e[d_idx])
             S2 = 0.01 * d_h[d_idx] * d_del2e[d_idx]
             d_aalpha2[d_idx] = (self.alpha2_min - d_alpha2[d_idx])/tau + S2

--- a/pysph/sph/iisph.py
+++ b/pysph/sph/iisph.py
@@ -343,13 +343,13 @@ class PressureForce(Equation):
         d_aw[d_idx] += fac*DWIJ[2]
 
     def post_loop(self, d_idx, d_au, d_av, d_aw,
-                  d_uadv, d_vadv, d_wadv, DT_ADAPT):
+                  d_uadv, d_vadv, d_wadv, d_dt_cfl, d_dt_force):
         fac = d_au[d_idx]*d_au[d_idx] + d_av[d_idx]*d_av[d_idx] +\
                    d_aw[d_idx]*d_aw[d_idx]
         vmag = sqrt(d_uadv[d_idx]*d_uadv[d_idx] + d_vadv[d_idx]*d_vadv[d_idx] +
                     d_wadv[d_idx]*d_wadv[d_idx])
-        DT_ADAPT[0] = max(2.0*vmag, DT_ADAPT[0])
-        DT_ADAPT[1] = max(2.0*fac, DT_ADAPT[1])
+        d_dt_cfl[d_idx] = 2.0*vmag
+        d_dt_force[d_idx] = 2.0*fac
 
 
 class PressureForceBoundary(Equation):

--- a/pysph/sph/iisph.py
+++ b/pysph/sph/iisph.py
@@ -38,12 +38,14 @@ class NumberDensity(Equation):
     def loop(self, d_idx, d_V, WIJ):
         d_V[d_idx] += WIJ
 
+
 class SummationDensity(Equation):
     def initialize(self, d_idx, d_rho):
         d_rho[d_idx] = 0.0
 
     def loop(self, d_idx, d_rho, s_idx, s_m, WIJ):
         d_rho[d_idx] += s_m[s_idx]*WIJ
+
 
 class SummationDensityBoundary(Equation):
     def __init__(self, dest, sources, rho0):
@@ -52,6 +54,7 @@ class SummationDensityBoundary(Equation):
 
     def loop(self, d_idx, d_rho, s_idx, s_V, WIJ):
         d_rho[d_idx] += self.rho0/s_V[s_idx]*WIJ
+
 
 class NormalizedSummationDensity(Equation):
     def initialize(self, d_idx, d_rho, d_rho_adv, d_rho0, d_V):
@@ -94,6 +97,7 @@ class AdvectionAcceleration(Equation):
         d_vadv[d_idx] = d_v[d_idx] + dt*d_av[d_idx]
         d_wadv[d_idx] = d_w[d_idx] + dt*d_aw[d_idx]
 
+
 class ViscosityAcceleration(Equation):
     def __init__(self, dest, sources, nu):
         self.nu = nu
@@ -106,6 +110,7 @@ class ViscosityAcceleration(Equation):
         d_au[d_idx] += fac*VIJ[0]
         d_av[d_idx] += fac*VIJ[1]
         d_aw[d_idx] += fac*VIJ[2]
+
 
 class ViscosityAccelerationBoundary(Equation):
     """The acceleration on the fluid due to a boundary.
@@ -161,8 +166,8 @@ class ComputeRhoAdvection(Equation):
         d_p0[d_idx] = d_p[d_idx]
         d_piter[d_idx] = 0.5*d_p[d_idx]
 
-    def loop(self, d_idx, d_rho, d_rho_adv, d_uadv, d_vadv, d_wadv, d_u, d_v, d_w,
-             s_idx, s_m, s_uadv, s_vadv, s_wadv, DWIJ, dt=0.0):
+    def loop(self, d_idx, d_rho, d_rho_adv, d_uadv, d_vadv, d_wadv, d_u,
+             d_v, d_w, s_idx, s_m, s_uadv, s_vadv, s_wadv, DWIJ, dt=0.0):
 
         vijdotdwij = (d_uadv[d_idx] - s_uadv[s_idx])*DWIJ[0] + \
                      (d_vadv[d_idx] - s_vadv[s_idx])*DWIJ[1] + \
@@ -212,8 +217,8 @@ class ComputeAIIBoundary(Equation):
     def loop(self, d_idx, d_aii, d_dii0, d_dii1, d_dii2, d_rho,
              s_idx, s_m, s_V, DWIJ, dt=0.0):
         phi_b = self.rho0/s_V[s_idx]
-        dijdotdwij = d_dii0[d_idx]*DWIJ[0] + d_dii1[d_idx]*DWIJ[1] + \
-                     d_dii2[d_idx]*DWIJ[2]
+        dijdotdwij = (d_dii0[d_idx]*DWIJ[0] + d_dii1[d_idx]*DWIJ[1] +
+                      d_dii2[d_idx]*DWIJ[2])
         d_aii[d_idx] += phi_b*dijdotdwij
 
 
@@ -246,8 +251,8 @@ class PressureSolve(Equation):
         d_p[d_idx] = 0.0
         d_compression[d_idx] = 0.0
 
-    def loop(self, d_idx, d_p, d_piter, d_rho, d_m, d_dijpj0, d_dijpj1, d_dijpj2,
-             s_idx, s_m, s_dii0, s_dii1, s_dii2,
+    def loop(self, d_idx, d_p, d_piter, d_rho, d_m, d_dijpj0, d_dijpj1,
+             d_dijpj2, s_idx, s_m, s_dii0, s_dii1, s_dii2,
              s_piter, s_dijpj0, s_dijpj1, s_dijpj2, DWIJ, dt=0.0):
 
         # Note that a good way to check this is to see that when
@@ -268,7 +273,6 @@ class PressureSolve(Equation):
 
     def post_loop(self, d_idx, d_piter, d_p0, d_p, d_aii, d_rho_adv, d_rho,
                   d_compression, dt=0.0):
-        #tmp = d_rho[d_idx] - d_rho_adv[d_idx] - d_p[d_idx]
         tmp = self.rho0 - d_rho_adv[d_idx] - d_p[d_idx]
         p = (1.0 - self.omega)*d_piter[d_idx] + self.omega/d_aii[d_idx]*tmp
 
@@ -277,7 +281,7 @@ class PressureSolve(Equation):
         # Clamp pressure to positive values.
         if p < 0.0:
             p = 0.0
-        elif abs(d_aii[d_idx]) < aii_min :
+        elif abs(d_aii[d_idx]) < aii_min:
             p = 0.0
         else:
             d_compression[d_idx] = abs(p*d_aii[d_idx] - tmp)
@@ -286,8 +290,8 @@ class PressureSolve(Equation):
         d_p[d_idx] = p
 
     def reduce(self, dst):
-        dst.tmp_comp[0] = serial_reduce_array(dst.array.compression > 0.0, 'sum')
-        dst.tmp_comp[1] = serial_reduce_array(dst.array.compression, 'sum')
+        dst.tmp_comp[0] = serial_reduce_array(dst.compression > 0.0, 'sum')
+        dst.tmp_comp[1] = serial_reduce_array(dst.compression, 'sum')
         dst.tmp_comp.set_data(parallel_reduce_array(dst.tmp_comp, 'sum'))
         if dst.tmp_comp[0] > 0:
             comp = dst.tmp_comp[1]/dst.tmp_comp[0]/self.rho0
@@ -308,6 +312,7 @@ class PressureSolve(Equation):
                 print("Converged:", compression)
             return 1.0
 
+
 class PressureSolveBoundary(Equation):
     def __init__(self, dest, sources, rho0):
         self.rho0 = rho0
@@ -316,9 +321,9 @@ class PressureSolveBoundary(Equation):
     def loop(self, d_idx, d_p, d_rho, d_dijpj0, d_dijpj1, d_dijpj2,
              s_idx, s_V, DWIJ):
         phi_b = self.rho0/s_V[s_idx]
-        dijdotwij = d_dijpj0[d_idx]*DWIJ[0] + \
-                    d_dijpj1[d_idx]*DWIJ[1] + \
-                    d_dijpj2[d_idx]*DWIJ[2]
+        dijdotwij = (d_dijpj0[d_idx]*DWIJ[0] +
+                     d_dijpj1[d_idx]*DWIJ[1] +
+                     d_dijpj2[d_idx]*DWIJ[2])
         d_p[d_idx] += phi_b*dijdotwij
 
 

--- a/pysph/sph/integrator.py
+++ b/pysph/sph/integrator.py
@@ -11,6 +11,7 @@ from numpy import sqrt
 # Local imports.
 from .integrator_step import IntegratorStep
 
+
 ###############################################################################
 # `Integrator` class
 ###############################################################################
@@ -30,7 +31,8 @@ class Integrator(object):
         """
         for array_name, integrator_step in kw.items():
             if not isinstance(integrator_step, IntegratorStep):
-                msg='Stepper %s must be an instance of IntegratorStep'%(integrator_step)
+                msg = ('Stepper %s must be an instance of '
+                       'IntegratorStep' % (integrator_step))
                 raise ValueError(msg)
 
         self.steppers = kw
@@ -42,8 +44,8 @@ class Integrator(object):
     def __repr__(self):
         name = self.__class__.__name__
         s = self.steppers
-        args = ', '.join(['%s=%s'%(k, s[k]) for k in s])
-        return '%s(%s)'%(name, args)
+        args = ', '.join(['%s=%s' % (k, s[k]) for k in s])
+        return '%s(%s)' % (name, args)
 
     ##########################################################################
     # Public interface.
@@ -53,7 +55,7 @@ class Integrator(object):
         if fixed_h:
             self.compute_h_minimum()
 
-        self.fixed_h=fixed_h
+        self.fixed_h = fixed_h
 
     def set_nnps(self, nnps):
         self.c_integrator.set_nnps(nnps)
@@ -99,14 +101,14 @@ class Integrator(object):
 
         # stable time step based on force criterion
         if dt_force_factor > 0:
-            dt_force = sqrt( hmin/sqrt(dt_force_factor) )
+            dt_force = sqrt(hmin/sqrt(dt_force_factor))
 
         # stable time step based on viscous condition
         if dt_visc_factor > 0:
             dt_viscous = hmin/dt_visc_factor
 
         # minimum of all three
-        dt_min = min( dt_cfl, dt_force, dt_viscous )
+        dt_min = min(dt_cfl, dt_force, dt_viscous)
 
         # return the computed time steps. If dt factors aren't
         # defined, the default dt is returned
@@ -203,7 +205,8 @@ class PECIntegrator(Integrator):
 
     .. math::
 
-        y^{n+\frac{1}{2}} = y^n + \frac{\Delta t}{2}F(y^{n-\frac{1}{2}}) --> Predict
+        y^{n+\frac{1}{2}} = y^n + \frac{\Delta t}{2}F(y^{n-\frac{1}{2}})
+        --> Predict
 
         F(y^{n+\frac{1}{2}}) --> Evaluate
 
@@ -226,6 +229,7 @@ class PECIntegrator(Integrator):
 
         # Call any post-stage functions.
         self.do_post_stage(dt, 2)
+
 
 ###############################################################################
 # `EPECIntegrator` class
@@ -256,7 +260,8 @@ class EPECIntegrator(Integrator):
 
     In the EPEC mode, the final corrector can be modified to:
 
-    :math:`y^{n+1} = y^n + \frac{\Delta t}{2}\left( F(y^n) + F(y^{n+\frac{1}{2}}) \right)`
+    :math:`y^{n+1} = y^n + \frac{\Delta t}{2}\left( F(y^n) +
+                                F(y^{n+\frac{1}{2}}) \right)`
 
     This would require additional storage for the accelerations.
 
@@ -280,6 +285,7 @@ class EPECIntegrator(Integrator):
         # Call any post-stage functions.
         self.do_post_stage(dt, 2)
 
+
 ###############################################################################
 # `TVDRK3Integrator` class
 ###############################################################################
@@ -291,9 +297,11 @@ class TVDRK3Integrator(Integrator):
 
         y^{n + \frac{1}{3}} = y^n + \Delta t F( y^n )
 
-        y^{n + \frac{2}{3}} = \frac{3}{4}y^n + \frac{1}{4}(y^{n + \frac{1}{3}} + \Delta t F(y^{n + \frac{1}{3}}))
+        y^{n + \frac{2}{3}} = \frac{3}{4}y^n +
+        \frac{1}{4}(y^{n + \frac{1}{3}} + \Delta t F(y^{n + \frac{1}{3}}))
 
-        y^{n + 1} = \frac{1}{3}y^n + \frac{2}{3}(y^{n + \frac{2}{3}} + \Delta t F(y^{n + \frac{2}{3}}))
+        y^{n + 1} = \frac{1}{3}y^n + \frac{2}{3}(y^{n + \frac{2}{3}}
+        + \Delta t F(y^{n + \frac{2}{3}}))
 
     """
     def one_timestep(self, t, dt):

--- a/pysph/sph/integrator_opencl_helper.py
+++ b/pysph/sph/integrator_opencl_helper.py
@@ -58,7 +58,9 @@ class OpenCLIntegrator(object):
         for name, (call, args, dest) in call_info.items():
             n = dest.get_number_of_particles(real=True)
             args[1] = (n,)
-            call(*(args + extra_args))
+            # Compute the remaining arguments.
+            rest = [x() for x in args[3:]]
+            call(*(args[:3] + rest + extra_args))
 
     def set_nnps(self, nnps):
         self.nnps = nnps
@@ -120,8 +122,15 @@ class IntegratorOpenCLHelper(IntegratorCythonHelper):
         for method, info in self.data.items():
             for dest_name, (kernel, args) in info.items():
                 dest = array_map[dest_name]
+
+                # Note: This is done to do some late binding. Instead of just
+                # directly storing the dest.gpu.x, we compute it on the fly
+                # as the number of particles and the actual buffer may change.
+                def _getter(dest_gpu, x):
+                    return getattr(dest_gpu, x).data
+
                 _args = [
-                    getattr(dest.gpu, x[2:]).data for x in args
+                    functools.partial(_getter, dest.gpu, x[2:]) for x in args
                 ]
                 all_args = [q, None, None] + _args
                 calls[method][dest] = (

--- a/pysph/sph/integrator_opencl_helper.py
+++ b/pysph/sph/integrator_opencl_helper.py
@@ -205,7 +205,7 @@ class IntegratorOpenCLHelper(IntegratorCythonHelper):
         ] + wrap_code(
             '{cls}_{method}({args});'.format(
                 cls=cls, method=method,
-                args='0, ' + ', '.join(args)
+                args=', '.join(['0'] + args)
             ), indent=''
         )
 

--- a/pysph/sph/tests/test_acceleration_eval.py
+++ b/pysph/sph/tests/test_acceleration_eval.py
@@ -172,8 +172,13 @@ class MixedTypeEquation(Equation):
 
 
 class SimpleReduction(Equation):
+    def initialize(self, d_idx, d_au):
+        d_au[d_idx] = 0.0
+
     def reduce(self, dst):
-        dst.total_mass[0] = serial_reduce_array(dst.array.m, op='sum')
+        dst.total_mass[0] = serial_reduce_array(dst.m, op='sum')
+        if dst.gpu is not None:
+            dst.gpu.push('total_mass')
 
 
 class TestAccelerationEval1D(unittest.TestCase):
@@ -551,6 +556,21 @@ class TestAccelerationEval1DGPU(unittest.TestCase):
         expect = np.ones(10)*1.5
         pa.gpu.pull('au')
         self.assertListEqual(list(pa.au), list(expect))
+
+    def test_should_run_reduce_when_using_gpu(self):
+        # Given.
+        pa = self.pa
+        pa.add_constant('total_mass', 0.0)
+        equations = [SimpleReduction(dest='fluid', sources=['fluid'])]
+        a_eval = self._make_accel_eval(equations)
+
+        # When
+        a_eval.compute(0.1, 0.1)
+
+        # Then
+        expect = np.sum(pa.m)
+        pa.gpu.pull('total_mass')
+        self.assertAlmostEqual(pa.total_mass[0], expect, 14)
 
     def test_get_equations_with_converged(self):
         pytest.importorskip('pysph.base.gpu_nnps')

--- a/pysph/sph/wc/basic.py
+++ b/pysph/sph/wc/basic.py
@@ -4,28 +4,28 @@ Basic WCSPH Equations
 """
 
 from pysph.sph.equation import Equation
-from textwrap import dedent
+
 
 class TaitEOS(Equation):
     r"""**Tait equation of state for water-like fluids**
 
     :math:`p_a = \frac{c_{0}^2\rho_0}{\gamma}\left(
     \left(\frac{\rho_a}{\rho_0}\right)^{\gamma} -1\right)`
-    
+
     References
     ----------
     .. [Cole1948] H. R. Cole, "Underwater Explosions", Princeton University
         Press, 1948.
-    
-    .. [Batchelor2002] G. Batchelor, "An Introduction to Fluid Dynamics", 
+
+    .. [Batchelor2002] G. Batchelor, "An Introduction to Fluid Dynamics",
         Cambridge University Press, 2002.
-    
-    .. [Monaghan2005] J. Monaghan, "Smoothed particle hydrodynamics", 
-        Reports on Progress in Physics, 68 (2005), pp. 1703-1759. 
+
+    .. [Monaghan2005] J. Monaghan, "Smoothed particle hydrodynamics",
+        Reports on Progress in Physics, 68 (2005), pp. 1703-1759.
 
     """
     def __init__(self, dest, sources, rho0, c0, gamma, p0=0.0):
-                     
+
         r"""
         Parameters
         ----------
@@ -37,13 +37,13 @@ class TaitEOS(Equation):
             constant
         p0 : float
             reference pressure in the system (defaults to zero).
-        
+
         Notes
         -----
         The reference speed of sound, c0, is to be taken approximately as
         10 times the maximum expected velocity in the system. The particle
         sound speed is given by the usual expression:
-    
+
         :math:`c_a = \sqrt{\frac{\partial p}{\partial \rho}}`
 
         """
@@ -54,7 +54,7 @@ class TaitEOS(Equation):
         self.gamma1 = 0.5*(gamma - 1.0)
         self.B = rho0*c0*c0/gamma
         self.p0 = p0
-        
+
         super(TaitEOS, self).__init__(dest, sources)
 
     def loop(self, d_idx, d_rho, d_p, d_cs):
@@ -62,7 +62,8 @@ class TaitEOS(Equation):
         tmp = pow(ratio, self.gamma)
 
         d_p[d_idx] = self.p0 + self.B * (tmp - 1.0)
-        d_cs[d_idx] = self.c0 * pow( ratio, self.gamma1 )
+        d_cs[d_idx] = self.c0 * pow(ratio, self.gamma1)
+
 
 class TaitEOSHGCorrection(Equation):
     r"""**Tait Equation of State with Hughes and Graham Correction**
@@ -70,24 +71,24 @@ class TaitEOSHGCorrection(Equation):
     .. math::
         p_a = \frac{c_{0}^2\rho_0}{\gamma}\left(
         \left(\frac{\rho_a}{\rho_0}\right)^{\gamma} -1\right)
-    
+
     where
-    
+
     .. math::
-    
+
         \rho_{a}=\begin{cases}\rho_{a} & \rho_{a}\geq\rho_{0}\\
         \rho_{0} & \rho_{a}<\rho_{0}\end{cases}`
 
     References
     ----------
-    .. [Hughes2010] J. P. Hughes and D. I. Graham, "Comparison of incompressible 
-        and weakly-compressible SPH models for free-surface water flows",
-        Journal of Hydraulic Research, 48 (2010), pp. 105-117.
+    .. [Hughes2010] J. P. Hughes and D. I. Graham, "Comparison of
+        incompressible and weakly-compressible SPH models for free-surface
+        water flows", Journal of Hydraulic Research, 48 (2010), pp. 105-117.
 
     """
-    
+
     def __init__(self, dest, sources, rho0, c0, gamma):
-        
+
         r"""
         Parameters
         ----------
@@ -97,7 +98,7 @@ class TaitEOSHGCorrection(Equation):
             reference speed of sound
         gamma : float
             constant
-            
+
         Notes
         -----
         The correction is to be applied on boundary particles and imposes
@@ -105,7 +106,7 @@ class TaitEOSHGCorrection(Equation):
         instantiation. This correction avoids particle sticking behaviour
         at walls.
         """
-        
+
         self.rho0 = rho0
         self.rho01 = 1.0/rho0
         self.c0 = c0
@@ -122,47 +123,48 @@ class TaitEOSHGCorrection(Equation):
         tmp = pow(ratio, self.gamma)
 
         d_p[d_idx] = self.B * (tmp - 1.0)
-        d_cs[d_idx] = self.c0 * pow( ratio, self.gamma1 )
+        d_cs[d_idx] = self.c0 * pow(ratio, self.gamma1)
+
 
 class MomentumEquation(Equation):
     r"""**Classic Monaghan Style Momentum Equation with Artificial Viscosity**
-    
+
     .. math::
-    
+
         \frac{d\mathbf{v}_{a}}{dt}=-\sum_{b}m_{b}\left(\frac{p_{b}}
         {\rho_{b}^{2}}+\frac{p_{a}}{\rho_{a}^{2}}+\Pi_{ab}\right)
         \nabla_{a}W_{ab}
-        
+
     where
-    
+
     .. math::
-    
+
         \Pi_{ab}=\begin{cases}
-        \frac{-\alpha\bar{c}_{ab}\mu_{ab}+\beta\mu_{ab}^{2}}{\bar{\rho}_{ab}} & 
+        \frac{-\alpha\bar{c}_{ab}\mu_{ab}+\beta\mu_{ab}^{2}}{\bar{\rho}_{ab}} &
         \mathbf{v}_{ab}\cdot\mathbf{r}_{ab}<0;\\
         0 & \mathbf{v}_{ab}\cdot\mathbf{r}_{ab}\geq0;
         \end{cases}
-        
+
     with
-    
+
     .. math::
-    
+
         \mu_{ab}=\frac{h\mathbf{v}_{ab}\cdot\mathbf{r}_{ab}}
         {\mathbf{r}_{ab}^{2}+\eta^{2}}\\
-        
+
         \bar{c}_{ab} = \frac{c_a + c_b}{2}\\
-        
+
         \bar{\rho}_{ab} = \frac{\rho_a + \rho_b}{2}
-        
+
     References
     ----------
-    .. [Monaghan1992] J. Monaghan, Smoothed Particle Hydrodynamics, "Annual 
+    .. [Monaghan1992] J. Monaghan, Smoothed Particle Hydrodynamics, "Annual
         Review of Astronomy and Astrophysics", 30 (1992), pp. 543-574.
     """
     def __init__(self, dest, sources, c0,
                  alpha=1.0, beta=1.0, gx=0.0, gy=0.0, gz=0.0,
                  tensile_correction=False):
-        
+
         r"""
         Parameters
         ----------
@@ -181,7 +183,7 @@ class MomentumEquation(Equation):
         tensilte_correction : bool
             switch for tensile instability correction (Default: False)
         """
-        
+
         self.alpha = alpha
         self.beta = beta
         self.gx = gx
@@ -221,32 +223,30 @@ class MomentumEquation(Equation):
         # compute the CFL time step factor
         _dt_cfl = 0.0
         if R2IJ > 1e-12:
-            _dt_cfl = abs( HIJ * vijdotxij/R2IJ ) + self.c0
+            _dt_cfl = abs(HIJ * vijdotxij/R2IJ) + self.c0
             DT_ADAPT[0] = max(_dt_cfl, DT_ADAPT[0])
 
         tmpi = d_p[d_idx]*rhoi21
         tmpj = s_p[s_idx]*rhoj21
 
         fij = WIJ/WDP
-        Ri = 0.0; Rj = 0.0
-
-        #tmp = d_p[d_idx] * rhoi21 + s_p[s_idx] * rhoj21
-        #tmp = tmpi + tmpj
+        Ri = 0.0
+        Rj = 0.0
 
         # tensile instability correction
         if self.tensile_correction:
             fij = fij*fij
             fij = fij*fij
 
-            if d_p[d_idx] > 0 :
+            if d_p[d_idx] > 0:
                 Ri = 0.01 * tmpi
             else:
-                Ri = 0.2*abs( tmpi )
+                Ri = 0.2*abs(tmpi)
 
             if s_p[s_idx] > 0:
                 Rj = 0.01 * tmpj
             else:
-                Rj = 0.2 * abs( tmpj )
+                Rj = 0.2 * abs(tmpj)
 
         # gradient and correction terms
         tmp = (tmpi + tmpj) + (Ri + Rj)*fij
@@ -256,48 +256,47 @@ class MomentumEquation(Equation):
         d_aw[d_idx] += -s_m[s_idx] * (tmp + piij) * DWIJ[2]
 
     def post_loop(self, d_idx, d_au, d_av, d_aw, DT_ADAPT):
-        d_au[d_idx] +=  self.gx
-        d_av[d_idx] +=  self.gy
-        d_aw[d_idx] +=  self.gz
+        d_au[d_idx] += self.gx
+        d_av[d_idx] += self.gy
+        d_aw[d_idx] += self.gz
 
-        acc2 = ( d_au[d_idx]*d_au[d_idx] + \
-                    d_av[d_idx]*d_av[d_idx] + \
-                    d_aw[d_idx]*d_aw[d_idx] )
+        acc2 = (d_au[d_idx]*d_au[d_idx] +
+                d_av[d_idx]*d_av[d_idx] +
+                d_aw[d_idx]*d_aw[d_idx])
 
         # store the square of the max acceleration
-        DT_ADAPT[1] = max( acc2, DT_ADAPT[1] )
+        DT_ADAPT[1] = max(acc2, DT_ADAPT[1])
+
 
 class MomentumEquationDeltaSPH(Equation):
     r"""**Momentum equation defined in JOSEPHINE and the delta-SPH model**
 
     .. math::
-    
+
         \frac{du_{i}}{dt}=-\frac{1}{\rho_{i}}\sum_{j}\left(p_{j}+p_{i}\right)
         \nabla_{i}W_{ij}V_{j}+\mathbf{g}_{i}+\alpha hc_{0}\rho_{0}\sum_{j}
         \pi_{ij}\nabla_{i}W_{ij}V_{j}
-    
+
     where
-    
-    .. math:: 
-    
+
+    .. math::
+
         \pi_{ij}=\frac{\mathbf{u}_{ij}\cdot\mathbf{r}_{ij}}
         {|\mathbf{r}_{ij}|^{2}}
-    
+
     References
     ----------
-    .. [Marrone2011] S. Marrone et al., "delta-SPH model for simulating 
-        violent impact flows", Computer Methods in Applied Mechanics and 
+    .. [Marrone2011] S. Marrone et al., "delta-SPH model for simulating
+        violent impact flows", Computer Methods in Applied Mechanics and
         Engineering, 200 (2011), pp 1526--1542.
 
-    .. [Cherfils2012] J. M. Cherfils et al., "JOSEPHINE: A parallel SPH code for 
-        free-surface flows", Computer Physics Communications, 183 (2012), 
+    .. [Cherfils2012] J. M. Cherfils et al., "JOSEPHINE: A parallel SPH code
+        for free-surface flows", Computer Physics Communications, 183 (2012),
         pp 1468--1480.
-       
-    """
-    def __init__(
-        self, dest, sources, rho0, c0, alpha=1.0,
-        gx=0.0, gy=0.0, gz=0.0):
 
+    """
+    def __init__(self, dest, sources, rho0, c0, alpha=1.0,
+                 gx=0.0, gy=0.0, gz=0.0):
         r"""
         Parameters
         ----------
@@ -306,7 +305,7 @@ class MomentumEquationDeltaSPH(Equation):
         c0 : float
             reference speed of sound
         alpha : float
-            coefficient used to control the intensity of the 
+            coefficient used to control the intensity of the
             diffusion of velocity
         gx : float
             body force per unit mass along the x-axis
@@ -314,7 +313,7 @@ class MomentumEquationDeltaSPH(Equation):
             body force per unit mass along the y-axis
         gz : float
             body force per unit mass along the z-axis
-        
+
         Notes
         -----
         Artificial viscosity is used in this momentum equation and is
@@ -322,7 +321,7 @@ class MomentumEquationDeltaSPH(Equation):
         artificial viscosity is similar but not identical to the
         Monaghan-style artificial viscosity.
         """
-        
+
         self.alpha = alpha
         self.gx = gx
         self.gy = gy
@@ -360,16 +359,17 @@ class MomentumEquationDeltaSPH(Equation):
         d_aw[d_idx] += tmp * DWIJ[2]
 
     def post_loop(self, d_idx, d_au, d_av, d_aw, DT_ADAPT):
-        d_au[d_idx] +=  self.gx
-        d_av[d_idx] +=  self.gy
-        d_aw[d_idx] +=  self.gz
+        d_au[d_idx] += self.gx
+        d_av[d_idx] += self.gy
+        d_aw[d_idx] += self.gz
 
-        acc2 = ( d_au[d_idx]*d_au[d_idx] + \
-                    d_av[d_idx]*d_av[d_idx] + \
-                    d_aw[d_idx]*d_aw[d_idx] )
+        acc2 = (d_au[d_idx]*d_au[d_idx] +
+                d_av[d_idx]*d_av[d_idx] +
+                d_aw[d_idx]*d_aw[d_idx])
 
         # store the square of the max acceleration
-        DT_ADAPT[1] = max( acc2, DT_ADAPT[1] )
+        DT_ADAPT[1] = max(acc2, DT_ADAPT[1])
+
 
 class ContinuityEquationDeltaSPH(Equation):
     r"""**Continuity equation with dissipative terms**
@@ -381,8 +381,8 @@ class ContinuityEquationDeltaSPH(Equation):
 
     References
     ----------
-    .. [Marrone2011] S. Marrone et al., "delta-SPH model for simulating 
-        violent impact flows", Computer Methods in Applied Mechanics and 
+    .. [Marrone2011] S. Marrone et al., "delta-SPH model for simulating
+        violent impact flows", Computer Methods in Applied Mechanics and
         Engineering, 200 (2011), pp 1526--1542.
     """
     def __init__(self, dest, sources, c0, delta=0.1):
@@ -416,12 +416,12 @@ class ContinuityEquationDeltaSPH(Equation):
         etadotdwij /= (RIJ + EPS)
 
         # celerity (sound speed)
-        #cij =  max( d_cs[d_idx], s_cs[s_idx] )
         cij = self.c0
         psi_ij = self.delta * HIJ * cij * (rhoj - rhoi)
 
         # standard term with dissipative penalization eqn (5a)
         d_arho[d_idx] += rhoi*vijdotdwij*Vj + psi_ij*etadotdwij*Vj
+
 
 class UpdateSmoothingLengthFerrari(Equation):
     r"""**Update the particle smoothing lengths**
@@ -433,7 +433,7 @@ class UpdateSmoothingLengthFerrari(Equation):
     .. [Ferrari2009] A. Ferrari et al., "A new 3D parallel SPH scheme for free
         surface flows", Computers and Fluids, 38 (2009), pp. 1203--1217.
     """
-    
+
     def __init__(self, dest, sources, dim, hdx):
         r"""
         Parameters
@@ -442,20 +442,20 @@ class UpdateSmoothingLengthFerrari(Equation):
             number of dimensions
         hdx : float
             scaling factor
-            
+
         Notes
         -----
         Ideally, the kernel scaling factor should be determined from the
         kernel used based on a linear stability analysis. The default
         value of (hdx=1) reduces to the formulation suggested by Ferrari
         et al. who used a Cubic Spline kernel.
-    
+
         Typically, a change in the smoothing length should mean the
         neighbors are re-computed which in PySPH means the NNPS must be
         updated. This equation should therefore be placed as the last
         equation so that after the final corrector stage, the smoothing
         lengths are updated and the new NNPS data structure is computed.
-    
+
         Note however that since this is to be used with incompressible flow
         equations, the density variations are small and hence the smoothing
         lengths should also not vary too much.
@@ -474,7 +474,7 @@ class UpdateSmoothingLengthFerrari(Equation):
 
 class PressureGradientUsingNumberDensity(Equation):
     r"""Pressure gradient discretized using number density:
-    
+
     .. math::
 
         \frac{d \boldsymbol{v}_a}{dt} = -\frac{1}{m_a}\sum_b
@@ -485,16 +485,19 @@ class PressureGradientUsingNumberDensity(Equation):
         d_au[d_idx] = 0.0
         d_av[d_idx] = 0.0
         d_aw[d_idx] = 0.0
-        
-    def loop(self, d_idx, s_idx, d_m, d_rho, s_rho, 
+
+    def loop(self, d_idx, s_idx, d_m, d_rho, s_rho,
              d_au, d_av, d_aw, d_p, s_p, d_V, s_V, DWIJ):
 
         # particle volumes
-        Vi = 1./d_V[d_idx]; Vj = 1./s_V[s_idx]
-        Vi2 = Vi * Vi; Vj2 = Vj * Vj
+        Vi = 1./d_V[d_idx]
+        Vj = 1./s_V[s_idx]
+        Vi2 = Vi * Vi
+        Vj2 = Vj * Vj
 
         # pressure gradient term
-        pi = d_p[d_idx]; pj = s_p[s_idx]
+        pi = d_p[d_idx]
+        pj = s_p[s_idx]
         pij = pi*Vi2 + pj*Vj2
 
         # accelerations

--- a/pysph/sph/wc/edac.py
+++ b/pysph/sph/wc/edac.py
@@ -272,20 +272,13 @@ class MomentumEquation(Equation):
         d_av[d_idx] += tmp * DWIJ[1]
         d_aw[d_idx] += tmp * DWIJ[2]
 
-    def post_loop(self, d_idx, d_au, d_av, d_aw, t, DT_ADAPT):
+    def post_loop(self, d_idx, d_au, d_av, d_aw, t):
         damping_factor = 1.0
         if t < self.tdamp:
             damping_factor = 0.5 * (sin((-0.5 + t/self.tdamp)*M_PI) + 1.0)
         d_au[d_idx] += damping_factor*self.gx
         d_av[d_idx] += damping_factor*self.gy
         d_aw[d_idx] += damping_factor*self.gz
-
-        acc2 = (d_au[d_idx]*d_au[d_idx] +
-                d_av[d_idx]*d_av[d_idx] +
-                d_aw[d_idx]*d_aw[d_idx])
-
-        # store the square of the max acceleration
-        DT_ADAPT[1] = max(acc2, DT_ADAPT[1])
 
 
 class EDACEquation(Equation):

--- a/pysph/sph/wc/transport_velocity.py
+++ b/pysph/sph/wc/transport_velocity.py
@@ -15,10 +15,11 @@ References
 """
 
 from pysph.sph.equation import Equation
-from math import sin, cos, pi
+from math import sin, pi
 
 # constants
 M_PI = pi
+
 
 class SummationDensity(Equation):
     r"""**Summation density with volume summation**
@@ -37,8 +38,8 @@ class SummationDensity(Equation):
     Notes
     -----
 
-    Note that in the pysph implementation, V is the inverse volume of a particle,
-    i.e. the equation computes V as follows:
+    Note that in the pysph implementation, V is the inverse volume of a
+    particle, i.e. the equation computes V as follows:
 
     .. math::
 
@@ -56,6 +57,7 @@ class SummationDensity(Equation):
         d_V[d_idx] += WIJ
         d_rho[d_idx] += d_m[d_idx]*WIJ
 
+
 class VolumeSummation(Equation):
     """**Number density for volume computation**
 
@@ -72,10 +74,12 @@ class VolumeSummation(Equation):
     def loop(self, d_idx, d_V, WIJ):
         d_V[d_idx] += WIJ
 
+
 class VolumeFromMassDensity(Equation):
     """**Set the inverse volume using mass density**"""
     def loop(self, d_idx, d_V, d_rho, d_m):
         d_V[d_idx] = d_rho[d_idx]/d_m[d_idx]
+
 
 class SetWallVelocity(Equation):
     r"""**Extrapolating the fluid velocity on to the wall**
@@ -113,7 +117,7 @@ class SetWallVelocity(Equation):
         d_wf[d_idx] += s_w[s_idx] * WIJ
 
     def post_loop(self, d_uf, d_vf, d_wf, d_wij, d_idx,
-            d_ug, d_vg, d_wg, d_u, d_v, d_w):
+                  d_ug, d_vg, d_wg, d_u, d_v, d_w):
 
         # calculation is done only for the relevant boundary particles.
         # d_wij (and d_uf) is 0 for particles sufficiently away from the
@@ -128,6 +132,7 @@ class SetWallVelocity(Equation):
         d_ug[d_idx] = 2*d_u[d_idx] - d_uf[d_idx]
         d_vg[d_idx] = 2*d_v[d_idx] - d_vf[d_idx]
         d_wg[d_idx] = 2*d_w[d_idx] - d_wf[d_idx]
+
 
 class ContinuityEquation(Equation):
     r"""**Conservation of mass equation**
@@ -147,6 +152,7 @@ class ContinuityEquation(Equation):
         vijdotdwij = VIJ[0]*DWIJ[0] + VIJ[1]*DWIJ[1] + VIJ[2]*DWIJ[2]
 
         d_arho[d_idx] += d_rho[d_idx] * s_m[s_idx]/s_rho[s_idx] * vijdotdwij
+
 
 class StateEquation(Equation):
     r"""**Generalized Weakly Compressible Equation of State**
@@ -182,13 +188,14 @@ class StateEquation(Equation):
             constant (default 1.0).
         """
 
-        self.b=b
+        self.b = b
         self.p0 = p0
         self.rho0 = rho0
         super(StateEquation, self).__init__(dest, sources)
 
     def loop(self, d_idx, d_p, d_rho):
-        d_p[d_idx] = self.p0 * ( d_rho[d_idx]/self.rho0 - self.b )
+        d_p[d_idx] = self.p0 * (d_rho[d_idx]/self.rho0 - self.b)
+
 
 class MomentumEquationPressureGradient(Equation):
     r"""**Momentum equation for the Transport Velocity Formulation: Pressure**
@@ -232,8 +239,8 @@ class MomentumEquationPressureGradient(Equation):
         This function also computes the contribution to the background
         pressure and accelerations due to a body force or gravity.
 
-        The body forces are damped according to Eq. (13) in [Adami2012] to avoid
-        instantaneous accelerations. By default, damping is neglected.
+        The body forces are damped according to Eq. (13) in [Adami2012] to
+        avoid instantaneous accelerations. By default, damping is neglected.
         """
 
         self.pb = pb
@@ -257,15 +264,19 @@ class MomentumEquationPressureGradient(Equation):
              d_auhat, d_avhat, d_awhat, d_V, s_V, DWIJ):
 
         # averaged pressure Eq. (7)
-        rhoi = d_rho[d_idx]; rhoj = s_rho[s_idx]
-        pi = d_p[d_idx]; pj = s_p[s_idx]
+        rhoi = d_rho[d_idx]
+        rhoj = s_rho[s_idx]
+        p_i = d_p[d_idx]
+        p_j = s_p[s_idx]
 
-        pij = rhoj * pi + rhoi * pj
+        pij = rhoj * p_i + rhoi * p_j
         pij /= (rhoj + rhoi)
 
         # particle volumes; d_V is inverse volume
-        Vi = 1./d_V[d_idx]; Vj = 1./s_V[s_idx]
-        Vi2 = Vi * Vi; Vj2 = Vj * Vj
+        Vi = 1./d_V[d_idx]
+        Vj = 1./s_V[s_idx]
+        Vi2 = Vi * Vi
+        Vj2 = Vj * Vj
 
         # inverse mass of destination particle
         mi1 = 1.0/d_m[d_idx]
@@ -288,11 +299,12 @@ class MomentumEquationPressureGradient(Equation):
         # damped accelerations due to body or external force
         damping_factor = 1.0
         if t < self.tdamp:
-            damping_factor = 0.5 * ( sin((-0.5 + t/self.tdamp)*M_PI)+ 1.0 )
+            damping_factor = 0.5 * (sin((-0.5 + t/self.tdamp)*M_PI) + 1.0)
 
         d_au[d_idx] += self.gx * damping_factor
         d_av[d_idx] += self.gy * damping_factor
         d_aw[d_idx] += self.gz * damping_factor
+
 
 class MomentumEquationViscosity(Equation):
     r"""**Momentum equation for the Transport Velocity Formulation: Viscosity**
@@ -342,8 +354,10 @@ class MomentumEquationViscosity(Equation):
         Fij = DWIJ[0]*XIJ[0] + DWIJ[1]*XIJ[1] + DWIJ[2]*XIJ[2]
 
         # particle volumes, d_V is inverse volume.
-        Vi = 1./d_V[d_idx]; Vj = 1./s_V[s_idx]
-        Vi2 = Vi * Vi; Vj2 = Vj * Vj
+        Vi = 1./d_V[d_idx]
+        Vj = 1./s_V[s_idx]
+        Vi2 = Vi * Vi
+        Vj2 = Vj * Vj
 
         # accelerations 3rd term in Eq. (8)
         tmp = 1./d_m[d_idx] * (Vi2 + Vj2) * etaij * Fij/(R2IJ + EPS)
@@ -351,6 +365,7 @@ class MomentumEquationViscosity(Equation):
         d_au[d_idx] += tmp * VIJ[0]
         d_av[d_idx] += tmp * VIJ[1]
         d_aw[d_idx] += tmp * VIJ[2]
+
 
 class MomentumEquationArtificialViscosity(Equation):
     r"""**Artificial viscosity for the momentum equation**
@@ -386,7 +401,9 @@ class MomentumEquationArtificialViscosity(Equation):
 
         self.alpha = alpha
         self.c0 = c0
-        super(MomentumEquationArtificialViscosity, self).__init__(dest, sources)
+        super(MomentumEquationArtificialViscosity, self).__init__(
+            dest, sources
+        )
 
     def initialize(self, d_idx, d_au, d_av, d_aw):
         d_au[d_idx] = 0.0
@@ -437,34 +454,49 @@ class MomentumEquationArtificialStress(Equation):
     def loop(self, d_idx, s_idx, d_rho, d_u, d_v, d_w, d_V,
              d_uhat, d_vhat, d_what, d_au, d_av, d_aw, d_m,
              s_rho, s_u, s_v, s_w, s_V, s_uhat, s_vhat, s_what, DWIJ):
-        rhoi = d_rho[d_idx]; rhoj = s_rho[s_idx]
+        rhoi = d_rho[d_idx]
+        rhoj = s_rho[s_idx]
 
         # physical and advection velocities
-        ui = d_u[d_idx]; uhati = d_uhat[d_idx]
-        vi = d_v[d_idx]; vhati = d_vhat[d_idx]
-        wi = d_w[d_idx]; whati = d_what[d_idx]
+        ui = d_u[d_idx]
+        uhati = d_uhat[d_idx]
+        vi = d_v[d_idx]
+        vhati = d_vhat[d_idx]
+        wi = d_w[d_idx]
+        whati = d_what[d_idx]
 
-        uj = s_u[s_idx]; uhatj = s_uhat[s_idx]
-        vj = s_v[s_idx]; vhatj = s_vhat[s_idx]
-        wj = s_w[s_idx]; whatj = s_what[s_idx]
+        uj = s_u[s_idx]
+        uhatj = s_uhat[s_idx]
+        vj = s_v[s_idx]
+        vhatj = s_vhat[s_idx]
+        wj = s_w[s_idx]
+        whatj = s_what[s_idx]
 
         # particle volumes; d_V is inverse volume.
-        Vi = 1./d_V[d_idx]; Vj = 1./s_V[s_idx]
-        Vi2 = Vi * Vi; Vj2 = Vj * Vj
+        Vi = 1./d_V[d_idx]
+        Vj = 1./s_V[s_idx]
+        Vi2 = Vi * Vi
+        Vj2 = Vj * Vj
 
         # artificial stress tensor
-        Axxi = rhoi*ui*(uhati - ui); Axyi = rhoi*ui*(vhati - vi)
+        Axxi = rhoi*ui*(uhati - ui)
+        Axyi = rhoi*ui*(vhati - vi)
         Axzi = rhoi*ui*(whati - wi)
-        Ayxi = rhoi*vi*(uhati - ui); Ayyi = rhoi*vi*(vhati - vi)
+        Ayxi = rhoi*vi*(uhati - ui)
+        Ayyi = rhoi*vi*(vhati - vi)
         Ayzi = rhoi*vi*(whati - wi)
-        Azxi = rhoi*wi*(uhati - ui); Azyi = rhoi*wi*(vhati - vi)
+        Azxi = rhoi*wi*(uhati - ui)
+        Azyi = rhoi*wi*(vhati - vi)
         Azzi = rhoi*wi*(whati - wi)
 
-        Axxj = rhoj*uj*(uhatj - uj); Axyj = rhoj*uj*(vhatj - vj)
+        Axxj = rhoj*uj*(uhatj - uj)
+        Axyj = rhoj*uj*(vhatj - vj)
         Axzj = rhoj*uj*(whatj - wj)
-        Ayxj = rhoj*vj*(uhatj - uj); Ayyj = rhoj*vj*(vhatj - vj)
+        Ayxj = rhoj*vj*(uhatj - uj)
+        Ayyj = rhoj*vj*(vhatj - vj)
         Ayzj = rhoj*vj*(whatj - wj)
-        Azxj = rhoj*wj*(uhatj - uj); Azyj = rhoj*wj*(vhatj - vj)
+        Azxj = rhoj*wj*(uhatj - uj)
+        Azyj = rhoj*wj*(vhatj - vj)
         Azzj = rhoj*wj*(whatj - wj)
 
         # contraction of stress tensor with kernel gradient
@@ -492,6 +524,7 @@ class MomentumEquationArtificialStress(Equation):
         d_au[d_idx] += tmp * Ax
         d_av[d_idx] += tmp * Ay
         d_aw[d_idx] += tmp * Az
+
 
 class SolidWallNoSlipBC(Equation):
     r"""**Solid wall boundary condition** [Adami2012]_
@@ -569,8 +602,10 @@ class SolidWallNoSlipBC(Equation):
         etaij = 2 * (etai * etaj)/(etai + etaj)
 
         # particle volumes; d_V inverse volume.
-        Vi = 1./d_V[d_idx]; Vj = 1./s_V[s_idx]
-        Vi2 = Vi * Vi; Vj2 = Vj * Vj
+        Vi = 1./d_V[d_idx]
+        Vj = 1./s_V[s_idx]
+        Vi2 = Vi * Vi
+        Vj2 = Vj * Vj
 
         # scalar part of the kernel gradient
         Fij = XIJ[0]*DWIJ[0] + XIJ[1]*DWIJ[1] + XIJ[2]*DWIJ[2]
@@ -582,6 +617,7 @@ class SolidWallNoSlipBC(Equation):
         d_au[d_idx] += tmp * (d_u[d_idx] - s_ug[s_idx])
         d_av[d_idx] += tmp * (d_v[d_idx] - s_vg[s_idx])
         d_aw[d_idx] += tmp * (d_w[d_idx] - s_wg[s_idx])
+
 
 class SolidWallPressureBC(Equation):
     r"""**Solid wall pressure boundary condition** [Adami2012]_
@@ -639,8 +675,8 @@ class SolidWallPressureBC(Equation):
         source.
 
         The boundary particle array must additionally define a property
-        :math:`wij` for the denominator in Eq. (27) from [Adami2012]. This array
-        sums the kernel terms from the ghost particle to the fluid
+        :math:`wij` for the denominator in Eq. (27) from [Adami2012]. This
+        array sums the kernel terms from the ghost particle to the fluid
         particle.
         """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 setuptools>=6.0
-Cython>=0.20
+Cython>=0.20,<0.27
 mako
 pytest>=3.0
 mock>=1.0


### PR DESCRIPTION
Note that the DT_ADAPT implementation is completely changed.  Adaptive timesteps and reduction are now supported on OpenCL completing the basic support.  Periodicity is also supported but only through the CPU which makes it slow.  Further optimizations are needed to improve performance.  inlets and outlets are not supported yet and this will be done later.