### PR TITLE
Add loop all

### DIFF
--- a/pysph/base/cython_generator.py
+++ b/pysph/base/cython_generator.py
@@ -85,11 +85,24 @@ class KnownType(object):
     Smells but is convenient as the type may be one available only inside
     Cython without a corresponding Python type.
     """
-    def __init__(self, type_str):
+    def __init__(self, type_str, base_type=''):
+        """Constructor
+
+        The ``base_type`` argument is optional and used to represent the base
+        type, i.e. the type_str may be 'Foo*' but the base type will be 'Foo'
+        if specified.
+
+        Parameters
+        ----------
+        type_str: str: A string representation of how the type is declared.
+        base_type: str: The base type of this entity. (optional)
+
+        """
         self.type = type_str
+        self.base_type = base_type
 
     def __repr__(self):
-        return 'KnownType("%s")'%self.type
+        return 'KnownType("%s")' % self.type
 
 
 class CythonGenerator(object):

--- a/pysph/base/tests/test_translator.py
+++ b/pysph/base/tests/test_translator.py
@@ -353,6 +353,21 @@ def test_known_types_in_funcargs():
     assert code.strip() == expect.strip()
 
 
+def test_calling_method_of_known_type():
+    # Given
+    src = 'obj.method(1, 2)'
+    known = {'obj': KnownType('SomeClass*', base_typr='SomeClass')}
+
+    # When
+    code = py2c(src, known_types=known)
+
+    # Then
+    expect = dedent('''
+    SomeClass_method(obj, 1, 2);
+    ''')
+    assert code.strip() == expect.strip()
+
+
 def test_raises_error_when_unknown_args_are_given():
     # Given
     src = dedent('''

--- a/pysph/base/translator.py
+++ b/pysph/base/translator.py
@@ -282,18 +282,19 @@ class CConverter(ast.NodeVisitor):
                 args=', '.join(self.visit(x) for x in node.args)
             )
         elif isinstance(node.func, ast.Attribute):
-            if len(self._class_name) > 0:
+            if node.func.value.id in self._known_types:
+                name = node.func.value.id
+                cls = self._known_types[name].base_type
+                args = [name] + [self.visit(x) for x in node.args]
+                return '{func}({args})'.format(
+                    func='%s_%s' % (cls, node.func.attr),
+                    args=', '.join(args)
+                )
+            elif len(self._class_name) > 0:
+                args = ['self'] + [self.visit(x) for x in node.args]
                 return '{func}({args})'.format(
                     func='%s_%s' % (self._class_name, node.func.attr),
-                    args='self, ' + ', '.join(self.visit(x) for x in node.args)
-                )
-            elif node.func.value.id in self._known_types:
-                name = node.func.value.id
-                cls = self._known_types[name].base
-                return '{func}({obj}, {args})'.format(
-                    func='%s_%s' % (cls, node.func.attr),
-                    obj=name,
-                    args=', '.join(self.visit(x) for x in node.args)
+                    args=', '.join(args)
                 )
             else:
                 self.error('Unsupported function call', node)

--- a/pysph/sph/acceleration_eval_cython_helper.py
+++ b/pysph/sph/acceleration_eval_cython_helper.py
@@ -171,6 +171,9 @@ class AccelerationEvalCythonHelper(object):
         headers.append(cg.get_code())
 
         # Equation wrappers.
+        self.known_types['KERNEL'] = KnownType(
+            object.kernel.__class__.__name__
+        )
         headers.append(object.all_group.get_equation_wrappers(
             self.known_types
         ))

--- a/pysph/sph/acceleration_eval_opencl.mako
+++ b/pysph/sph/acceleration_eval_opencl.mako
@@ -28,7 +28,7 @@ ${helper.get_simple_loop_kernel(g_idx, sg_idx, group, dest, eqs_with_no_source)}
 ###################################################################
 ## Do any loop interactions between source and destination.
 ###################################################################
-% if eq_group.has_loop():
+% if eq_group.has_loop() or eq_group.has_loop_all():
 ${helper.get_loop_kernel(g_idx, sg_idx, group, dest, source, eq_group)}
 % endif
 % endfor

--- a/pysph/sph/acceleration_eval_opencl_helper.py
+++ b/pysph/sph/acceleration_eval_opencl_helper.py
@@ -26,7 +26,8 @@ main methods:
 
 - get_code(): returns the code to be compiled.
 
-- compile(code): compile the code and return the compiled module/opencl Program.
+- compile(code): compile the code and return the compiled module/opencl
+  Program.
 
 - setup_compiled_module(module): sets the AccelerationEval's
   c_acceleration_eval to an instance based on the helper.

--- a/pysph/sph/equation.py
+++ b/pysph/sph/equation.py
@@ -35,7 +35,7 @@ def camel_to_underscore(name):
 
 def declare(type):
     if type.startswith('matrix'):
-        return numpy.zeros(eval(type[6:]))
+        return numpy.zeros(eval(type[7:-1]))
     else:
         return 0
 
@@ -794,6 +794,7 @@ class OpenCLGroup(Group):
         wrappers = []
         predefined = dict(get_predefined_types(self.pre_comp))
         predefined.update(known_types)
+        predefined['NBRS'] = KnownType('__global unsigned int*')
         code_gen = OpenCLConverter(known_types=predefined)
         ignore = ['reduce']
         for cls in sorted(classes.keys()):

--- a/pysph/sph/tests/test_acceleration_eval.py
+++ b/pysph/sph/tests/test_acceleration_eval.py
@@ -12,7 +12,7 @@ import numpy as np
 # Local imports.
 from pysph.base.config import get_config
 from pysph.base.utils import get_particle_array
-from pysph.sph.equation import Equation, Group
+from pysph.sph.equation import Equation, Group, declare
 from pysph.sph.acceleration_eval import (AccelerationEval,
                                          check_equation_array_properties)
 from pysph.sph.basic_equations import SummationDensity
@@ -30,8 +30,8 @@ class DummyEquation(Equation):
     def loop(self, d_idx, d_rho, s_idx, s_m, s_u, WIJ):
         d_rho[d_idx] += s_m[s_idx]*WIJ
 
-    def post_loop(self, d_idx, d_rho, s_idx, s_m, s_V, WIJ):
-        d_rho[d_idx] += s_m[s_idx]*WIJ
+    def post_loop(self, d_idx, d_rho, s_idx, s_m, s_V):
+        d_rho[d_idx] += s_m[d_idx]
 
 
 class FindTotalMass(Equation):
@@ -181,6 +181,29 @@ class SimpleReduction(Equation):
             dst.gpu.push('total_mass')
 
 
+class LoopAllEquation(Equation):
+    def initialize(self, d_idx, d_rho):
+        d_rho[d_idx] = 0.0
+
+    def loop(self, d_idx, d_rho, s_m, s_idx, WIJ):
+        d_rho[d_idx] += s_m[s_idx]*WIJ
+
+    def loop_all(self, d_idx, d_x, d_rho, s_m, s_x, s_h, KERNEL, NBRS, N_NBRS):
+        i = declare('int')
+        s_idx = declare('long')
+        xij = declare('matrix((3,))')
+        rij = 0.0
+        sum = 0.0
+        xij[1] = 0.0
+        xij[2] = 0.0
+        for i in range(N_NBRS):
+            s_idx = NBRS[i]
+            xij[0] = d_x[d_idx] - s_x[s_idx]
+            rij = fabs(xij[0])
+            sum += s_m[s_idx]*KERNEL.kernel(xij, rij, s_h[s_idx])
+        d_rho[d_idx] += sum
+
+
 class TestAccelerationEval1D(unittest.TestCase):
     def setUp(self):
         self.dim = 1
@@ -311,6 +334,25 @@ class TestAccelerationEval1D(unittest.TestCase):
         # Then
         expect = np.asarray([3., 4., 5., 5., 5., 5., 5., 5.,  4.,  3.])
         self.assertListEqual(list(pa.u), list(expect))
+
+    def test_should_support_loop_all_and_loop(self):
+        # Given
+        pa = self.pa
+        equations = [SummationDensity(dest='fluid', sources=['fluid'])]
+        a_eval = self._make_accel_eval(equations)
+        a_eval.compute(0.1, 0.1)
+        ref_rho = pa.rho.copy()
+
+        # When
+        pa.rho[:] = 0.0
+        equations = [LoopAllEquation(dest='fluid', sources=['fluid'])]
+        a_eval = self._make_accel_eval(equations)
+        a_eval.compute(0.1, 0.1)
+
+        # Then
+        # 2*ref_rho as we are doing both the loop and loop_all to test if
+        # both are called.
+        self.assertTrue(np.allclose(pa.rho, 2.0*ref_rho))
 
 
 class EqWithTime(Equation):


### PR DESCRIPTION
Add support for a `loop_all` method in the equations.   This also adds support to pass the SPH kernel to equations and be able to call their kernel or gradient method.  Adds documentation and tests for this.  This works fine on both CPU and GPU.  This allows for more complex computations with the neighboring particles including non-pairwise interactions!  Paves the way for MD and other methods. 