### PR TITLE
BUG: Fix bug with the WCSPH scheme.

### DIFF
--- a/pysph/sph/scheme.py
+++ b/pysph/sph/scheme.py
@@ -406,10 +406,15 @@ class WCSPHScheme(Scheme):
                 gamma=self.gamma
             ))
 
-        if self.hg_correction:
-            # This correction applies only to solids.
-            for name in self.solids:
+        # This correction applies only to solids.
+        for name in self.solids:
+            if self.hg_correction:
                 g1.append(TaitEOSHGCorrection(
+                    dest=name, sources=None, rho0=self.rho0, c0=self.c0,
+                    gamma=self.gamma
+                ))
+            else:
+                g1.append(TaitEOS(
                     dest=name, sources=None, rho0=self.rho0, c0=self.c0,
                     gamma=self.gamma
                 ))


### PR DESCRIPTION
When there is no hg correction we should still run the tait eos on
solids in order to set the pressure but this was not being done leading
to a lot of leakage on the solids.  This is now fixed.