### PR TITLE
Py3 annotations

### DIFF
--- a/pysph/cpy/ast_utils.py
+++ b/pysph/cpy/ast_utils.py
@@ -88,7 +88,8 @@ class SymbolParser(ast.NodeVisitor):
                 self.funcargs.add(node.args.kwarg.arg)
             if node.args.kwonlyargs:
                 self.funcargs.update(x.arg for x in node.args.kwonlyargs)
-        self.generic_visit(node)
+        for arg in node.body:
+            self.visit(arg)
 
 
 def _get_tree(code):

--- a/pysph/cpy/cython_generator.py
+++ b/pysph/cpy/cython_generator.py
@@ -89,7 +89,7 @@ def get_func_definition(sourcelines):
     # For now return the line after the first.
     count = 1
     for line in sourcelines:
-        if line.rstrip().endswith('):'):
+        if line.rstrip().endswith(':'):
             break
         count += 1
     return sourcelines[:count], sourcelines[count:]

--- a/pysph/cpy/tests/py3_code.py
+++ b/pysph/cpy/tests/py3_code.py
@@ -1,0 +1,9 @@
+# Python3 specific code for some tests.
+
+from pysph.cpy.types import int_, declare
+
+
+def py3_f(x: int_) -> int_:
+    y = declare('int')
+    y = x + 1
+    return x*y

--- a/pysph/cpy/tests/test_ast_utils.py
+++ b/pysph/cpy/tests/test_ast_utils.py
@@ -1,5 +1,6 @@
 
 import ast
+import sys
 from textwrap import dedent
 import unittest
 
@@ -94,6 +95,28 @@ class TestASTUtils(unittest.TestCase):
         # Then.
         e_names = {'SIZE', 'i', 'JUNK'}
         e_calls = {'g', 'h', 'range', 'func', 'sin'}
+        self.assertSetEqual(names, e_names)
+        self.assertSetEqual(calls, e_calls)
+
+    @unittest.skipIf(sys.version_info < (3, 4),
+                     reason='Test requires Python 3.')
+    def test_get_unknown_names_and_calls_with_py3_annotation(self):
+        code = dedent('''
+        from pysph.cpy import types as T
+
+        def f(x: T.doublep, n: T.int_)-> T.double:
+            s = declare('double')
+            for i in range(n):
+                s += func(x)
+            return s
+        ''')
+
+        # When
+        names, calls = get_unknown_names_and_calls(code)
+
+        # Then.
+        e_names = {'i'}
+        e_calls = {'declare', 'func', 'range'}
         self.assertSetEqual(names, e_names)
         self.assertSetEqual(calls, e_calls)
 

--- a/pysph/cpy/tests/test_cython_generator.py
+++ b/pysph/cpy/tests/test_cython_generator.py
@@ -3,7 +3,8 @@
 import unittest
 from textwrap import dedent
 from math import pi, sin
-import numpy as np
+import sys
+
 
 from ..config import get_config, set_config
 from ..types import declare, KnownType, annotate
@@ -170,6 +171,22 @@ class TestCythonCodeGenerator(TestBase):
         cdef inline float annotated_f(int i, float* y):
             cdef unsigned int x[64]
             return y[i]
+        ''')
+        self.assert_code_equal(cg.get_code().strip(), expect.strip())
+
+    @unittest.skipIf(sys.version_info < (3, 4), reason='Requires Python3.')
+    def test_python3_annotation(self):
+        # Given
+        from .py3_code import py3_f
+        cg = CythonGenerator()
+
+        # When
+        cg.parse(py3_f)
+        expect = dedent('''
+        cdef inline int py3_f(int x):
+            cdef int y
+            y = x + 1
+            return x*y
         ''')
         self.assert_code_equal(cg.get_code().strip(), expect.strip())
 

--- a/pysph/cpy/tests/test_translator.py
+++ b/pysph/cpy/tests/test_translator.py
@@ -1,6 +1,7 @@
 from textwrap import dedent
 import pytest
 import numpy as np
+import sys
 
 from ..config import get_config
 from ..types import annotate, declare
@@ -391,6 +392,25 @@ def test_annotated_function():
     {
         LOCAL_MEM double x[64];
         return y[i];
+    }
+    ''')
+    assert code.strip() == expect.strip()
+
+
+@pytest.mark.skipIf(sys.version_info < (3, 4), reason='Requires Python3')
+def test_py3_annotations():
+    # Given/When
+    from .py3_code import py3_f
+    t = CConverter()
+    code = t.parse_function(py3_f)
+
+    # Then
+    expect = dedent('''
+    int py3_f(int x)
+    {
+        int y;
+        y = (x + 1);
+        return (x * y);
     }
     ''')
     assert code.strip() == expect.strip()

--- a/pysph/cpy/tests/test_translator.py
+++ b/pysph/cpy/tests/test_translator.py
@@ -397,7 +397,7 @@ def test_annotated_function():
     assert code.strip() == expect.strip()
 
 
-@pytest.mark.skipIf(sys.version_info < (3, 4), reason='Requires Python3')
+@pytest.mark.skipif(sys.version_info < (3, 4), reason='Requires Python3')
 def test_py3_annotations():
     # Given/When
     from .py3_code import py3_f

--- a/pysph/cpy/types.py
+++ b/pysph/cpy/types.py
@@ -103,7 +103,10 @@ class KnownType(object):
         self.base_type = base_type
 
     def __repr__(self):
-        return 'KnownType("%s")' % self.type
+        if self.base_type:
+            return 'KnownType("%s", "%s")' % (self.type, self.base_type)
+        else:
+            return 'KnownType("%s")' % self.type
 
     def __eq__(self, other):
         return self.type == other.type and self.base_type == other.base_type
@@ -138,6 +141,18 @@ TYPES = dict(
     luintp=KnownType('LOCAL_MEM unsigned int*', 'unsigned int'),
     lulongp=KnownType('LOCAL_MEM unsigned long*', 'unsigned long'),
 )
+
+
+def _inject_types_in_module():
+    g = globals()
+    for name, type in TYPES.items():
+        if name in ['int', 'long', 'float']:
+            name = name + '_'
+        g[name] = type
+
+
+# A convenience so users can import types directly from the module.
+_inject_types_in_module()
 
 
 NP_C_TYPE_MAP = {

--- a/pysph/cpy/types.py
+++ b/pysph/cpy/types.py
@@ -156,7 +156,7 @@ _inject_types_in_module()
 
 
 NP_C_TYPE_MAP = {
-    np.bool: 'bint',
+    np.bool: 'char',
     np.float32: 'float', np.float64: 'double',
     np.int8: 'char', np.uint8: 'unsigned char',
     np.int16: 'short', np.uint16: 'unsigned short',
@@ -165,7 +165,7 @@ NP_C_TYPE_MAP = {
 }
 
 C_NP_TYPE_MAP = {
-    'bint': np.bool,
+    'bool': np.bool,
     'char': np.int8,
     'double': np.float64,
     'float': np.float32,


### PR DESCRIPTION
This is entirely optional but at least we support the basic annotations.
Variable annotations are NOT supported, use `declare` instead.  I've
also exposed the basic types in the types module namespace to make it
easy to use the declared types.