### PR TITLE
Add the GSPH schemes including the ones from Kunal's paper

### DIFF
--- a/pysph/examples/gas_dynamics/shocktube_setup.py
+++ b/pysph/examples/gas_dynamics/shocktube_setup.py
@@ -82,7 +82,9 @@ class ShockTubeSetup(Application):
         from pysph.solver.utils import load
         data = load(last_output)
         pa = data['arrays']['fluid']
-        riemann_solver.set_gamma(self.options.gamma)
+        gamma = self.options.gamma if self.options.gamma else 1.4
+        riemann_solver.set_gamma(gamma)
+
         rho_e, u_e, p_e, e_e, x_e = riemann_solver.solve(
             x_min=self.xmin, x_max=self.xmax, x_0=self.x0,
             t=self.tf, p_l=self.pl, p_r=self.pr, rho_l=self.rhol,
@@ -145,5 +147,8 @@ class ShockTubeSetup(Application):
             s.configure_solver(dt=self.dt, tf=self.tf,
                                adaptive_timestep=True, pfreq=50)
         elif self.options.scheme == 'adke':
+            s.configure_solver(dt=self.dt, tf=self.tf,
+                               adaptive_timestep=False, pfreq=50)
+        elif self.options.scheme == 'gsph':
             s.configure_solver(dt=self.dt, tf=self.tf,
                                adaptive_timestep=False, pfreq=50)

--- a/pysph/examples/gas_dynamics/sod_shocktube.py
+++ b/pysph/examples/gas_dynamics/sod_shocktube.py
@@ -64,7 +64,7 @@ class SodShockTube(ShockTubeSetup):
         mpm = GasDScheme(
             fluids=['fluid'], solids=[], dim=dim, gamma=gamma,
             kernel_factor=1.2, alpha1=1.0, alpha2=0.1,
-            beta=2.0, update_alpha1=True, update_alpha2=True
+            beta=1.0, update_alpha1=True, update_alpha2=True
         )
         gsph = GSPHScheme(
             fluids=['fluid'], solids=[], dim=dim, gamma=gamma,

--- a/pysph/examples/gas_dynamics/sod_shocktube.py
+++ b/pysph/examples/gas_dynamics/sod_shocktube.py
@@ -1,7 +1,7 @@
 """Simulate the classical Sod Shocktube problem in 1D (5 seconds).
 """
 from pysph.examples.gas_dynamics.shocktube_setup import ShockTubeSetup
-from pysph.sph.scheme import ADKEScheme, GasDScheme, SchemeChooser
+from pysph.sph.scheme import ADKEScheme, GasDScheme, GSPHScheme, SchemeChooser
 import numpy
 
 # Numerical constants
@@ -66,7 +66,13 @@ class SodShockTube(ShockTubeSetup):
             kernel_factor=1.2, alpha1=1.0, alpha2=0.1,
             beta=2.0, update_alpha1=True, update_alpha2=True
         )
-        s = SchemeChooser(default='adke', adke=adke, mpm=mpm)
+        gsph = GSPHScheme(
+            fluids=['fluid'], solids=[], dim=dim, gamma=gamma,
+            kernel_factor=1.2,
+            g1=0.2, g2=0.4, rsolver=2, interpolation=1, monotonicity=1,
+            interface_zero=True, niter=20, tol=1e-6
+        )
+        s = SchemeChooser(default='adke', adke=adke, mpm=mpm, gsph=gsph)
         return s
 
 

--- a/pysph/examples/gas_dynamics/sod_shocktube.py
+++ b/pysph/examples/gas_dynamics/sod_shocktube.py
@@ -70,7 +70,8 @@ class SodShockTube(ShockTubeSetup):
             fluids=['fluid'], solids=['boundary'], dim=dim, gamma=gamma,
             kernel_factor=1.2,
             g1=0.2, g2=0.4, rsolver=2, interpolation=1, monotonicity=1,
-            interface_zero=True, niter=20, tol=1e-6
+            interface_zero=True, hybrid=False, blend_alpha=2.0,
+            niter=20, tol=1e-6
         )
         s = SchemeChooser(default='adke', adke=adke, mpm=mpm, gsph=gsph)
         return s

--- a/pysph/examples/gas_dynamics/sod_shocktube.py
+++ b/pysph/examples/gas_dynamics/sod_shocktube.py
@@ -67,7 +67,7 @@ class SodShockTube(ShockTubeSetup):
             beta=1.0, update_alpha1=True, update_alpha2=True
         )
         gsph = GSPHScheme(
-            fluids=['fluid'], solids=[], dim=dim, gamma=gamma,
+            fluids=['fluid'], solids=['boundary'], dim=dim, gamma=gamma,
             kernel_factor=1.2,
             g1=0.2, g2=0.4, rsolver=2, interpolation=1, monotonicity=1,
             interface_zero=True, niter=20, tol=1e-6

--- a/pysph/sph/gas_dynamics/gsph.py
+++ b/pysph/sph/gas_dynamics/gsph.py
@@ -25,7 +25,7 @@ Cubic = 2
 
 
 def sgn(x=0.0):
-    return -1.0 if x < 0.0 else 1.0
+    return (x > 0) - (x < 0)
 
 
 def monotonicity_min(_x1=0.0, _x2=0.0, _x3=0.0):
@@ -211,9 +211,12 @@ class GSPHAcceleration(Equation):
         pj = s_p[s_idx]
 
         if self.monotonicity == 0:  # First order scheme
-            rsi = rsj = 0.0
-            psi = psj = 0.0
-            vsi = vsj = 0.0
+            rsi = 0.0
+            rsj = 0.0
+            psi = 0.0
+            psj = 0.0
+            vsi = 0.0
+            vsj = 0.0
 
         if self.monotonicity == 1:  # I02 algorithm
             if (vsi * vsj) < 0:
@@ -257,6 +260,13 @@ class GSPHAcceleration(Equation):
             rsj = monotonicity_min(qijr, delr, delrp)/RIJ
             psj = monotonicity_min(qijp, delp, delpp)/RIJ
             vsj = monotonicity_min(qiju, delv, delvp)/RIJ
+        elif self.monotonicity == 2 and RIJ < 1e-14:  # IwIn algorithm
+            rsi = 0.0
+            rsj = 0.0
+            psi = 0.0
+            psj = 0.0
+            vsi = 0.0
+            vsj = 0.0
 
         # Input to the riemann solver
         sstar *= 2.0
@@ -296,8 +306,12 @@ class GSPHAcceleration(Equation):
 
         # blend of two intermediate states
         #if self.hybrid:
-        #    pstar2, ustar2 = self.rsolver2.compute_star(
-        #        rhoj, rhoi, pj, pi, vl, vr)
+        #    riemann_solve(
+        #        10, rhoj, rhoi, pj, pi, vl, vr, self.gamma,
+        #        self.niter self.tol, result
+        #    )
+        #    pstar2 = result[0]
+        #    ustar2 = result[1]
         #    ustar = ustar + blending_factor * (ustar2 - ustar)
         #    pstar = pstar + blending_factor * (pstar2 - pstar)
 
@@ -430,4 +444,4 @@ class GSPHAcceleration(Equation):
 
         result[0] = vij_i
         result[1] = vij_j
-        result[1] = sstar
+        result[2] = sstar

--- a/pysph/sph/gas_dynamics/gsph.py
+++ b/pysph/sph/gas_dynamics/gsph.py
@@ -1,0 +1,433 @@
+from pysph.base.cython_generator import declare
+from pysph.sph.equation import Equation
+from pysph.sph.gas_dynamics.riemann_solver import (HELPERS, riemann_solve,
+                                                   printf)
+
+# Constants
+
+# Riemann solver types
+NonDiffusive = 0
+VanLeer = 1
+Exact = 2
+HLLC = 3
+Ducowicz = 4
+HLLE = 5
+Roe = 6
+LLXF = 7
+HLLCBall = 8
+HLLBall = 9
+HLLSY = 10
+
+# GSPHInterpolationType
+Delta = 0
+Linear = 1
+Cubic = 2
+
+
+def sgn(x=0.0):
+    return -1.0 if x < 0.0 else 1.0
+
+
+def monotonicity_min(_x1=0.0, _x2=0.0, _x3=0.0):
+    x1, x2, x3, _min = declare('double', 4)
+    x1 = 2.0 * abs(_x1)
+    x2 = abs(_x2)
+    x3 = 2.0 * abs(_x3)
+
+    sx1 = sgn(_x1)
+    sx2 = sgn(_x2)
+    sx3 = sgn(_x3)
+
+    if ((sx1 != sx2) or (sx2 != sx3)):
+        return 0.0
+    else:
+        if x2 < x1:
+            if x3 < x2:
+                _min = x3
+            else:
+                _min = x2
+        else:
+            if x3 < x1:
+                _min = x3
+            else:
+                _min = x1
+
+    return sx1 * _min
+
+
+class GSPHGradients(Equation):
+    def initialize(self, d_idx, d_px, d_py, d_pz, d_ux, d_uy, d_uz,
+                   d_vx, d_vy, d_vz, d_wx, d_wy, d_wz):
+        d_px[d_idx] = 0.0
+        d_py[d_idx] = 0.0
+        d_pz[d_idx] = 0.0
+        d_ux[d_idx] = 0.0
+        d_uy[d_idx] = 0.0
+        d_uz[d_idx] = 0.0
+        d_vx[d_idx] = 0.0
+        d_vy[d_idx] = 0.0
+        d_vz[d_idx] = 0.0
+        d_wx[d_idx] = 0.0
+        d_wy[d_idx] = 0.0
+        d_wz[d_idx] = 0.0
+
+    def loop(self, d_idx, d_px, d_py, d_pz, d_ux, d_uy, d_uz,
+             d_vx, d_vy, d_vz, d_wx, d_wy, d_wz, d_p, d_u, d_v, d_w,
+             s_idx, s_p, s_u, s_v, s_w, s_rho, s_m,
+             DWIJ):
+        rj1 = 1.0/s_rho[s_idx]
+        pji = s_p[s_idx] - d_p[d_idx]
+        uji = s_u[s_idx] - d_u[d_idx]
+        vji = s_v[s_idx] - d_v[d_idx]
+        wji = s_w[s_idx] - d_w[d_idx]
+        tmp = rj1*s_m[s_idx]*pji
+        d_px[d_idx] += tmp*DWIJ[0]
+        d_py[d_idx] += tmp*DWIJ[1]
+        d_pz[d_idx] += tmp*DWIJ[2]
+        tmp = rj1*s_m[s_idx]*uji
+        d_ux[d_idx] += tmp*DWIJ[0]
+        d_uy[d_idx] += tmp*DWIJ[1]
+        d_uz[d_idx] += tmp*DWIJ[2]
+        tmp = rj1*s_m[s_idx]*vji
+        d_vx[d_idx] += tmp*DWIJ[0]
+        d_vy[d_idx] += tmp*DWIJ[1]
+        d_vz[d_idx] += tmp*DWIJ[2]
+        tmp = rj1*s_m[s_idx]*wji
+        d_wx[d_idx] += tmp*DWIJ[0]
+        d_wy[d_idx] += tmp*DWIJ[1]
+        d_wz[d_idx] += tmp*DWIJ[2]
+
+
+class GSPHAcceleration(Equation):
+    """Class to implement the GSPH acclerations.
+
+    We implement Inutsuka's original GSPH algorithm I02 defined in
+    'Reformulation of Smoothed Particle Hydrodynamics with Riemann
+    Solver', (2002), JCP, 179, 238--267 and Iwasaki and Inutsuka's
+    vesion (specifically the monotonicity constraint) described in
+    'Smoothed particle magnetohydrodynamics with a Riemann solver and
+    the method of characteristics' 2011, MNRAS, referred to as IwIn
+
+    Additional details about the algorithm are also described by
+    Murante et al.
+
+    """
+    def __init__(self, dest, sources, g1=0.0, g2=0.0,
+                 monotonicity=0, rsolver=Exact,
+                 interpolation=Linear, interface_zero=True,
+                 gamma=1.4, niter=20, tol=1e-6):
+        self.gamma = gamma
+        self.niter = niter
+        self.tol = tol
+        self.g1 = g1
+        self.g2 = g2
+        self.monotonicity = monotonicity
+        self.interpolation = interpolation
+        self.rsolver = rsolver
+        # Interface position for data reconstruction
+        self.sstar = 0.0
+        if (g1 == 0 and g2 == 0):
+            self.thermal_conduction = 0
+        else:
+            self.thermal_conduction = 1
+        self.interface_zero = interface_zero
+
+        super(GSPHAcceleration, self).__init__(dest, sources)
+
+    def _get_helpers_(self):
+        return HELPERS + [monotonicity_min, sgn]
+
+    def initialize(self, d_idx, d_au, d_av, d_aw, d_ae):
+        d_au[d_idx] = 0.0
+        d_av[d_idx] = 0.0
+        d_aw[d_idx] = 0.0
+        d_ae[d_idx] = 0.0
+
+    def loop(self, d_idx, d_m, d_h, d_rho, d_cs, d_div, d_p, d_e, d_grhox,
+             d_grhoy, d_grhoz, d_u, d_v, d_w, d_px, d_py, d_pz, d_ux, d_uy,
+             d_uz, d_vx, d_vy, d_vz, d_wx, d_wy, d_wz, d_au, d_av, d_aw, d_ae,
+             s_idx, s_rho, s_m, s_h, s_cs, s_div, s_p, s_e, s_grhox,
+             s_grhoy, s_grhoz, s_u, s_v, s_w, s_px, s_py, s_pz,
+             s_ux, s_uy, s_uz, s_vx, s_vy, s_vz, s_wx, s_wy, s_wz,
+             XIJ, DWIJ, DWI, DWJ, RIJ, RHOIJ, EPS, dt):
+        g1 = self.g1
+        g2 = self.g2
+        hi = d_h[d_idx]
+        hj = s_h[s_idx]
+        eij = declare('matrix(3)')
+        if RIJ < 1e-14:
+            eij[0] = 0.0
+            eij[1] = 0.0
+            eij[2] = 0.0
+        else:
+            eij[0] = XIJ[0]/RIJ
+            eij[1] = XIJ[1]/RIJ
+            eij[2] = XIJ[2]/RIJ
+
+        vl = s_u[s_idx]*eij[0] + s_v[s_idx]*eij[1] + s_w[s_idx]*eij[2]
+        vr = d_u[d_idx]*eij[0] + d_v[d_idx]*eij[1] + d_w[d_idx]*eij[2]
+        sij = 1.0/(RIJ + EPS)
+
+        Hi = g1*hi*d_cs[d_idx] + g2*hi*hi*(abs(d_div[d_idx]) - d_div[d_idx])
+
+        grhoi_dot_eij = (d_grhox[d_idx]*eij[0] + d_grhoy[d_idx]*eij[1]
+                         + d_grhoz[d_idx]*eij[2])
+        grhoj_dot_eij = (s_grhox[s_idx]*eij[0] + s_grhoy[s_idx]*eij[1]
+                         + s_grhoz[s_idx]*eij[2])
+
+        sp_vol = declare('matrix(3)')
+        self.interpolate(hi, hj, d_rho[d_idx], s_rho[s_idx], RIJ,
+                         grhoi_dot_eij, grhoj_dot_eij, sp_vol)
+        vij_i = sp_vol[0]
+        vij_j = sp_vol[1]
+        sstar = sp_vol[2]
+
+        # Gradients in the local coordinate system
+        rsi = (d_grhox[d_idx]*eij[0] + d_grhoy[d_idx]*eij[1] +
+               d_grhoz[d_idx]*eij[2])
+        psi = (d_px[d_idx]*eij[0] + d_py[d_idx]*eij[1] + d_pz[d_idx]*eij[2])
+        vsi = (eij[0]*eij[0]*d_ux[d_idx] +
+               eij[0]*eij[1]*(d_uy[d_idx] + d_vx[d_idx]) +
+               eij[0]*eij[2]*(d_uz[d_idx] + d_wx[d_idx]) +
+               eij[1]*eij[1]*d_vy[d_idx] +
+               eij[1]*eij[2]*(d_vz[d_idx] + d_wy[d_idx]) +
+               eij[2]*eij[2]*d_wy[d_idx])
+
+        rsj = (s_grhox[s_idx]*eij[0] + s_grhoy[s_idx]*eij[1] +
+               s_grhoz[s_idx]*eij[2])
+        psj = (s_px[s_idx]*eij[0] + s_py[s_idx]*eij[1] + s_pz[s_idx]*eij[2])
+        vsj = (eij[0]*eij[0]*s_ux[s_idx] +
+               eij[0]*eij[1]*(s_uy[s_idx] + s_vx[s_idx]) +
+               eij[0]*eij[2]*(s_uz[s_idx] + s_wx[s_idx]) +
+               eij[1]*eij[1]*s_vy[s_idx] +
+               eij[1]*eij[2]*(s_vz[s_idx] + s_wy[s_idx]) +
+               eij[2]*eij[2]*s_wy[s_idx])
+
+        csi = d_cs[d_idx]
+        csj = s_cs[s_idx]
+        rhoi = d_rho[d_idx]
+        rhoj = s_rho[s_idx]
+        pi = d_p[d_idx]
+        pj = s_p[s_idx]
+
+        if self.monotonicity == 0:  # First order scheme
+            rsi = rsj = 0.0
+            psi = psj = 0.0
+            vsi = vsj = 0.0
+
+        if self.monotonicity == 1:  # I02 algorithm
+            if (vsi * vsj) < 0:
+                vsi = 0.
+                vsj = 0.
+
+            # default to first order near a shock
+            if (min(csi, csj) < 3.0*(vl - vr)):
+                rsi = 0.
+                rsj = 0.
+                psi = 0.
+                psj = 0.
+                vsi = 0.
+                vsj = 0.
+
+        if self.monotonicity == 2 and RIJ > 1e-14:  # IwIn algorithm
+            qijr = rhoi - rhoj
+            qijp = pi - pj
+            qiju = vr - vl
+
+            delr = rsi * RIJ
+            delrp = 2 * delr - qijr
+            delp = psi * RIJ
+            delpp = 2 * delp - qijp
+            delv = vsi * RIJ
+            delvp = 2 * delv - qiju
+
+            # corrected values for i
+            rsi = monotonicity_min(qijr, delr, delrp)/RIJ
+            psi = monotonicity_min(qijp, delp, delpp)/RIJ
+            vsi = monotonicity_min(qiju, delv, delvp)/RIJ
+
+            delr = rsj * RIJ
+            delrp = 2 * delr - qijr
+            delp = psj * RIJ
+            delpp = 2 * delp - qijp
+            delv = vsj * RIJ
+            delvp = 2 * delv - qiju
+
+            # corrected values for j
+            rsj = monotonicity_min(qijr, delr, delrp)/RIJ
+            psj = monotonicity_min(qijp, delp, delpp)/RIJ
+            vsj = monotonicity_min(qiju, delv, delvp)/RIJ
+
+        # Input to the riemann solver
+        sstar *= 2.0
+
+        # left and right density
+        rhol = rhoj + 0.5 * rsj * RIJ * (1.0 - csj*dt*sij + sstar)
+        rhor = rhoi - 0.5 * rsi * RIJ * (1.0 - csi*dt*sij + sstar)
+
+        # corrected density
+        if rhol < 0:
+            rhol = rhoj
+        if rhor < 0:
+            rhor = rhoi
+
+        # left and right pressure
+        pl = pj + 0.5 * psj * RIJ * (1.0 - csj*dt*sij + sstar)
+        pr = pi - 0.5 * psi * RIJ * (1.0 - csi*dt*sij + sstar)
+
+        # corrected pressure
+        if pl < 0:
+            pl = pj
+        if pr < 0:
+            pr = pi
+
+        # left and right velocity
+        ul = vl + 0.5 * vsj * RIJ * (1.0 - csj*dt*sij + sstar)
+        ur = vr - 0.5 * vsi * RIJ * (1.0 - csi*dt*sij + sstar)
+
+        # Intermediate state from the Riemann solver
+        result = declare('matrix(2)')
+        riemann_solve(
+            self.rsolver, rhol, rhor, pl, pr, ul, ur,
+            self.gamma, self.niter, self.tol, result
+        )
+        pstar = result[0]
+        ustar = result[1]
+
+        # blend of two intermediate states
+        #if self.hybrid:
+        #    pstar2, ustar2 = self.rsolver2.compute_star(
+        #        rhoj, rhoi, pj, pi, vl, vr)
+        #    ustar = ustar + blending_factor * (ustar2 - ustar)
+        #    pstar = pstar + blending_factor * (pstar2 - pstar)
+
+        # three dimensional velocity (70)
+        vstar = declare('matrix(3)')
+        vstar[0] = ustar*eij[0]
+        vstar[1] = ustar*eij[1]
+        vstar[2] = ustar*eij[2]
+
+        # velocity accelerations
+        mj = s_m[s_idx]
+        d_au[d_idx] += -mj * pstar * (vij_i * DWI[0] + vij_j * DWJ[0])
+        d_av[d_idx] += -mj * pstar * (vij_i * DWI[1] + vij_j * DWJ[1])
+        d_aw[d_idx] += -mj * pstar * (vij_i * DWI[2] + vij_j * DWJ[2])
+
+        # contribution to the thermal energy term
+        # (85). The contribution due to \dot{x}^*_i will
+        # be added in the integrator.
+        vstardotdwi = vstar[0]*DWI[0] + vstar[1]*DWI[1] + vstar[2]*DWI[2]
+        vstardotdwj = vstar[0]*DWJ[0] + vstar[1]*DWJ[1] + vstar[2]*DWJ[2]
+        d_ae[d_idx] += -mj * pstar * (vij_i * vstardotdwi +
+                                      vij_j * vstardotdwj)
+
+        # artificial thermal conduction terms
+        if self.thermal_conduction:
+            divj = s_div[s_idx]
+            Hj = g1 * hj * csj + g2 * hj*hj * (abs(divj) - divj)
+            Hij = (Hi + Hj) * (d_e[d_idx] - s_e[s_idx])
+
+            Hij /= (RHOIJ * (RIJ*RIJ + EPS))
+
+            d_ae[d_idx] += mj*Hij*(XIJ[0]*DWIJ[0] + XIJ[1]*DWIJ[1] +
+                                   XIJ[2]*DWIJ[2])
+
+    def interpolate(self, hi=0.0, hj=0.0, rhoi=0.0, rhoj=0.0,
+                    sij=0.0, gri_eij=0.0, grj_eij=0.0,
+                    result=[0.0, 0.0, 0.0]):
+        """Interpolation for the specific volume integrals in GSPH.
+
+        Parameters:
+        -----------
+
+        hi, hj : double
+            Particle smoothing length (scale?) at i (right) and j (left)
+
+        rhoi, rhoj : double
+            Particle densities at i (right) and j (left)
+
+        sij : double
+            Particle separation in the local coordinate system (si - sj)
+
+        gri_eij, grj_eij : double
+            Gradient of density at the particles in the global coordinate
+            system dot product with eij
+
+        Notes:
+        ------
+
+        The interpolation scheme determines the form of the 'specific
+        volume' contributions Vij^2 in the GSPH equations.
+
+        The simplest Delta or point interpolation uses Vi^2 =
+        1./rho_i^2.
+
+        The more involved linear or cubic spline interpolations are
+        defined in the GSPH references.
+
+        Most recent papers on GSPH typically assume the interface to
+        be located midway between the particles. In the local
+        coordinate system, this corresponds to sij = 0. From I02, it
+        seems the definition is only really valid for the constant
+        smoothing length case. Set interface_zero to False if you want
+        to include this term
+
+        """
+        Vi = 1./rhoi
+        Vj = 1./rhoj
+
+        Vip = -1./(rhoi*rhoi) * gri_eij
+        Vjp = -1./(rhoj*rhoj) * grj_eij
+
+        aij, bij, cij, dij, hij, vij, vij_i, vij_j = declare('double', 8)
+        hij = 0.5 * (hi + hj)
+        sstar = self.sstar
+
+        # simplest delta or point interpolation
+        if self.interpolation == 0:
+            vij_i = 1./(rhoi * rhoi)
+            vij_j = 1./(rhoj * rhoj)
+
+        # linear interpolation
+        elif self.interpolation == 1:
+            # avoid singularities
+            if sij < 1e-8:
+                cij = 0.0
+            else:
+                cij = (Vi - Vj)/sij
+
+            dij = 0.5 * (Vi + Vj)
+
+            vij_i = 0.25 * hi * hi * cij * cij + dij * dij
+            vij_j = 0.25 * hj * hj * cij * cij + dij * dij
+
+            # approximate value for the interface location when using
+            # variable smoothing lengths
+            if not self.interface_zero:
+                vij = 0.5 * (vij_i + vij_j)
+                sstar = 0.5 * hij*hij * cij*dij/vij
+
+        # cubic spline interpolation
+        elif self.interpolation == 2:
+            if sij < 1e-8:
+                aij = bij = cij = 0.0
+                dij = 0.5 * Vi + Vj
+            else:
+                aij = -2.0 * (Vi - Vj)/(sij*sij*sij) + (Vip + Vjp)/(sij*sij)
+                bij = 0.5 * (Vip - Vjp)/sij
+                cij = 1.5 * (Vi - Vj)/sij - 0.25 * (Vip + Vjp)
+                dij = 0.5 * (Vi + Vj) - 0.125*(Vip - Vjp)*sij
+
+            vij_i = ((15.0)/(64.0)*hi**6 * aij*aij +
+                     (3.0)/(16.0) * hi**4 * (2*aij*cij + bij*bij) +
+                     0.25*hi*hi*(2*bij*dij + cij*cij) + dij * dij)
+
+            vij_j = ((15.0)/(64.0)*hj**6 * aij*aij +
+                     (3.0)/(16.0) * hj**4 * (2*aij*cij + bij*bij) +
+                     0.25*hj*hj * (2*bij*dij + cij*cij) + dij * dij)
+        else:
+            printf("Unknown interpolation type")
+
+        result[0] = vij_i
+        result[1] = vij_j
+        result[1] = sstar

--- a/pysph/sph/gas_dynamics/riemann_solver.py
+++ b/pysph/sph/gas_dynamics/riemann_solver.py
@@ -1,0 +1,920 @@
+"""GSPH functions"""
+
+from math import sqrt
+
+from pysph.base.cython_generator import declare
+
+
+def SIGN(x, y):
+    if y >= 0:
+        return abs(x)
+    else:
+        return -abs(x)
+
+
+def printf(s):
+    print(s)
+
+
+def van_leer(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
+             ul=0.0, ur=1.0, gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
+    """Van Leer Riemann solver.
+
+
+    Parameters
+    ----------
+    rhol, rhor: double: left and right density.
+    pl, pr: double: left and right pressure.
+    ul, ur: double: left and right speed.
+    gamma: double: Ratio of specific heats.
+    niter: int: Max number of iterations to try for iterative schemes.
+    tol: double: Error tolerance for convergence.
+
+    result: list: List of length 2. Result will contain computed pstar, ustar
+
+    Returns
+    -------
+
+    Returns 0 if the value is computed correctly else 1 if the iterations
+    either did not converge or if there is an error.
+
+    """
+    if ((rhol < 0) or (rhor < 0) or (pl <0) or (pr < 0)):
+        result[0] = 0.0
+        result[1] = 0.0
+        return 1
+
+    # local variables
+    gamma1, gamma2 = declare('double', 2)
+    Vl, Vr, cl, cr, zl, zr, wl, wr = declare('double', 8)
+    ustar_l, ustar_r, pstar, pstar_old = declare('double', 4)
+    converged, iteration = declare('int', 2)
+
+    gamma2 = 1.0 + gamma
+    gamma1 = 0.5 * gamma2/gamma
+    smallp = 1e-25
+
+    # initialize variables
+    wl = 0.0; wr = 0.0
+    zl = 0.0; zr = 0.0
+
+    # specific volumes
+    Vl = 1./rhol; Vr = 1./rhor
+
+    # Lagrangean sound speeds
+    cl = sqrt(gamma * pl * rhol)
+    cr = sqrt(gamma * pr * rhor)
+
+    # Initial guess for pstar
+    pstar = pr - pl - cr * (ur - ul)
+    pstar = pl + pstar * cl/(cl + cr)
+
+    pstar = max(pstar, smallp)
+
+    # Now Iterate using NR to obtain the star values
+    iteration = 0
+    while iteration < niter:
+        pstar_old = pstar
+
+        wl = 1.0 + gamma1 * (pstar - pl)/pl
+        wl = cl * sqrt(wl)
+
+        wr = 1.0 + gamma1 * (pstar - pr)/pr
+        wr = cr * sqrt(wr)
+
+        zl = 4.0 * Vl * wl * wl
+        zl = -zl * wl/(zl - gamma2*(pstar - pl))
+
+        zr = 4.0 * Vr * wr * wr
+        zr = zr * wr/(zr - gamma2*(pstar - pr))
+
+        ustar_l = ul - (pstar - pl)/wl
+        ustar_r = ur + (pstar - pr)/wr
+
+        pstar = pstar + (ustar_r - ustar_l)*(zl*zr)/(zr - zl)
+        pstar = max(smallp, pstar)
+
+        converged = (abs(pstar - pstar_old)/pstar < tol)
+        if converged:
+            break
+
+        iteration += 1
+
+    # calculate the averaged ustar
+    ustar_l = ul - (pstar - pl)/wl
+    ustar_r = ur + (pstar - pr)/wr
+    ustar = 0.5 * (ustar_l + ustar_r)
+
+    result[0] = pstar
+    result[1] = ustar
+    if converged:
+        return 0
+    else:
+        return 1
+
+
+def _prefun_exact(p=0.0, dk=0.0, pk=0.0, ck=0.0, g1=0.0, g2=0.0,
+                  g4=0.0, g5=0.0, g6=0.0, result=[0.0, 0.0]):
+    """The pressure function.  Updates result with f, fd.
+    """
+
+    pratio, f, fd, ak, bk, qrt = declare('double', 6)
+
+    if (p <= pk):
+        pratio = p/pk
+        f = g4*ck*(pratio**g1 - 1.0)
+        fd = (1.0/(dk*ck))*pratio**(-g2)
+    else:
+        ak = g5/dk
+        bk = g6*pk
+        qrt = sqrt(ak/(bk+p))
+        f = (p-pk)*qrt
+        fd = (1.0 - 0.5*(p-pk)/(bk + p))*qrt
+
+    result[0] = f
+    result[1] = fd
+
+
+def exact(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
+          ul=0.0, ur=1.0, gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
+    """Exact Riemann solver.
+
+    Solve the Riemann problem for the Euler equations to determine the
+    intermediate states.
+
+    Parameters
+    ----------
+    rhol, rhor: double: left and right density.
+    pl, pr: double: left and right pressure.
+    ul, ur: double: left and right speed.
+    gamma: double: Ratio of specific heats.
+    niter: int: Max number of iterations to try for iterative schemes.
+    tol: double: Error tolerance for convergence.
+
+    result: list: List of length 2. Result will contain computed pstar, ustar
+
+    Returns
+    -------
+
+    Returns 0 if the value is computed correctly else 1 if the iterations
+    either did not converge or if there is an error.
+
+    """
+    # save derived variables
+    tmp1 = 1.0/(2*gamma)
+    tmp2 = 1.0/(gamma - 1.0)
+    tmp3 = 1.0/(gamma + 1.0)
+
+    gamma1 = (gamma - 1.0) * tmp1
+    gamma2 = (gamma + 1.0) * tmp1
+    gamma3 = 2*gamma * tmp2
+    gamma4 = 2 * tmp2
+    gamma5 = 2 * tmp3
+    gamma6 = tmp3/tmp2
+    gamma7 = 0.5 * (gamma - 1.0)
+    gamma8 = gamma - 1.0
+
+    # sound speed to the left and right based on the Ideal EOS
+    cl, cr = declare('double', 2)
+    cl = sqrt(gamma*pl/rhol)
+    cr = sqrt(gamma*pr/rhor)
+
+    # Iteration constants
+    i = declare('int')
+    i = 0
+
+    # local variables
+    qser, cup, ppv, pmin, pmax, qmax = declare('double', 6)
+    pq, um, ptl, ptr, pm, gel, ger = declare('double', 7)
+    pstar, pold, udifff, fl, fld, fr, frd = declare('double', 7)
+    p, change = declare('double', 2)
+
+    # initialize variables
+    fl = 0.0; fr = 0.0
+    p = 0.0
+
+    # check the initial data
+    if (gamma4*(cl+cr) <= (ur-ul)):
+        return 1
+
+    # compute the guess pressure 'pm'
+    qser = 2.0
+    cup = 0.25 * (rhol + rhor)*(cl+cr)
+    ppv = 0.5 * (pl + pr) + 0.5*(ul - ur)*cup
+    pmin = min(pl, pr)
+    pmax = max(pl, pr)
+    qmax = pmax/pmin
+
+    ppv = max(0.0, ppv)
+
+    if ((qmax <= qser) and (pmin <= ppv) and (ppv <= pmax)):
+        pm = ppv
+    elif (ppv < pmin):
+        pq = (pl/pr)**gamma1
+        um = ( pq*ul/cl + ur/cr + gamma4*(pq - 1.0) )/( pq/cl + 1.0/cr )
+        ptl = 1.0 + gamma7 * (ul - um)/cl
+        ptr = 1.0 + gamma7 * (um - ur)/cr
+        pm = 0.5*(pl*ptl**gamma3 + pr*ptr**gamma3)
+    else:
+        gel = sqrt( (gamma5/rhol)/(gamma6*pl + ppv) )
+        ger = sqrt( (gamma5/rhor)/(gamma6*pr + ppv) )
+        pm = (gel*pl + ger*pr - (ur-ul))/(gel + ger)
+
+    # the guessed value is pm
+    pstart = pm
+
+    pold = pstart
+    udifff = ur-ul
+    fl, fr = declare('matrix(2)', 2)
+
+    for i in range(niter):
+        _prefun_exact(pold, rhol, pl, cl, gamma1, gamma2,
+                      gamma4, gamma5, gamma6, fl)
+        _prefun_exact(pold, rhor, pr, cr, gamma1, gamma2,
+                      gamma4, gamma5, gamma6, fr)
+
+        p = pold - (fl[0] + fr[0] + udifff)/(fl[1] + fr[1])
+        change = 2.0 * abs((p - pold)/(p + pold))
+        if change <= tol:
+            break
+        pold = p
+
+    if i == niter - 1:
+        printf("Divergence in Newton-Raphson Iteration")
+        return 1
+
+    # compute the velocity in the star region 'um'
+    um = 0.5 * (ul + ur + fr[0] - fl[0])
+    result[0] = p
+    result[1] = um
+    return 0
+
+
+def sample(pm=0.0, um=0.0, s=0.0, rhol=1.0, rhor=0.0, pl=1.0, pr=0.0,
+           ul=1.0, ur=0.0, gamma=1.4, result=[0.0, 0.0, 0.0]):
+    """Sample the solution to the Riemann problem.
+
+    Parameters
+    ----------
+
+    pm, um : float
+        Pressure and velocity in the star region as returned
+        by `exact`
+
+    s : float
+        Sampling point (x/t)
+
+    rhol, rhor : float
+        Densities on either side of the discontinuity
+
+    pl, pr : float
+        Pressures on either side of the discontinuity
+
+    ul, ur : float
+        Velocities on either side of the discontinuity
+
+    gamma : float
+        Ratio of specific heats
+
+    result : list(double)
+        (rho, u, p) : Sampled density, velocity and pressure
+
+    """
+    tmp1, tmp2, tmp3 = declare('double', 3)
+    g1, g2, g3, g4, g5, g6 = declare('double', 6)
+    cl, cr = declare('double', 2)
+
+    # save derived variables
+    tmp1 = 1.0/(2*gamma)
+    tmp2 = 1.0/(gamma - 1.0)
+    tmp3 = 1.0/(gamma + 1.0)
+
+    g1 = (gamma - 1.0) * tmp1
+    g2 = (gamma + 1.0) * tmp1
+    g3 = 2*gamma * tmp2
+    g4 = 2 * tmp2
+    g5 = 2 * tmp3
+    g6 = tmp3/tmp2
+    g7 = 0.5 * (gamma - 1.0)
+    g8 = gamma - 1.0
+
+    # sound speeds at the left and right data states
+    cl = sqrt(gamma*pl/rhol)
+    cr = sqrt(gamma*pr/rhor)
+
+    if s <= um:
+        # sampling point lies to the left of the contact discontinuity
+        if (pm <= pl):  # left rarefaction
+            # speed of the head of the rarefaction
+            shl = ul - cl
+
+            if (s <= shl):
+                # sampled point is left state
+                rho = rhol; u = ul; p = pl
+            else:
+                cml = cl*(pm/pl)**g1    # eqn (4.54)
+                stl = um - cml          # eqn (4.55)
+
+                if (s > stl):
+                    # sampled point is Star left state. eqn (4.53)
+                    rho = rhol*(pm/pl)**(1.0/gamma); u = um; p = pm
+                else:
+                    # sampled point is inside left fan
+                    u = g5 * (cl + g7*ul + s)
+                    c = g5 * (cl + g7*(ul - s))
+
+                    rho = rhol*(c/cl)**g4
+                    p = pl * (c/cl)**g3
+
+        else: # pm <= pl
+            # left shock
+            pml = pm/pl
+            sl = ul - cl*sqrt(g2*pml + g1)
+
+            if (s <= sl):
+                # sampled point is left data state
+                rho = rhol; u=ul; p=pl
+            else:
+                # sampled point is Star left state
+                rho = rhol*(pml + g6)/(pml*g6 + 1.0)
+                u = um
+                p = pm
+
+    else: # s < um
+        # sampling point lies to the right of the contact discontinuity
+        if (pm > pr):
+            # right shock
+            pmr = pm/pr
+            sr = ur + cr * sqrt(g2*pmr + g1)
+
+            if (s >= sr):
+                #sampled point is right data state
+                rho = rhor; u = ur; p = pr
+            else:
+                # sampled point is star right state
+                rho = rhor*(pmr + g6)/(pmr*g6 + 1.0); u = um; p = pm
+        else:
+            # right rarefaction
+            shr = ur + cr
+
+            if (s >= shr):
+                # sampled point is right state
+                rho = rhor; u = ur; p = pr
+            else:
+                cmr = cr*(pm/pr)**g1
+                STR = um + cmr
+
+                if (s <= STR):
+                    # sampled point is star right
+                    rho = rhor*(pm/pr)**(1.0/gamma); u = um; p = pm
+                else:
+                    # sampled point is inside left fan
+                    u = g5*(-cr + g7*ur + s)
+                    c = g5*(cr - g7*(ur -s))
+                    rho = rhor * (c/cr)**g4
+                    p = pr*(c/cr)**g3
+
+    result[0] = rho
+    result[1] = u
+    result[2] = p
+
+
+def ducowicz(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
+             ul=0.0, ur=1.0, gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
+    """Ducowicz Approximate Riemann solver for the Euler equations to
+    determine the intermediate states.
+
+    Parameters
+    ----------
+    rhol, rhor: double: left and right density.
+    pl, pr: double: left and right pressure.
+    ul, ur: double: left and right speed.
+    gamma: double: Ratio of specific heats.
+    niter: int: Max number of iterations to try for iterative schemes.
+    tol: double: Error tolerance for convergence.
+
+    result: list: List of length 2. Result will contain computed pstar, ustar
+
+    Returns
+    -------
+
+    Returns 0 if the value is computed correctly else 1 if the iterations
+    either did not converge or if there is an error.
+
+    """
+    al, ar = declare('double', 2)
+    # strong shock parameters
+    al = 0.5 * (gamma + 1.0)
+    ar = 0.5 * (gamma + 1.0)
+
+    csl, csr, umin, umax, plmin, prmin, bl, br = declare('double', 8)
+    a, b, c, d, pstar, ustar, dd = declare('double', 7)
+    # Lagrangian sound speeds
+    csl = sqrt( gamma * pl * rhol )
+    csr = sqrt( gamma * pr * rhor )
+
+    umin = ur - 0.5 * csr/ar
+    umax = ul + 0.5 * csl/al
+
+    plmin = pl - 0.25*rhol*csl*csl/al
+    prmin = pr - 0.25*rhor*csr*csr/ar
+
+    bl = rhol*al
+    br = rhor*ar
+
+    a = (br-bl) * (prmin-plmin)
+    b = br*umin*umin - bl*umax*umax
+    c = br*umin - bl*umax
+    d = br*bl * (umin-umax)*(umin-umax)
+
+    # Case A : ustar - umin > 0
+    dd = sqrt(max(0.0, d-a))
+    ustar = (b + prmin-plmin)/(c - SIGN(dd, umax-umin))
+
+    if ( ((ustar - umin) >= 0.0) and ((ustar - umax) <= 0) ):
+        pstar = 0.5 * (plmin + prmin + br*abs(ustar-umin)*(ustar-umin) -
+                       bl*abs(ustar-umax)*(ustar-umax))
+        pstar = max(pstar, 0.0)
+        result[0] = pstar
+        result[1] = ustar
+        return 0
+
+    # Case B: ustar - umin < 0, ustar - umax > 0
+    dd = sqrt( max(0.0, d+a) )
+    ustar = (b-prmin + plmin)/(c - SIGN(dd,umax-umin))
+    if ( ((ustar-umin) <= 0.0) and ((ustar-umax) >= 0.0)):
+        pstar = 0.5 * (plmin+prmin + br*abs(ustar-umin)*(ustar-umin) -
+                       bl*abs(ustar-umax)*(ustar-umax))
+        pstar = max(pstar, 0.0)
+        result[0] = pstar
+        result[1] = ustar
+        return 0
+
+    a = (bl+br)*(plmin-prmin)
+    b = bl*umax + br*umin
+    c = 1./(bl + br)
+
+    # Case C : ustar-umin >0, ustar-umax > 0
+    dd = sqrt( max(0.0, a-d) )
+    ustar = (b+dd)*c
+    if ( ((ustar-umin) >= 0) and ( (ustar-umax) >=0.0) ):
+        pstar = 0.5 * (plmin+prmin + br*abs(ustar-umin)*(ustar-umin)
+                       -bl*abs(ustar-umax)*(ustar-umax))
+        pstar = max(pstar, 0.0)
+        result[0] = pstar
+        result[1] = ustar
+        return 0
+
+    # Case D: ustar - umin < 0, ustar - umax < 0
+    dd = sqrt( max(0.0, -a-d) )
+    ustar = (b-dd)*c
+    pstar = 0.5 * (plmin+prmin + br*abs(ustar-umin)*(ustar-umin)
+                   -bl*abs(ustar-umax)*(ustar-umax))
+    pstar = max(pstar, 0.0)
+    result[0] = pstar
+    result[1] = ustar
+    return 0
+
+
+def roe(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
+        gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
+    """Roe's approximate Riemann solver for the Euler equations to
+    determine the intermediate states.
+
+    Parameters
+    ----------
+    rhol, rhor: double: left and right density.
+    pl, pr: double: left and right pressure.
+    ul, ur: double: left and right speed.
+    gamma: double: Ratio of specific heats.
+    niter: int: Max number of iterations to try for iterative schemes.
+    tol: double: Error tolerance for convergence.
+
+    result: list: List of length 2. Result will contain computed pstar, ustar
+
+    Returns
+    -------
+
+    Returns 0 if the value is computed correctly else 1 if the iterations
+    either did not converge or if there is an error.
+
+    """
+
+    rrhol, rrhor, denominator, plr, vlr, ulr = declare('double', 6)
+    cslr, cslr1 = declare('double', 2)
+    # Roe-averaged pressure and specific volume
+    rrhol = sqrt(rhol)
+    rrhor = sqrt(rhor)
+
+    denominator = 1./(rrhor + rrhol)
+
+    plr = (rrhol*pl + rrhor*pr) * denominator
+    vlr = (rrhol/rhol + rrhor/rhor) * denominator
+    ulr = (rrhol*ul + rrhor*ur) * denominator
+
+    # average sound speed at the interface
+    cslr = sqrt( gamma * plr/vlr )
+    cslr1 = 1./cslr
+
+    # the intermediate states
+    result[0] = plr  - 0.5 * (ur - ul) * cslr
+    result[1] = ulr  - 0.5 * (pr - pl) * cslr1
+
+    return 0
+
+
+def llxf(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
+        gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
+    """Lax Friedrichs approximate Riemann solver for the Euler equations to
+    determine the intermediate states.
+
+    Parameters
+    ----------
+    rhol, rhor: double: left and right density.
+    pl, pr: double: left and right pressure.
+    ul, ur: double: left and right speed.
+    gamma: double: Ratio of specific heats.
+    niter: int: Max number of iterations to try for iterative schemes.
+    tol: double: Error tolerance for convergence.
+
+    result: list: List of length 2. Result will contain computed pstar, ustar
+
+    Returns
+    -------
+
+    Returns 0 if the value is computed correctly else 1 if the iterations
+    either did not converge or if there is an error.
+
+    """
+
+    gamma1, csl, csr, cslr, el, El, er, Er, pstar = declare('double', 9)
+    gamma1 = 1./(gamma - 1.0)
+
+    # Lagrangian sound speeds
+    csl = sqrt( gamma * pl * rhol )
+    csr = sqrt( gamma * pr * rhor )
+    cslr = max( csr, csl )
+
+    # Total energy on either side
+    el = pl*gamma1/rhol
+    El = el + 0.5 * ul*ul
+
+    er = pr*gamma1/rhor
+    Er = er + 0.5 * ur*ur
+
+    # the intermediate states
+    #cdef double ustar = 0.5 * ( ul + ur - 1./cslr * (pr - pl) ) # roe's average
+    pstar = 0.5 * ( pl + pr - cslr * (ur - ul) )
+    result[0] = pstar
+    result[1] = 1./pstar * (0.5 * ( (pl*ul + pr*ur) - cslr*(Er - El) ))
+    return 0
+
+
+def hllc(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
+        gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
+    """Harten-Lax-van Leer-Contact approximate Riemann solver for the Euler
+    equations to determine the intermediate states.
+
+    Parameters
+    ----------
+    rhol, rhor: double: left and right density.
+    pl, pr: double: left and right pressure.
+    ul, ur: double: left and right speed.
+    gamma: double: Ratio of specific heats.
+    niter: int: Max number of iterations to try for iterative schemes.
+    tol: double: Error tolerance for convergence.
+
+    result: list: List of length 2. Result will contain computed pstar, ustar
+
+    Returns
+    -------
+
+    Returns 0 if the value is computed correctly else 1 if the iterations
+    either did not converge or if there is an error.
+
+    """
+
+    gamma1, pstar, ustar, mstar, estar = declare('double', 5)
+    gamma1 = 1./(gamma - 1.0)
+
+    # Roe-averaged interface velocity
+    rrhol = sqrt(rhol)
+    rrhor = sqrt(rhor)
+    ulr = (rrhol*ul + rrhor*ur)/(rrhol + rrhor)
+
+    # relative velocities at the interface
+    vl = ul - ulr
+    vr = ur - ulr
+
+    # Sound speeds at the interface
+    csl = sqrt( gamma * pl/rhol )
+    csr = sqrt( gamma * pr/rhor )
+    cslr = (rrhol*csl + rrhor*csr)/(rrhol + rrhor)
+
+    # wave speed estimates at the interface
+    sl = min(vl - csl, 0 - cslr)
+    sr = max(vr + csr, 0 + cslr)
+
+    sm = rhor*vr*(sr-vr) - rhol*vl*(sl-vl) + pl - pr
+    sm /= ( rhor*(sr-vr) - rhol*(sl-vl) )
+
+    # phat
+    phat = rhol*(vl - sl)*(vl - sm) + pl
+
+    # Total energy on either side
+    el = pl*gamma1/rhol
+    El = rhol*(el + 0.5 * ul*ul )
+
+    er = pr*gamma1/rhor
+    Er = rhor*(er + 0.5 * ur*ur )
+
+    # Momentum on either side
+    Ml = rhol*ul
+    Mr = rhor*ur
+
+    # compute the values based on the wave speeds
+    if ( sl > 0 ):
+        pstar = pl; ustar = ul
+
+    elif ( sl <= 0.0 < sm ):
+        mstar = 1./(sl - sm) * ( (sl - vl) * Ml + (phat - pl) )
+        estar = 1./(sl - sm) * ( (sl - vl) * El - pl*vl + phat*sm )
+
+        pstar = sm*mstar + phat
+
+        ustar = sm*estar + (sm + ulr)*phat
+        ustar /= pstar
+
+    elif ( sm <= 0 < sr ):
+        mstar = 1./(sr - sm) * ( (sr - vr) * Mr + (phat - pr) )
+        estar = 1./(sr - sm) * ( (sr - vr) * Er - pr*vr + phat*sm )
+
+        pstar = sm*mstar + phat
+
+        ustar = sm*estar + (sm + ulr)*phat
+        ustar /= pstar
+
+    elif ( sr < 0 ):
+        pstar = pr; ustar = ur
+
+    else:
+        msg = str((sl, sr, sm, csl, csr, rhol, rhor))
+        printf("Incorrect wave speeds: %s" % msg)
+        return 1
+
+    result[0] = pstar
+    result[1] = ustar
+    return 0
+
+
+def hllc_ball(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
+              gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
+    """Harten-Lax-van Leer-Contact approximate Riemann solver for the Euler
+    equations to determine the intermediate states.
+
+    Parameters
+    ----------
+    rhol, rhor: double: left and right density.
+    pl, pr: double: left and right pressure.
+    ul, ur: double: left and right speed.
+    gamma: double: Ratio of specific heats.
+    niter: int: Max number of iterations to try for iterative schemes.
+    tol: double: Error tolerance for convergence.
+
+    result: list: List of length 2. Result will contain computed pstar, ustar
+
+    Returns
+    -------
+
+    Returns 0 if the value is computed correctly else 1 if the iterations
+    either did not converge or if there is an error.
+
+    """
+    gamma1, csl, csr, cslr, rholr, pstar, ustar = declare('double', 7)
+    Sl, Sr, ql, qr, pstar_l, pstar_r = declare('double', 6)
+
+    gamma1 = 0.5 * (gamma + 1.0)/gamma
+
+    # sound speeds in the undisturbed fluid
+    csl = sqrt(gamma * pl/rhol)
+    csr = sqrt(gamma * pr/rhor)
+    cslr = 0.5 * (csl + csr)
+
+    # averaged density
+    rholr = 0.5 * (rhol + rhor)
+
+    # provisional intermediate pressure
+    pstar = 0.5 * ( pl + pr - rholr*cslr*(ur - ul) )
+
+    # Wave speed estimates (ustar is taken as the intermediate velocity)
+    ustar = 0.5 * ( ul + ur - 1./(rholr*cslr)*(pr - pl) )
+
+    Hl = pstar/pl
+    Hr = pstar/pr
+
+    ql = 1.0
+    if ( Hl > 1 ):
+        ql = sqrt( 1 + gamma1*(Hl - 1.0) )
+
+    qr = 1.0
+    if ( Hr > 1 ):
+        qr = sqrt( 1 + gamma1*(Hr - 1.0) )
+
+    Sl = ul - csl*ql; Sr = ur + csr*qr
+
+    # compute the intermediate pressure
+    pstar_l = pl + rhol*(ul - Sl)*(ul - ustar)
+    pstar_r = pr + rhor*(ur - Sr)*(ur - ustar)
+
+    pstar = 0.5 * (pstar_l + pstar_r)
+
+    # return intermediate states
+    result[0] = pstar
+    result[1] = ustar
+    return 0
+
+
+def hlle(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
+         gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
+    """Harten-Lax-van Leer-Einfeldt approximate Riemann solver for the Euler
+    equations to determine the intermediate states.
+
+    Parameters
+    ----------
+    rhol, rhor: double: left and right density.
+    pl, pr: double: left and right pressure.
+    ul, ur: double: left and right speed.
+    gamma: double: Ratio of specific heats.
+    niter: int: Max number of iterations to try for iterative schemes.
+    tol: double: Error tolerance for convergence.
+
+    result: list: List of length 2. Result will contain computed pstar, ustar
+
+    Returns
+    -------
+
+    Returns 0 if the value is computed correctly else 1 if the iterations
+    either did not converge or if there is an error.
+
+    """
+    gamma1 = 1./(gamma - 1.0)
+
+    # Roe-averaged interface velocity
+    rrhol = sqrt(rhol)
+    rrhor = sqrt(rhor)
+    ulr = (rrhol*ul + rrhor*ur)/(rrhol + rrhor)
+
+    # lagrangian sound speeds
+    csl = sqrt( gamma * pl * rhol )
+    csr = sqrt( gamma * pr * rhor )
+    cslr = (rrhol*csl + rrhor*csr)/(rrhol + rrhor)
+
+    # wave speed estimates
+    sl = min(ul - csl, -cslr)
+    sr = max(ur + csr, +cslr)
+
+    smax = max( sl, sr )
+    smin = min( sl, sr )
+    #cdef double smax = max( (ur-ulr) + csr,  cslr )
+    #cdef double smin = max( (ul-ulr) - csl, -cslr )
+
+    # Total energy on either side
+    el = pl*gamma1/rhol
+    El = el + 0.5 * ul*ul
+
+    er = pr*gamma1/rhor
+    Er = er + 0.5 * ur*ur
+
+    # Momentum on either side
+    Ml = rhol*ul
+    Mr = rhor*ur
+
+    # the intermediate states
+    pstar = ((smax * pl - smin * pr)/(smax - smin) +
+             smax*smin/(smax - smin)*(ur - ul))
+    ustar = ((smax * pl*ul - smin * pr*ur)/(smax - smin) +
+             smax*smin/(smax - smin)*(Er - El))
+    result[0] = pstar
+    result[1] = ustar/pstar
+
+    return 0
+
+
+def hll_ball(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
+             gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
+    """Harten-Lax-van Leer-Ball approximate Riemann solver for the Euler equations
+    to determine the intermediate states.
+
+    Parameters
+    ----------
+    rhol, rhor: double: left and right density.
+    pl, pr: double: left and right pressure.
+    ul, ur: double: left and right speed.
+    gamma: double: Ratio of specific heats.
+    niter: int: Max number of iterations to try for iterative schemes.
+    tol: double: Error tolerance for convergence.
+
+    result: list: List of length 2. Result will contain computed pstar, ustar
+
+    Returns
+    -------
+
+    Returns 0 if the value is computed correctly else 1 if the iterations
+    either did not converge or if there is an error.
+
+    """
+    # Roe-averaged pressure and specific volume
+    rrhol = sqrt(rhol)
+    rrhor = sqrt(rhor)
+
+    denominator = 1./(rrhor + rrhol)
+
+    # sound speeds
+    csl = sqrt( gamma * pl/rhol )
+    csr = sqrt( gamma * pr/rhor )
+    # cslr2 = denominator * (rrhol*csl*csl + rrhor*csr*csr )
+    eta = 0.5 * (gamma - 1.0) * (rrhor*rrhol) * denominator * denominator
+    betal = abs( ul )
+    betar = abs( ur )
+
+    # averaged velocity and cs2
+    ulr = ( rrhol*ul + rrhor*ur )/( rrhol*rrhor )
+    cslr2 = ( rrhol*csl*csl + rrhor*csr*csr )/( rrhol*rrhor )
+    cslr = sqrt( cslr2 + eta * (betar - betal) * (betar - betal) )
+
+    # wave speed estimates
+    Sl = min( ulr - cslr, ul - csl )
+    Sr = max( ulr + cslr, ur + csr )
+
+    # intermediate states
+    rhostar = 1./(Sr - Sl) * ( rhor*(Sr-ur) - rhol*(Sl-ul) )
+    ustar = (Sr*Sl*(rhor-rhol) + rhol*ul*Sr - rhor*ur*Sl)/(rhol*(ul-Sl) + rhor*(Sr-ur))
+    # pstar = 0.5 * (pl + pr - rhostar*ustar*( (Sr-ustar) + (Sl-ustar) ) + \
+    #                                rhor*ur*(ur - Sr) + rhol*ul*(ul-Sl) )
+    pstar = (pr*(ustar-Sl) - pl*(ustar-Sr) +
+             rhor*ur*(ustar-Sl)*(ur-Sr) -
+             rhol*ul*(ustar-Sr)*(ul-Sl))
+    pstar = pstar/(Sr - Sl)
+    result[0] = pstar
+    result[1] = ustar
+
+    return 0
+
+
+def hllsy(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
+             gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
+    """HLL Riemann solver defined by Sirotkin and Yoh in 'A Smoothed Particle
+    Hydrodynamics method with approximate Riemann solvers for simulation of
+    strong explosions' (2013), Computers and Fluids.
+
+    Parameters
+    ----------
+    rhol, rhor: double: left and right density.
+    pl, pr: double: left and right pressure.
+    ul, ur: double: left and right speed.
+    gamma: double: Ratio of specific heats.
+    niter: int: Max number of iterations to try for iterative schemes.
+    tol: double: Error tolerance for convergence.
+
+    result: list: List of length 2. Result will contain computed pstar, ustar
+
+    Returns
+    -------
+
+    Returns 0 if the value is computed correctly else 1 if the iterations
+    either did not converge or if there is an error.
+
+    """
+
+    gamma1 = 1./(gamma - 1.0)
+
+    # Roe-averaging factors
+    rrhol = sqrt(rhol)
+    rrhor = sqrt(rhor)
+    denominator = 1./(rrhor + rrhol)
+
+    # Lagrangian sound speed Eq. (35) in SY13
+    csl = sqrt( gamma * pl*rhol )
+    csr = sqrt( gamma * pr*rhor )
+    cslr = denominator * (rrhol*csl + rrhor*csr )
+
+    # weighting factors Eqs. (33 - 35) in SY13
+    bl = max(csl, cslr)
+    br = max(csr, cslr)
+    wl = br/(bl + br)
+    wr = bl/(bl + br)
+    wlr = bl*br/(bl + br)
+
+    # Total energy on either side
+    el = pl*gamma1/rhol
+    El = el + 0.5 * ul*ul
+
+    er = pr*gamma1/rhor
+    Er = er + 0.5 * ur*ur
+
+    # intermediate states Eq.(32) in SY13
+    pstar = wl*pl + wr*pr - wlr*(ur - ul)
+    ustar = wl*(pl*ul) + wr*(pr*ur) - wlr*(Er - El)
+    result[0] = pstar
+    result[1] = ustar/pstar
+    return 0

--- a/pysph/sph/gas_dynamics/riemann_solver.py
+++ b/pysph/sph/gas_dynamics/riemann_solver.py
@@ -5,7 +5,7 @@ from math import sqrt
 from pysph.base.cython_generator import declare
 
 
-def SIGN(x, y):
+def SIGN(x=0.0, y=0.0):
     if y >= 0:
         return abs(x)
     else:
@@ -151,7 +151,7 @@ def van_leer(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
         return 1
 
 
-def _prefun_exact(p=0.0, dk=0.0, pk=0.0, ck=0.0, g1=0.0, g2=0.0,
+def prefun_exact(p=0.0, dk=0.0, pk=0.0, ck=0.0, g1=0.0, g2=0.0,
                   g4=0.0, g5=0.0, g6=0.0, result=[0.0, 0.0]):
     """The pressure function.  Updates result with f, fd.
     """
@@ -223,12 +223,11 @@ def exact(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
     # local variables
     qser, cup, ppv, pmin, pmax, qmax = declare('double', 6)
     pq, um, ptl, ptr, pm, gel, ger = declare('double', 7)
-    pstar, pold, udifff, fl, fld, fr, frd = declare('double', 7)
+    pstar, pold, udifff = declare('double', 3)
     p, change = declare('double', 2)
 
     # initialize variables
-    fl = 0.0
-    fr = 0.0
+    fl, fr = declare('matrix(2)', 2)
     p = 0.0
 
     # check the initial data
@@ -263,13 +262,12 @@ def exact(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
 
     pold = pstart
     udifff = ur-ul
-    fl, fr = declare('matrix(2)', 2)
 
     for i in range(niter):
-        _prefun_exact(pold, rhol, pl, cl, gamma1, gamma2,
-                      gamma4, gamma5, gamma6, fl)
-        _prefun_exact(pold, rhor, pr, cr, gamma1, gamma2,
-                      gamma4, gamma5, gamma6, fr)
+        prefun_exact(pold, rhol, pl, cl, gamma1, gamma2,
+                     gamma4, gamma5, gamma6, fl)
+        prefun_exact(pold, rhor, pr, cr, gamma1, gamma2,
+                     gamma4, gamma5, gamma6, fr)
 
         p = pold - (fl[0] + fr[0] + udifff)/(fl[1] + fr[1])
         change = 2.0 * abs((p - pold)/(p + pold))
@@ -711,8 +709,7 @@ def hllc(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
         ustar = ur
 
     else:
-        msg = str((sl, sr, sm, csl, csr, rhol, rhor))
-        printf("Incorrect wave speeds: %s" % msg)
+        printf("Incorrect wave speeds")
         return 1
 
     result[0] = pstar
@@ -976,8 +973,8 @@ def hllsy(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
 
 
 HELPERS = [
-    SIGN, printf, riemann_solve, non_diffusive,
+    SIGN, riemann_solve, non_diffusive,
     ducowicz, exact, hll_ball, hllc,
     hllc_ball, hlle, hllsy, llxf, roe,
-    van_leer
+    van_leer, prefun_exact
 ]

--- a/pysph/sph/gas_dynamics/riemann_solver.py
+++ b/pysph/sph/gas_dynamics/riemann_solver.py
@@ -16,6 +16,41 @@ def printf(s):
     print(s)
 
 
+def riemann_solve(method=1, rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
+                  gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
+    if method == 0:
+        return non_diffusive(rhol, rhor, pl, pr, ul, ur, gamma, niter, tol,
+                             result)
+    elif method == 1:
+        return van_leer(rhol, rhor, pl, pr, ul, ur, gamma, niter, tol, result)
+    elif method == 2:
+        return exact(rhol, rhor, pl, pr, ul, ur, gamma, niter, tol, result)
+    elif method == 3:
+        return hllc(rhol, rhor, pl, pr, ul, ur, gamma, niter, tol, result)
+    elif method == 4:
+        return ducowicz(rhol, rhor, pl, pr, ul, ur, gamma, niter, tol, result)
+    elif method == 5:
+        return hlle(rhol, rhor, pl, pr, ul, ur, gamma, niter, tol, result)
+    elif method == 6:
+        return roe(rhol, rhor, pl, pr, ul, ur, gamma, niter, tol, result)
+    elif method == 7:
+        return llxf(rhol, rhor, pl, pr, ul, ur, gamma, niter, tol, result)
+    elif method == 8:
+        return hllc_ball(rhol, rhor, pl, pr, ul, ur, gamma, niter, tol,
+                         result)
+    elif method == 9:
+        return hll_ball(rhol, rhor, pl, pr, ul, ur, gamma, niter, tol, result)
+    elif method == 10:
+        return hllsy(rhol, rhor, pl, pr, ul, ur, gamma, niter, tol, result)
+
+
+def non_diffusive(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
+                  gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
+    result[0] = 0.5*(pl + pr)
+    result[1] = 0.5*(ul + ur)
+    return 0
+
+
 def van_leer(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
              ul=0.0, ur=1.0, gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
     """Van Leer Riemann solver.
@@ -39,7 +74,7 @@ def van_leer(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
     either did not converge or if there is an error.
 
     """
-    if ((rhol < 0) or (rhor < 0) or (pl <0) or (pr < 0)):
+    if ((rhol < 0) or (rhor < 0) or (pl < 0) or (pr < 0)):
         result[0] = 0.0
         result[1] = 0.0
         return 1
@@ -55,11 +90,14 @@ def van_leer(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
     smallp = 1e-25
 
     # initialize variables
-    wl = 0.0; wr = 0.0
-    zl = 0.0; zr = 0.0
+    wl = 0.0
+    wr = 0.0
+    zl = 0.0
+    zr = 0.0
 
     # specific volumes
-    Vl = 1./rhol; Vr = 1./rhor
+    Vl = 1./rhol
+    Vr = 1./rhor
 
     # Lagrangean sound speeds
     cl = sqrt(gamma * pl * rhol)
@@ -172,7 +210,6 @@ def exact(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
     gamma5 = 2 * tmp3
     gamma6 = tmp3/tmp2
     gamma7 = 0.5 * (gamma - 1.0)
-    gamma8 = gamma - 1.0
 
     # sound speed to the left and right based on the Ideal EOS
     cl, cr = declare('double', 2)
@@ -190,7 +227,8 @@ def exact(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
     p, change = declare('double', 2)
 
     # initialize variables
-    fl = 0.0; fr = 0.0
+    fl = 0.0
+    fr = 0.0
     p = 0.0
 
     # check the initial data
@@ -211,13 +249,13 @@ def exact(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
         pm = ppv
     elif (ppv < pmin):
         pq = (pl/pr)**gamma1
-        um = ( pq*ul/cl + ur/cr + gamma4*(pq - 1.0) )/( pq/cl + 1.0/cr )
+        um = (pq*ul/cl + ur/cr + gamma4*(pq - 1.0))/(pq/cl + 1.0/cr)
         ptl = 1.0 + gamma7 * (ul - um)/cl
         ptr = 1.0 + gamma7 * (um - ur)/cr
         pm = 0.5*(pl*ptl**gamma3 + pr*ptr**gamma3)
     else:
-        gel = sqrt( (gamma5/rhol)/(gamma6*pl + ppv) )
-        ger = sqrt( (gamma5/rhor)/(gamma6*pr + ppv) )
+        gel = sqrt((gamma5/rhol)/(gamma6*pl + ppv))
+        ger = sqrt((gamma5/rhor)/(gamma6*pr + ppv))
         pm = (gel*pl + ger*pr - (ur-ul))/(gel + ger)
 
     # the guessed value is pm
@@ -296,7 +334,6 @@ def sample(pm=0.0, um=0.0, s=0.0, rhol=1.0, rhor=0.0, pl=1.0, pr=0.0,
     g5 = 2 * tmp3
     g6 = tmp3/tmp2
     g7 = 0.5 * (gamma - 1.0)
-    g8 = gamma - 1.0
 
     # sound speeds at the left and right data states
     cl = sqrt(gamma*pl/rhol)
@@ -310,14 +347,18 @@ def sample(pm=0.0, um=0.0, s=0.0, rhol=1.0, rhor=0.0, pl=1.0, pr=0.0,
 
             if (s <= shl):
                 # sampled point is left state
-                rho = rhol; u = ul; p = pl
+                rho = rhol
+                u = ul
+                p = pl
             else:
                 cml = cl*(pm/pl)**g1    # eqn (4.54)
                 stl = um - cml          # eqn (4.55)
 
                 if (s > stl):
                     # sampled point is Star left state. eqn (4.53)
-                    rho = rhol*(pm/pl)**(1.0/gamma); u = um; p = pm
+                    rho = rhol*(pm/pl)**(1.0/gamma)
+                    u = um
+                    p = pm
                 else:
                     # sampled point is inside left fan
                     u = g5 * (cl + g7*ul + s)
@@ -326,21 +367,23 @@ def sample(pm=0.0, um=0.0, s=0.0, rhol=1.0, rhor=0.0, pl=1.0, pr=0.0,
                     rho = rhol*(c/cl)**g4
                     p = pl * (c/cl)**g3
 
-        else: # pm <= pl
+        else:  # pm <= pl
             # left shock
             pml = pm/pl
             sl = ul - cl*sqrt(g2*pml + g1)
 
             if (s <= sl):
                 # sampled point is left data state
-                rho = rhol; u=ul; p=pl
+                rho = rhol
+                u = ul
+                p = pl
             else:
                 # sampled point is Star left state
                 rho = rhol*(pml + g6)/(pml*g6 + 1.0)
                 u = um
                 p = pm
 
-    else: # s < um
+    else:  # s < um
         # sampling point lies to the right of the contact discontinuity
         if (pm > pr):
             # right shock
@@ -348,29 +391,37 @@ def sample(pm=0.0, um=0.0, s=0.0, rhol=1.0, rhor=0.0, pl=1.0, pr=0.0,
             sr = ur + cr * sqrt(g2*pmr + g1)
 
             if (s >= sr):
-                #sampled point is right data state
-                rho = rhor; u = ur; p = pr
+                # sampled point is right data state
+                rho = rhor
+                u = ur
+                p = pr
             else:
                 # sampled point is star right state
-                rho = rhor*(pmr + g6)/(pmr*g6 + 1.0); u = um; p = pm
+                rho = rhor*(pmr + g6)/(pmr*g6 + 1.0)
+                u = um
+                p = pm
         else:
             # right rarefaction
             shr = ur + cr
 
             if (s >= shr):
                 # sampled point is right state
-                rho = rhor; u = ur; p = pr
+                rho = rhor
+                u = ur
+                p = pr
             else:
                 cmr = cr*(pm/pr)**g1
                 STR = um + cmr
 
                 if (s <= STR):
                     # sampled point is star right
-                    rho = rhor*(pm/pr)**(1.0/gamma); u = um; p = pm
+                    rho = rhor*(pm/pr)**(1.0/gamma)
+                    u = um
+                    p = pm
                 else:
                     # sampled point is inside left fan
                     u = g5*(-cr + g7*ur + s)
-                    c = g5*(cr - g7*(ur -s))
+                    c = g5*(cr - g7*(ur - s))
                     rho = rhor * (c/cr)**g4
                     p = pr*(c/cr)**g3
 
@@ -410,8 +461,8 @@ def ducowicz(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
     csl, csr, umin, umax, plmin, prmin, bl, br = declare('double', 8)
     a, b, c, d, pstar, ustar, dd = declare('double', 7)
     # Lagrangian sound speeds
-    csl = sqrt( gamma * pl * rhol )
-    csr = sqrt( gamma * pr * rhor )
+    csl = sqrt(gamma * pl * rhol)
+    csr = sqrt(gamma * pr * rhor)
 
     umin = ur - 0.5 * csr/ar
     umax = ul + 0.5 * csl/al
@@ -431,7 +482,7 @@ def ducowicz(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
     dd = sqrt(max(0.0, d-a))
     ustar = (b + prmin-plmin)/(c - SIGN(dd, umax-umin))
 
-    if ( ((ustar - umin) >= 0.0) and ((ustar - umax) <= 0) ):
+    if (((ustar - umin) >= 0.0) and ((ustar - umax) <= 0)):
         pstar = 0.5 * (plmin + prmin + br*abs(ustar-umin)*(ustar-umin) -
                        bl*abs(ustar-umax)*(ustar-umax))
         pstar = max(pstar, 0.0)
@@ -440,9 +491,9 @@ def ducowicz(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
         return 0
 
     # Case B: ustar - umin < 0, ustar - umax > 0
-    dd = sqrt( max(0.0, d+a) )
-    ustar = (b-prmin + plmin)/(c - SIGN(dd,umax-umin))
-    if ( ((ustar-umin) <= 0.0) and ((ustar-umax) >= 0.0)):
+    dd = sqrt(max(0.0, d+a))
+    ustar = (b - prmin + plmin)/(c - SIGN(dd, umax-umin))
+    if (((ustar-umin) <= 0.0) and ((ustar-umax) >= 0.0)):
         pstar = 0.5 * (plmin+prmin + br*abs(ustar-umin)*(ustar-umin) -
                        bl*abs(ustar-umax)*(ustar-umax))
         pstar = max(pstar, 0.0)
@@ -455,21 +506,21 @@ def ducowicz(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
     c = 1./(bl + br)
 
     # Case C : ustar-umin >0, ustar-umax > 0
-    dd = sqrt( max(0.0, a-d) )
+    dd = sqrt(max(0.0, a-d))
     ustar = (b+dd)*c
-    if ( ((ustar-umin) >= 0) and ( (ustar-umax) >=0.0) ):
+    if (((ustar-umin) >= 0) and ((ustar-umax) >= 0.0)):
         pstar = 0.5 * (plmin+prmin + br*abs(ustar-umin)*(ustar-umin)
-                       -bl*abs(ustar-umax)*(ustar-umax))
+                       - bl*abs(ustar-umax)*(ustar-umax))
         pstar = max(pstar, 0.0)
         result[0] = pstar
         result[1] = ustar
         return 0
 
     # Case D: ustar - umin < 0, ustar - umax < 0
-    dd = sqrt( max(0.0, -a-d) )
+    dd = sqrt(max(0.0, -a - d))
     ustar = (b-dd)*c
     pstar = 0.5 * (plmin+prmin + br*abs(ustar-umin)*(ustar-umin)
-                   -bl*abs(ustar-umax)*(ustar-umax))
+                   - bl*abs(ustar-umax)*(ustar-umax))
     pstar = max(pstar, 0.0)
     result[0] = pstar
     result[1] = ustar
@@ -513,18 +564,18 @@ def roe(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
     ulr = (rrhol*ul + rrhor*ur) * denominator
 
     # average sound speed at the interface
-    cslr = sqrt( gamma * plr/vlr )
+    cslr = sqrt(gamma * plr/vlr)
     cslr1 = 1./cslr
 
     # the intermediate states
-    result[0] = plr  - 0.5 * (ur - ul) * cslr
-    result[1] = ulr  - 0.5 * (pr - pl) * cslr1
+    result[0] = plr - 0.5 * (ur - ul) * cslr
+    result[1] = ulr - 0.5 * (pr - pl) * cslr1
 
     return 0
 
 
 def llxf(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
-        gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
+         gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
     """Lax Friedrichs approximate Riemann solver for the Euler equations to
     determine the intermediate states.
 
@@ -551,9 +602,9 @@ def llxf(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
     gamma1 = 1./(gamma - 1.0)
 
     # Lagrangian sound speeds
-    csl = sqrt( gamma * pl * rhol )
-    csr = sqrt( gamma * pr * rhor )
-    cslr = max( csr, csl )
+    csl = sqrt(gamma * pl * rhol)
+    csr = sqrt(gamma * pr * rhor)
+    cslr = max(csr, csl)
 
     # Total energy on either side
     el = pl*gamma1/rhol
@@ -563,15 +614,15 @@ def llxf(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
     Er = er + 0.5 * ur*ur
 
     # the intermediate states
-    #cdef double ustar = 0.5 * ( ul + ur - 1./cslr * (pr - pl) ) # roe's average
-    pstar = 0.5 * ( pl + pr - cslr * (ur - ul) )
+    # cdef double ustar = 0.5 * ( ul + ur - 1./cslr * (pr - pl) )
+    pstar = 0.5 * (pl + pr - cslr * (ur - ul))
     result[0] = pstar
-    result[1] = 1./pstar * (0.5 * ( (pl*ul + pr*ur) - cslr*(Er - El) ))
+    result[1] = 1./pstar * (0.5 * ((pl*ul + pr*ur) - cslr*(Er - El)))
     return 0
 
 
 def hllc(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
-        gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
+         gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
     """Harten-Lax-van Leer-Contact approximate Riemann solver for the Euler
     equations to determine the intermediate states.
 
@@ -607,8 +658,8 @@ def hllc(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
     vr = ur - ulr
 
     # Sound speeds at the interface
-    csl = sqrt( gamma * pl/rhol )
-    csr = sqrt( gamma * pr/rhor )
+    csl = sqrt(gamma * pl/rhol)
+    csr = sqrt(gamma * pr/rhor)
     cslr = (rrhol*csl + rrhor*csr)/(rrhol + rrhor)
 
     # wave speed estimates at the interface
@@ -616,46 +667,48 @@ def hllc(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
     sr = max(vr + csr, 0 + cslr)
 
     sm = rhor*vr*(sr-vr) - rhol*vl*(sl-vl) + pl - pr
-    sm /= ( rhor*(sr-vr) - rhol*(sl-vl) )
+    sm /= (rhor*(sr-vr) - rhol*(sl-vl))
 
     # phat
     phat = rhol*(vl - sl)*(vl - sm) + pl
 
     # Total energy on either side
     el = pl*gamma1/rhol
-    El = rhol*(el + 0.5 * ul*ul )
+    El = rhol*(el + 0.5 * ul*ul)
 
     er = pr*gamma1/rhor
-    Er = rhor*(er + 0.5 * ur*ur )
+    Er = rhor*(er + 0.5 * ur*ur)
 
     # Momentum on either side
     Ml = rhol*ul
     Mr = rhor*ur
 
     # compute the values based on the wave speeds
-    if ( sl > 0 ):
-        pstar = pl; ustar = ul
+    if (sl > 0):
+        pstar = pl
+        ustar = ul
 
-    elif ( sl <= 0.0 < sm ):
-        mstar = 1./(sl - sm) * ( (sl - vl) * Ml + (phat - pl) )
-        estar = 1./(sl - sm) * ( (sl - vl) * El - pl*vl + phat*sm )
-
-        pstar = sm*mstar + phat
-
-        ustar = sm*estar + (sm + ulr)*phat
-        ustar /= pstar
-
-    elif ( sm <= 0 < sr ):
-        mstar = 1./(sr - sm) * ( (sr - vr) * Mr + (phat - pr) )
-        estar = 1./(sr - sm) * ( (sr - vr) * Er - pr*vr + phat*sm )
+    elif (sl <= 0.0) and (0.0 < sm):
+        mstar = 1./(sl - sm) * ((sl - vl) * Ml + (phat - pl))
+        estar = 1./(sl - sm) * ((sl - vl) * El - pl*vl + phat*sm)
 
         pstar = sm*mstar + phat
 
         ustar = sm*estar + (sm + ulr)*phat
         ustar /= pstar
 
-    elif ( sr < 0 ):
-        pstar = pr; ustar = ur
+    elif (sm <= 0) and (0 < sr):
+        mstar = 1./(sr - sm) * ((sr - vr) * Mr + (phat - pr))
+        estar = 1./(sr - sm) * ((sr - vr) * Er - pr*vr + phat*sm)
+
+        pstar = sm*mstar + phat
+
+        ustar = sm*estar + (sm + ulr)*phat
+        ustar /= pstar
+
+    elif (sr < 0):
+        pstar = pr
+        ustar = ur
 
     else:
         msg = str((sl, sr, sm, csl, csr, rhol, rhor))
@@ -704,23 +757,24 @@ def hllc_ball(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
     rholr = 0.5 * (rhol + rhor)
 
     # provisional intermediate pressure
-    pstar = 0.5 * ( pl + pr - rholr*cslr*(ur - ul) )
+    pstar = 0.5 * (pl + pr - rholr*cslr*(ur - ul))
 
     # Wave speed estimates (ustar is taken as the intermediate velocity)
-    ustar = 0.5 * ( ul + ur - 1./(rholr*cslr)*(pr - pl) )
+    ustar = 0.5 * (ul + ur - 1./(rholr*cslr)*(pr - pl))
 
     Hl = pstar/pl
     Hr = pstar/pr
 
     ql = 1.0
-    if ( Hl > 1 ):
-        ql = sqrt( 1 + gamma1*(Hl - 1.0) )
+    if (Hl > 1):
+        ql = sqrt(1 + gamma1*(Hl - 1.0))
 
     qr = 1.0
-    if ( Hr > 1 ):
-        qr = sqrt( 1 + gamma1*(Hr - 1.0) )
+    if (Hr > 1):
+        qr = sqrt(1 + gamma1*(Hr - 1.0))
 
-    Sl = ul - csl*ql; Sr = ur + csr*qr
+    Sl = ul - csl*ql
+    Sr = ur + csr*qr
 
     # compute the intermediate pressure
     pstar_l = pl + rhol*(ul - Sl)*(ul - ustar)
@@ -762,21 +816,21 @@ def hlle(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
     # Roe-averaged interface velocity
     rrhol = sqrt(rhol)
     rrhor = sqrt(rhor)
-    ulr = (rrhol*ul + rrhor*ur)/(rrhol + rrhor)
+    # ulr = (rrhol*ul + rrhor*ur)/(rrhol + rrhor)
 
     # lagrangian sound speeds
-    csl = sqrt( gamma * pl * rhol )
-    csr = sqrt( gamma * pr * rhor )
+    csl = sqrt(gamma * pl * rhol)
+    csr = sqrt(gamma * pr * rhor)
     cslr = (rrhol*csl + rrhor*csr)/(rrhol + rrhor)
 
     # wave speed estimates
     sl = min(ul - csl, -cslr)
     sr = max(ur + csr, +cslr)
 
-    smax = max( sl, sr )
-    smin = min( sl, sr )
-    #cdef double smax = max( (ur-ulr) + csr,  cslr )
-    #cdef double smin = max( (ul-ulr) - csl, -cslr )
+    smax = max(sl, sr)
+    smin = min(sl, sr)
+    # cdef double smax = max( (ur-ulr) + csr,  cslr )
+    # cdef double smin = max( (ul-ulr) - csl, -cslr )
 
     # Total energy on either side
     el = pl*gamma1/rhol
@@ -786,8 +840,8 @@ def hlle(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
     Er = er + 0.5 * ur*ur
 
     # Momentum on either side
-    Ml = rhol*ul
-    Mr = rhor*ur
+    # Ml = rhol*ul
+    # Mr = rhor*ur
 
     # the intermediate states
     pstar = ((smax * pl - smin * pr)/(smax - smin) +
@@ -830,25 +884,26 @@ def hll_ball(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
     denominator = 1./(rrhor + rrhol)
 
     # sound speeds
-    csl = sqrt( gamma * pl/rhol )
-    csr = sqrt( gamma * pr/rhor )
+    csl = sqrt(gamma * pl/rhol)
+    csr = sqrt(gamma * pr/rhor)
     # cslr2 = denominator * (rrhol*csl*csl + rrhor*csr*csr )
     eta = 0.5 * (gamma - 1.0) * (rrhor*rrhol) * denominator * denominator
-    betal = abs( ul )
-    betar = abs( ur )
+    betal = abs(ul)
+    betar = abs(ur)
 
     # averaged velocity and cs2
-    ulr = ( rrhol*ul + rrhor*ur )/( rrhol*rrhor )
-    cslr2 = ( rrhol*csl*csl + rrhor*csr*csr )/( rrhol*rrhor )
-    cslr = sqrt( cslr2 + eta * (betar - betal) * (betar - betal) )
+    ulr = (rrhol*ul + rrhor*ur)/(rrhol*rrhor)
+    cslr2 = (rrhol*csl*csl + rrhor*csr*csr)/(rrhol*rrhor)
+    cslr = sqrt(cslr2 + eta * (betar - betal) * (betar - betal))
 
     # wave speed estimates
-    Sl = min( ulr - cslr, ul - csl )
-    Sr = max( ulr + cslr, ur + csr )
+    Sl = min(ulr - cslr, ul - csl)
+    Sr = max(ulr + cslr, ur + csr)
 
     # intermediate states
-    rhostar = 1./(Sr - Sl) * ( rhor*(Sr-ur) - rhol*(Sl-ul) )
-    ustar = (Sr*Sl*(rhor-rhol) + rhol*ul*Sr - rhor*ur*Sl)/(rhol*(ul-Sl) + rhor*(Sr-ur))
+    # rhostar = 1./(Sr - Sl) * (rhor*(Sr-ur) - rhol*(Sl-ul))
+    ustar = ((Sr*Sl*(rhor-rhol) + rhol*ul*Sr - rhor*ur*Sl) /
+             (rhol*(ul-Sl) + rhor*(Sr-ur)))
     # pstar = 0.5 * (pl + pr - rhostar*ustar*( (Sr-ustar) + (Sl-ustar) ) + \
     #                                rhor*ur*(ur - Sr) + rhol*ul*(ul-Sl) )
     pstar = (pr*(ustar-Sl) - pl*(ustar-Sr) +
@@ -862,7 +917,7 @@ def hll_ball(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
 
 
 def hllsy(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
-             gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
+          gamma=1.4, niter=20, tol=1e-6, result=[0.0, 0.0]):
     """HLL Riemann solver defined by Sirotkin and Yoh in 'A Smoothed Particle
     Hydrodynamics method with approximate Riemann solvers for simulation of
     strong explosions' (2013), Computers and Fluids.
@@ -894,9 +949,9 @@ def hllsy(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
     denominator = 1./(rrhor + rrhol)
 
     # Lagrangian sound speed Eq. (35) in SY13
-    csl = sqrt( gamma * pl*rhol )
-    csr = sqrt( gamma * pr*rhor )
-    cslr = denominator * (rrhol*csl + rrhor*csr )
+    csl = sqrt(gamma * pl*rhol)
+    csr = sqrt(gamma * pr*rhor)
+    cslr = denominator * (rrhol*csl + rrhor*csr)
 
     # weighting factors Eqs. (33 - 35) in SY13
     bl = max(csl, cslr)
@@ -918,3 +973,11 @@ def hllsy(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
     result[0] = pstar
     result[1] = ustar/pstar
     return 0
+
+
+HELPERS = [
+    SIGN, printf, riemann_solve, non_diffusive,
+    ducowicz, exact, hll_ball, hllc,
+    hllc_ball, hlle, hllsy, llxf, roe,
+    van_leer
+]

--- a/pysph/sph/integrator_step.py
+++ b/pysph/sph/integrator_step.py
@@ -428,7 +428,25 @@ class GasDFluidStep(IntegratorStep):
         d_alpha2[d_idx] = d_alpha20[d_idx] + dt*d_aalpha2[d_idx]
 
 
+class GSPHStep(IntegratorStep):
 
+    def stage1(self, d_idx, d_x, d_y, d_z, d_u, d_v, d_w, d_e,
+               d_au, d_av, d_aw, d_ae, dt):
+        dtb2 = dt*0.5
+        ustar = d_u[d_idx] + dtb2*d_au[d_idx]
+        vstar = d_v[d_idx] + dtb2*d_av[d_idx]
+        wstar = d_w[d_idx] + dtb2*d_aw[d_idx]
+
+        d_u[d_idx] += dt*d_au[d_idx]
+        d_v[d_idx] += dt*d_av[d_idx]
+        d_w[d_idx] += dt*d_aw[d_idx]
+        d_e[d_idx] += dt*(d_ae[d_idx]
+                          - ustar*d_au[d_idx]
+                          - vstar*d_av[d_idx]
+                          - wstar*d_aw[d_idx])
+        d_x[d_idx] += dt*ustar
+        d_y[d_idx] += dt*vstar
+        d_z[d_idx] += dt*wstar
 
 
 class ADKEStep(IntegratorStep):

--- a/pysph/sph/tests/test_riemann_solver.py
+++ b/pysph/sph/tests/test_riemann_solver.py
@@ -1,0 +1,98 @@
+from pytest import approx
+
+import pysph.sph.gas_dynamics.riemann_solver as R
+
+solvers = [
+    R.ducowicz, R.exact, R.hll_ball, R.hllc,
+    R.hllc_ball, R.hlle, R.hllsy, R.llxf, R.roe,
+    R.van_leer
+]
+
+
+def _check_shock_tube(solver, **approx_kw):
+    # Given
+    # Shock tube
+    gamma = 1.4
+    rhol, pl, ul = 1.0, 1.0, 0.0
+    rhor, pr, ur = 0.125, 0.1, 0.0
+
+    result = [0.0, 0.0]
+    # When
+    solver(rhol, rhor, pl, pr, ul, ur, gamma, niter=20,
+           tol=1e-6, result=result)
+
+    # Then
+    assert result == approx((0.30313, 0.92745), **approx_kw)
+
+
+def _check_blastwave(solver, **approx_kw):
+    # Given
+    gamma = 1.4
+    result = [0.0, 0.0]
+    rhol, pl, ul = 1.0, 1000.0, 0.0
+    rhor, pr, ur = 1.0, 0.01, 0.0
+
+    # When
+    solver(rhol, rhor, pl, pr, ul, ur, gamma, niter=20,
+           tol=1e-6, result=result)
+
+    # Then
+    assert result == approx((460.894, 19.5975), **approx_kw)
+
+
+def _check_sjogreen(solver, **approx_kw):
+    # Given
+    gamma = 1.4
+    result = [0.0, 0.0]
+    rhol, pl, ul = 1.0, 0.4, -2.0
+    rhor, pr, ur = 1.0, 0.4, 2.0
+
+    # When
+    solver(rhol, rhor, pl, pr, ul, ur, gamma, niter=20,
+           tol=1e-6, result=result)
+
+    # Then
+    assert result == approx((0.0018938, 0.0), **approx_kw)
+
+
+def _check_woodward_collela(solver, **approx_kw):
+    # Given
+    gamma = 1.4
+    result = [0.0, 0.0]
+    rhol, pl, ul = 1.0, 0.01, 0.0
+    rhor, pr, ur = 1.0, 100.0, 0.0
+
+    # When
+    solver(rhol, rhor, pl, pr, ul, ur, gamma, niter=20,
+           tol=1e-6, result=result)
+
+    # Then
+    assert result == approx((46.0950, -6.19633), **approx_kw)
+
+
+def test_exact_riemann():
+    solver = R.exact
+
+    _check_shock_tube(solver, rel=1e-4)
+    _check_blastwave(solver, rel=1e-4)
+    _check_sjogreen(solver, abs=1e-4)
+    _check_woodward_collela(solver, rel=1e-4)
+
+
+def test_van_leer():
+    solver = R.van_leer
+    _check_shock_tube(solver, rel=1e-3)
+    _check_blastwave(solver, rel=1e-2)
+    _check_sjogreen(solver, abs=1e-2)
+    _check_woodward_collela(solver, rel=1e-2)
+
+
+def test_ducowicz():
+    solver = R.ducowicz
+    _check_shock_tube(solver, rel=0.2)
+    _check_blastwave(solver, rel=0.4)
+    _check_sjogreen(solver, abs=1e-2)
+    _check_woodward_collela(solver, rel=0.4)
+
+
+# Most other solvers seem rather poor in comparison.

--- a/pysph/sph/tests/test_riemann_solver.py
+++ b/pysph/sph/tests/test_riemann_solver.py
@@ -1,3 +1,4 @@
+import pytest
 from pytest import approx
 
 import pysph.sph.gas_dynamics.riemann_solver as R
@@ -96,3 +97,10 @@ def test_ducowicz():
 
 
 # Most other solvers seem rather poor in comparison.
+@pytest.mark.parametrize("solver", solvers)
+def test_all_solver_api(solver):
+    if solver.__name__ in ['roe', 'hllc']:
+        rel = 2.0
+    else:
+        rel = 1.0
+    _check_shock_tube(solver, rel=rel)


### PR DESCRIPTION
This adds several things:
- Adds around 11 different Riemann solvers including the exact to pysph such that it should work out of the box as well as 10 other approximate Riemann solvers.  This can be used for other things too.
- Adds the GSPH scheme with a suitable scheme/stepper etc.
- Updated the sod shocktube example to work with GSPH.
- This ports the most difficult scheme from sph2d to pysph.