### PR TITLE
OpenMP Schedule

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -211,6 +211,24 @@ short do the following::
     $ source pysph_env/bin/activate
     $ pip install cython --upgrade # if you have an old version.
 
+If you wish to use a compiler which is not currently your default compiler,
+simply update the ``CC`` and ``CXX`` environment variables. For example, to use
+icc run the following commands `before` building PySPH::
+  
+    $ export CC=icc
+    $ export CXX=icpc
+
+.. note::
+
+    In this case, you will additionally have to ensure that the relevant intel
+    shared libraries can be found when `running` PySPH code. Most intel
+    installations come along with shell scripts that load relevant environment
+    variables with the right values automatically. This shell script is
+    generally named ``compilervars.sh`` and can be found in
+    ``/path/to/icc/bin``. If you didn't get this file along with your
+    installation, you can try running ``export
+    LD_LIBRARY_PATH=/path/to/icc/lib``.
+    
 You should be set now and should skip to :ref:`downloading-pysph` and
 :ref:`building-pysph`.
 

--- a/pysph/base/config.py
+++ b/pysph/base/config.py
@@ -10,6 +10,7 @@ class Config(object):
         self._use_openmp = None
         self._use_opencl = None
         self._use_double = None
+        self._omp_schedule = None
         self._profile = None
 
     @property
@@ -24,6 +25,34 @@ class Config(object):
 
     def _use_openmp_default(self):
         return False
+
+    @property
+    def omp_schedule(self):
+        if self._omp_schedule is None:
+            self._omp_schedule = self._omp_schedule_default()
+        return self._omp_schedule
+
+    @omp_schedule.setter
+    def omp_schedule(self, value):
+        if len(value) != 2 or \
+           value[0].lower() not in ("static", "dynamic", "guided"):
+            raise ValueError("Invalid OpenMP Schedule")
+
+        self._omp_schedule = value
+
+    def set_omp_schedule(self, omp_schedule):
+        """
+        Expects input to be in the format used by OMP_SCHEDULE
+        i.e. "schedule_type, chunk_size"
+        """
+        temp = omp_schedule.split(",")
+        if len(temp) == 2:
+            self.omp_schedule = (temp[0], int(temp[1]))
+        else:
+            self.omp_schedule = (temp[0], None)
+
+    def _omp_schedule_default(self):
+        return ("dynamic", 64)
 
     @property
     def use_opencl(self):

--- a/pysph/base/config.py
+++ b/pysph/base/config.py
@@ -36,7 +36,7 @@ class Config(object):
     def omp_schedule(self, value):
         if len(value) != 2 or \
            value[0].lower() not in ("static", "dynamic", "guided"):
-            raise ValueError("Invalid OpenMP Schedule")
+            raise ValueError("Invalid OpenMP Schedule: {}".format(value))
 
         self._omp_schedule = value
 

--- a/pysph/base/tests/test_config.py
+++ b/pysph/base/tests/test_config.py
@@ -31,6 +31,30 @@ class ConfigTestCase(TestCase):
         # Then
         self.assertEqual(config.use_openmp, 10)
 
+    def test_set_get_omp_schedule_config(self):
+        # Given
+        config = self.config
+        # When
+        config.omp_schedule = ("static", 10)
+        # Then
+        self.assertEqual(config.omp_schedule, ("static", 10))
+
+    def test_set_string_omp_schedule(self):
+        # Given
+        config = self.config
+        # When
+        config.set_omp_schedule("dynamic,20")
+        # Then
+        self.assertEqual(config.omp_schedule, ("dynamic", 20))
+
+    def test_set_omp_schedule_config_exception(self):
+        # Given
+        config = self.config
+        # When
+        # Then
+        with self.assertRaises(ValueError):
+            config.omp_schedule = ("random", 20)
+
     def test_use_opencl_config_default(self):
         # Given
         config = self.config

--- a/pysph/solver/application.py
+++ b/pysph/solver/application.py
@@ -17,8 +17,8 @@ from pysph.base import utils
 from pysph.base.utils import is_overloaded_method
 
 from pysph.base.nnps import LinkedListNNPS, BoxSortNNPS, SpatialHashNNPS, \
-        ExtendedSpatialHashNNPS, CellIndexingNNPS, StratifiedHashNNPS, \
-        StratifiedSFCNNPS, OctreeNNPS, CompressedOctreeNNPS, ZOrderNNPS
+    ExtendedSpatialHashNNPS, CellIndexingNNPS, StratifiedHashNNPS, \
+    StratifiedSFCNNPS, OctreeNNPS, CompressedOctreeNNPS, ZOrderNNPS
 
 from pysph.base import kernels
 from pysph.solver.controller import CommandManager
@@ -387,6 +387,16 @@ class Application(object):
             default=None,
             help="Do not use OpenMP to run the "
             "simulation using multiple cores.")
+
+        # --omp-schedule
+        parser.add_argument(
+            "--omp-schedule",
+            action="store",
+            dest="omp_schedule",
+            default="dynamic,64",
+            help="""Schedule how loop iterations 
+            are divided amongst multiple threads""")
+
         # --opencl
         parser.add_argument(
             "--opencl",
@@ -814,6 +824,8 @@ class Application(object):
         # Setup configuration options.
         if options.with_openmp is not None:
             get_config().use_openmp = options.with_openmp
+        if options.omp_schedule is not None:
+            get_config().set_omp_schedule(options.omp_schedule)
         if options.with_opencl:
             get_config().use_opencl = True
         if options.use_double:

--- a/pysph/sph/acceleration_eval_cython.mako
+++ b/pysph/sph/acceleration_eval_cython.mako
@@ -62,7 +62,7 @@ nnps.set_context(src_array_index, dst_array_index)
 ${helper.get_parallel_block()}
     thread_id = threadid()
     ${indent(eq_group.get_variable_array_setup(), 1)}
-    for d_idx in prange(NP_DEST):
+    for d_idx in ${helper.get_parallel_range("NP_DEST")}:
         ###############################################################
         ## Find and iterate over neighbors.
         ###############################################################

--- a/pysph/sph/acceleration_eval_cython_helper.py
+++ b/pysph/sph/acceleration_eval_cython_helper.py
@@ -229,6 +229,30 @@ class AccelerationEvalCythonHelper(object):
         else:
             return "if True: # Placeholder used for OpenMP."
 
+    def get_parallel_range(self, start, stop=None, step=1):
+        if stop is None:
+            stop = start
+            start = 0
+
+        args = "{start},{stop},{step}"
+        if self.config.use_openmp:
+            schedule = self.config.omp_schedule[0]
+            chunksize = self.config.omp_schedule[1]
+
+            if schedule is not None:
+                args = args + ", schedule='{schedule}'"
+
+            if chunksize is not None:
+                args = args + ", chunksize={chunksize}"
+
+            args = args.format(start=start, stop=stop, step=step,
+                               schedule=schedule, chunksize=chunksize)
+            return "prange({})".format(args)
+
+        else:
+            args = args.format(start=start, stop=stop, step=step)
+            return "range({})".format(args)
+
     def get_particle_array_names(self):
         parrays = [pa.name for pa in self.object.particle_arrays]
         return ', '.join(parrays)


### PR DESCRIPTION
Allow users to specify which OpenMP schedule to use through the `--omp-schedule` parameter. The default value is set to `dynamic` with a chunksize of `64`. 