### PR TITLE
Separate test requirements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
   - edm install -y numpy cython pytest mock h5py
 
   # Install pysph related dependencies.
-  - edm run -- pip install -r requirements.txt
+  - edm run -- pip install .[test]
 
   # Build pysph.
   - edm run -- python setup.py develop

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ numpy
 setuptools>=6.0
 Cython>=0.20,<0.27
 mako
-pytest>=3.0
-mock>=1.0

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
 from os import path
+
 try:
     from subprocess import check_output
 except ImportError:
@@ -26,9 +27,9 @@ import sys
 if len(os.environ.get('COVERAGE', '')) > 0:
     MACROS = [("CYTHON_TRACE", "1"), ("CYTHON_TRACE_NOGIL", "1")]
     COMPILER_DIRECTIVES = {"linetrace": True}
-    print("-"*80)
+    print("-" * 80)
     print("Enabling linetracing for cython and setting CYTHON_TRACE = 1")
-    print("-"*80)
+    print("-" * 80)
 else:
     MACROS = []
     COMPILER_DIRECTIVES = {}
@@ -85,7 +86,7 @@ def get_openmp_flags():
 
     env_var = os.environ.get('USE_OPENMP', '')
     if env_var.lower() in ("0", 'false', 'n'):
-        print("-"*70)
+        print("-" * 70)
         print("OpenMP disabled by environment variable (USE_OPENMP).")
         return [], [], False
 
@@ -119,18 +120,18 @@ def get_openmp_flags():
     has_omp = True
     try:
         pyxbuild.pyx_to_dll(fname, extension, pyxbuild_dir=tmp_dir)
-        print("-"*70)
+        print("-" * 70)
         print("Using OpenMP.")
-        print("-"*70)
+        print("-" * 70)
     except CompileError:
-        print("*"*70)
+        print("*" * 70)
         print("Unable to compile OpenMP code. Not using OpenMP.")
-        print("*"*70)
+        print("*" * 70)
         has_omp = False
     except LinkError:
-        print("*"*70)
+        print("*" * 70)
         print("Unable to link OpenMP code. Not using OpenMP.")
-        print("*"*70)
+        print("*" * 70)
         has_omp = False
     finally:
         shutil.rmtree(tmp_dir)
@@ -150,9 +151,9 @@ def get_zoltan_directory(varname):
     else:
         USE_ZOLTAN = True
     if not path.exists(d):
-        print("*"*80)
+        print("*" * 80)
         print("%s incorrectly set to %s, not using ZOLTAN!" % (varname, d))
-        print("*"*80)
+        print("*" * 80)
         USE_ZOLTAN = False
         return ''
     return d
@@ -186,9 +187,9 @@ def get_mpi_flags():
                 [mpic, '--showme:compile'], universal_newlines=True
             ).strip()
     except:  # noqa: E722
-        print('-'*80)
+        print('-' * 80)
         print("Unable to run mpic++ correctly, skipping parallel build")
-        print('-'*80)
+        print('-' * 80)
         HAVE_MPI = False
     else:
         mpi_link_args.extend(link_args.split())
@@ -220,14 +221,14 @@ def get_zoltan_args():
         lib = get_zoltan_directory('ZOLTAN_LIBRARY')
 
     if (not USE_ZOLTAN):
-        print("*"*80)
+        print("*" * 80)
         print("Zoltan Environment variable not set, not using ZOLTAN!")
-        print("*"*80)
+        print("*" * 80)
         HAVE_MPI = False
     else:
-        print('-'*70)
+        print('-' * 70)
         print("Using Zoltan from:\n%s\n%s" % (inc, lib))
-        print('-'*70)
+        print('-' * 70)
         zoltan_include_dirs = [inc]
         zoltan_library_dirs = [lib]
 
@@ -535,11 +536,11 @@ def get_parallel_extensions():
                 "pyzoltan/czoltan/czoltan",
                 "pyzoltan/czoltan/czoltan_types",
             ),
-            include_dirs=include_dirs+zoltan_include_dirs+mpi_inc_dirs,
+            include_dirs=include_dirs + zoltan_include_dirs + mpi_inc_dirs,
             library_dirs=zoltan_library_dirs,
             libraries=[zoltan_lib, 'mpi'],
             extra_link_args=mpi_link_args,
-            extra_compile_args=mpi_compile_args+extra_compile_args,
+            extra_compile_args=mpi_compile_args + extra_compile_args,
             cython_compile_time_env=cython_compile_time_env,
             language="c++",
             define_macros=MACROS,
@@ -557,7 +558,7 @@ def get_parallel_extensions():
             library_dirs=zoltan_library_dirs,
             libraries=[zoltan_lib, 'mpi'],
             extra_link_args=mpi_link_args,
-            extra_compile_args=mpi_compile_args+extra_compile_args,
+            extra_compile_args=mpi_compile_args + extra_compile_args,
             cython_compile_time_env=cython_compile_time_env,
             language="c++",
             define_macros=MACROS,
@@ -574,7 +575,7 @@ def get_parallel_extensions():
             library_dirs=zoltan_library_dirs,
             libraries=[zoltan_lib, 'mpi'],
             extra_link_args=mpi_link_args,
-            extra_compile_args=mpi_compile_args+extra_compile_args,
+            extra_compile_args=mpi_compile_args + extra_compile_args,
             cython_compile_time_env=cython_compile_time_env,
             language="c++",
             define_macros=MACROS,
@@ -596,7 +597,7 @@ def get_parallel_extensions():
             library_dirs=zoltan_library_dirs,
             libraries=[zoltan_lib, 'mpi'],
             extra_link_args=mpi_link_args,
-            extra_compile_args=mpi_compile_args+extra_compile_args,
+            extra_compile_args=mpi_compile_args + extra_compile_args,
             cython_compile_time_env=cython_compile_time_env,
             language="c++",
             define_macros=MACROS,
@@ -645,9 +646,9 @@ def setup_package():
 
     # The requirements.
     install_requires = [
-        'numpy', 'mako', 'Cython>=0.20', 'setuptools>=6.0',
-        'pytest>=3.0',
+        'numpy', 'mako', 'Cython>=0.20,<0.27', 'setuptools>=6.0',
     ]
+
     if sys.version_info[:2] == (2, 6):
         install_requires += [
             'ordereddict', 'importlib', 'unittest2'
@@ -657,7 +658,14 @@ def setup_package():
             'mock>=1.0'
         ]
 
+    test_deps = [
+        'pytest>=3.0',
+        'mock>=1.0',
+        'numpy-stl'
+    ]
+
     extras_require = dict(
+        test=test_deps,
         mpi=['mpi4py>=1.2'],
         ui=['mayavi>=4.0'],
     )
@@ -695,7 +703,7 @@ def setup_package():
           license="BSD",
           keywords="SPH simulation computational fluid dynamics",
           setup_requires=['pytest-runner'],
-          tests_require=['pytest'],
+          tests_require=test_deps,
           packages=find_packages(),
           package_data={
               '': ['*.pxd', '*.mako', '*.txt.gz', '*.txt', '*.vtk.gz', '*.gz',
@@ -703,7 +711,7 @@ def setup_package():
           },
           # exclude package data in installation.
           exclude_package_data={
-            '': ['Makefile', '*.bat', '*.cfg', '*.rst', '*.sh', '*.yml'],
+              '': ['Makefile', '*.bat', '*.cfg', '*.rst', '*.sh', '*.yml'],
           },
           ext_modules=ext_modules,
           include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,9 @@ changedir = {toxworkdir}
 passenv = CC CXX ZOLTAN* USE_TRILINOS USE_OPENMP
 deps =
     py26: -rrequirements-2.6.txt
-    py27: -rrequirements.txt
-    py34: -rrequirements.txt
-    py35: -rrequirements.txt
+    py27: .[test]
+    py34: .[test]
+    py35: .[test]
 commands = python -m pytest -v \
            --junit-xml=pytest-{envname}.xml \
            {posargs} \


### PR DESCRIPTION
One of the possible ways to separate test dependencies from the core installation dependencies. Here, the test dependencies are added to `extra_requires` under the `test` key. This way, the test dependencies can be installed by running `pip install .[test]`. 

Using this approach, requirements.txt will no longer be required but I haven't removed it in this commit since it would break any other build/installation scripts running `pip install -r requirements.txt`.

Edit: requirements.txt would also be useful if the dependencies have to be installed without installing the package. 
