### PR TITLE
BUG: Ensure that order of equations is preserved.

### DIFF
--- a/pysph/sph/acceleration_eval.py
+++ b/pysph/sph/acceleration_eval.py
@@ -86,6 +86,10 @@ class MegaGroup(object):
         all_eqs is a Group of all equations having this destination.
 
     This is what is stored in the `data` attribute.
+
+    Note that the order of the equations in all_eqs, eqs_with_no_source and
+    sources should honor the order in which the user defines them in the
+    original group.
     """
     def __init__(self, group, group_cls):
         self._orig_group = group
@@ -117,11 +121,12 @@ class MegaGroup(object):
         for dest in dest_list:
             sources = defaultdict(list)
             eqs_with_no_source = []
-            all_eqs = set()
+            all_equations = []
             for equation in equations:
                 if equation.dest != dest:
                     continue
-                all_eqs.add(equation)
+                if equation not in all_equations:
+                    all_equations.append(equation)
                 if equation.no_source:
                     eqs_with_no_source.append(equation)
                 else:
@@ -132,10 +137,6 @@ class MegaGroup(object):
                 eqs = sources[src]
                 sources[src] = self.Group(eqs)
 
-            # Sort the all_eqs set; so the order is deterministic.  Without
-            # this a  user may get a recompilation for no obvious reason.
-            all_equations = list(all_eqs)
-            all_equations.sort(key=lambda x: x.__class__.__name__)
             dests[dest] = (self.Group(eqs_with_no_source), sources,
                            self.Group(all_equations))
 

--- a/pysph/sph/tests/test_acceleration_eval.py
+++ b/pysph/sph/tests/test_acceleration_eval.py
@@ -229,7 +229,7 @@ class TestMegaGroup(unittest.TestCase):
         expect = ['SimpleEquation', 'DummyEquation', 'MixedTypeEquation']
         self.assertEqual(all_eqs_order, expect)
 
-        self.assertEqual(list(sources.keys()), ['s', 'f'])
+        self.assertEqual(sorted(sources.keys()), ['f', 's'])
         s_eqs = [x.__class__.__name__ for x in sources['s'].equations]
         expect = ['SimpleEquation', 'DummyEquation']
         self.assertEqual(s_eqs, expect)

--- a/pysph/sph/tests/test_acceleration_eval.py
+++ b/pysph/sph/tests/test_acceleration_eval.py
@@ -14,8 +14,10 @@ from pysph.base.config import get_config
 from pysph.base.utils import get_particle_array
 from pysph.base.cython_generator import declare
 from pysph.sph.equation import Equation, Group
-from pysph.sph.acceleration_eval import (AccelerationEval,
-                                         check_equation_array_properties)
+from pysph.sph.acceleration_eval import (
+    AccelerationEval, MegaGroup, CythonGroup,
+    check_equation_array_properties
+)
 from pysph.sph.basic_equations import SummationDensity
 from pysph.base.kernels import CubicSpline
 from pysph.base.nnps import LinkedListNNPS as NNPS
@@ -200,9 +202,41 @@ class LoopAllEquation(Equation):
         for i in range(N_NBRS):
             s_idx = NBRS[i]
             xij[0] = d_x[d_idx] - s_x[s_idx]
-            rij = fabs(xij[0])
+            rij = abs(xij[0])
             sum += s_m[s_idx]*KERNEL.kernel(xij, rij, s_h[s_idx])
         d_rho[d_idx] += sum
+
+
+class TestMegaGroup(unittest.TestCase):
+    def test_ensure_group_retains_user_order_of_equations(self):
+        # Given
+        group = Group(equations=[
+            SimpleEquation(dest='f', sources=['s', 'f']),
+            DummyEquation(dest='f', sources=['s', 'f']),
+            MixedTypeEquation(dest='f', sources=['f']),
+        ])
+
+        # When
+        mg = MegaGroup(group, CythonGroup)
+
+        # Then
+        data = mg.data
+        self.assertEqual(list(data.keys()), ['f'])
+        eqs_with_no_source, sources, all_eqs = data['f']
+        self.assertEqual(len(eqs_with_no_source.equations), 0)
+
+        all_eqs_order = [x.__class__.__name__ for x in all_eqs.equations]
+        expect = ['SimpleEquation', 'DummyEquation', 'MixedTypeEquation']
+        self.assertEqual(all_eqs_order, expect)
+
+        self.assertEqual(list(sources.keys()), ['s', 'f'])
+        s_eqs = [x.__class__.__name__ for x in sources['s'].equations]
+        expect = ['SimpleEquation', 'DummyEquation']
+        self.assertEqual(s_eqs, expect)
+
+        f_eqs = [x.__class__.__name__ for x in sources['f'].equations]
+        expect = ['SimpleEquation', 'DummyEquation', 'MixedTypeEquation']
+        self.assertEqual(f_eqs, expect)
 
 
 class TestAccelerationEval1D(unittest.TestCase):


### PR DESCRIPTION
Currently this was preserved for the loops but not for the
initialize/post_loop/reduce etc.  This is technically a problem as we
are supposed to guarantee the order.  In practice this does not matter
usually but some equations have dependencies where this is critical.  We
now ensure that everything is called strictly in the order in which it
is defined.  Thanks to Dileep Menon for spotting this issue.