### PR TITLE
Fix typo in Cython acceleration eval directory.

### DIFF
--- a/pysph/cpy/cython_generator.py
+++ b/pysph/cpy/cython_generator.py
@@ -166,7 +166,8 @@ class CythonGenerator(object):
         if name in ['s_idx', 'd_idx']:
             return 'long'
         if value is Undefined or isinstance(value, Undefined):
-            raise CodeGenerationError('Unknown type, for %s' % name)
+            msg = 'Unknown type, for function argument named: %s' % name
+            raise CodeGenerationError(msg)
 
         if isinstance(value, bool):
             return 'int'

--- a/pysph/sph/acceleration_eval_cython_helper.py
+++ b/pysph/sph/acceleration_eval_cython_helper.py
@@ -142,7 +142,7 @@ class AccelerationEvalCythonHelper(object):
     def compile(self, code):
         # Note, we do not add carray or particle_array as nnps_base would
         # have been rebuilt anyway if they changed.
-        root = expanduser(join('~', '.pypsh', 'source', get_platform_dir()))
+        root = expanduser(join('~', '.pysph', 'source', get_platform_dir()))
         depends = ["pysph.base.nnps_base"]
         # Add pysph/base directory to inc_dirs for including spatial_hash.h
         # for SpatialHashNNPS


### PR DESCRIPTION
We were placing the extensions into ~/.pypsh instead of ~/.pysph.  Also
improve an error message.