### PR TITLE
API: Change KERNEL in equations to SPH_KERNEL.

### DIFF
--- a/docs/source/design/equations.rst
+++ b/docs/source/design/equations.rst
@@ -172,10 +172,11 @@ equation:
 
     - ``EPS = 0.01 * HIJ * HIJ``
 
-    - ``KERNEL``: the kernel being used and one can call the kernel as
-      ``KERNEL.kernel(xij, rij, h)`` the gradient as ``KERNEL.gradient(...)``,
-      ``KERNEL.gradient_h(...)`` etc. The kernel is any one of the instances
-      of the kernel classes defined in :py:mod:`pysph.base.kernels`
+    - ``SPH_KERNEL``: the kernel being used and one can call the kernel as
+      ``SPH_KERNEL.kernel(xij, rij, h)`` the gradient as
+      ``SPH_KERNEL.gradient(...)``, ``SPH_KERNEL.gradient_h(...)`` etc. The
+      kernel is any one of the instances of the kernel classes defined in
+      :py:mod:`pysph.base.kernels`
 
 In addition if one requires the current time or the timestep in an equation,
 the following may be passed into any of the methods of an equation:
@@ -312,7 +313,7 @@ perform what the ``loop`` method usually does ourselves.
 
        def loop_all(self, d_idx, d_x, d_y, d_z, d_rho, d_h,
                     s_m, s_x, s_y, s_z, s_h,
-                    KERNEL, NBRS, N_NBRS):
+                    SPH_KERNEL, NBRS, N_NBRS):
            i = declare('int')
            s_idx = declare('long')
            xij = declare('matrix(3)')
@@ -324,7 +325,7 @@ perform what the ``loop`` method usually does ourselves.
                xij[1] = d_y[d_idx] - s_y[s_idx]
                xij[2] = d_z[d_idx] - s_z[s_idx]
                rij = sqrt(xij[0]*xij[0], xij[1]*xij[1], xij[2]*xij[2])
-               sum += s_m[s_idx]*KERNEL.kernel(xij, rij, 0.5*(s_h[s_idx] + d_h[d_idx]))
+               sum += s_m[s_idx]*SPH_KERNEL.kernel(xij, rij, 0.5*(s_h[s_idx] + d_h[d_idx]))
            d_rho[d_idx] += sum
 
 This seems a bit complex but let us look at what is being done. ``initialize``
@@ -332,14 +333,14 @@ is called once per particle and each of their densities is set to zero. Then
 when ``loop_all`` is called it is called once per destination particle (unlike
 ``loop`` which is called pairwise for each destination and source particle).
 The ``loop_all`` is passed arrays as is typical of most equations but is also
-passed the ``KERNEL`` itself, the list of neighbors, and the number of
+passed the ``SPH_KERNEL`` itself, the list of neighbors, and the number of
 neighbors.
 
 The code first declares the variables, ``i, s_idx`` as an integer and long,
 and then ``x_ij`` as a 3-element array. These are important for performance in
 the generated code. The code then loops over all neighbors and computes the
 summation density. Notice how the kernel is computed using
-``KERNEL.kernel(...)``. Notice also how the source index, ``s_idx`` is found
+``SPH_KERNEL.kernel(...)``. Notice also how the source index, ``s_idx`` is found
 from the neighbors.
 
 This above ``loop_all`` code does exactly what the following single line of

--- a/pysph/base/z_order_gpu_nnps.pyx
+++ b/pysph/base/z_order_gpu_nnps.pyx
@@ -116,7 +116,6 @@ cdef class ZOrderGPUNNPS(GPUNNPS):
         (sorted_indices, sorted_keys), evnt = self.radix_sort(
             self.pids[pa_index].array, self.pid_keys[pa_index].array, key_bits=64
         )
-        profile("radix_sort", evnt)
         self.pids[pa_index].set_data(sorted_indices)
         self.pid_keys[pa_index].set_data(sorted_keys)
 
@@ -254,4 +253,3 @@ cdef class ZOrderGPUNNPS(GPUNNPS):
                 self.cid_to_idx[self.src_index].array,
                 self.overflow_cid_to_idx.array, self.dst_to_src.array,
                 start_indices, nbrs, self.radius_scale2, self.cell_size)
-

--- a/pysph/sph/acceleration_eval_cython_helper.py
+++ b/pysph/sph/acceleration_eval_cython_helper.py
@@ -193,7 +193,7 @@ class AccelerationEvalCythonHelper(object):
         headers.append(cg.get_code())
 
         # Equation wrappers.
-        self.known_types['KERNEL'] = KnownType(
+        self.known_types['SPH_KERNEL'] = KnownType(
             object.kernel.__class__.__name__
         )
         headers.append(object.all_group.get_equation_wrappers(

--- a/pysph/sph/acceleration_eval_opencl_helper.py
+++ b/pysph/sph/acceleration_eval_opencl_helper.py
@@ -418,7 +418,7 @@ class AccelerationEvalOpenCLHelper(object):
         headers.append(transpiler.parse_instance(object.kernel))
 
         cls_name = object.kernel.__class__.__name__
-        self.known_types['KERNEL'] = KnownType(
+        self.known_types['SPH_KERNEL'] = KnownType(
             '__global %s*' % cls_name, base_type=cls_name
         )
         headers.append(object.all_group.get_equation_wrappers(
@@ -463,7 +463,7 @@ class AccelerationEvalOpenCLHelper(object):
         sph_k_name = self.object.kernel.__class__.__name__
         code = [
             'int d_idx = get_global_id(0);'
-            '__global %s* KERNEL = kern;' % sph_k_name
+            '__global %s* SPH_KERNEL = kern;' % sph_k_name
         ]
         all_args, py_args, _calls = self._get_equation_method_calls(
             all_eqs, kind, indent=''
@@ -594,7 +594,7 @@ class AccelerationEvalOpenCLHelper(object):
         code = self._declare_precomp_vars(context)
         code.append('unsigned int d_idx = get_global_id(0);')
         code.append('unsigned int s_idx, i;')
-        code.append('__global %s* KERNEL = kern;' % sph_k_name)
+        code.append('__global %s* SPH_KERNEL = kern;' % sph_k_name)
         code.append('unsigned int start = start_idx[d_idx];')
         code.append('__global unsigned int* NBRS = &(neighbors[start]);')
         code.append('int N_NBRS = nbr_length[d_idx];')

--- a/pysph/sph/equation.py
+++ b/pysph/sph/equation.py
@@ -660,8 +660,8 @@ class CythonGroup(Group):
                 args = inspect.getargspec(meth).args
                 if 'self' in args:
                     args.remove('self')
-                if 'KERNEL' in args:
-                    args[args.index('KERNEL')] = 'self.kernel'
+                if 'SPH_KERNEL' in args:
+                    args[args.index('SPH_KERNEL')] = 'self.kernel'
                 if kind == 'reduce':
                     args = ['dst.array', 't', 'dt']
                 call_args = ', '.join(args)

--- a/pysph/sph/tests/test_acceleration_eval.py
+++ b/pysph/sph/tests/test_acceleration_eval.py
@@ -191,7 +191,8 @@ class LoopAllEquation(Equation):
     def loop(self, d_idx, d_rho, s_m, s_idx, WIJ):
         d_rho[d_idx] += s_m[s_idx]*WIJ
 
-    def loop_all(self, d_idx, d_x, d_rho, s_m, s_x, s_h, KERNEL, NBRS, N_NBRS):
+    def loop_all(self, d_idx, d_x, d_rho, s_m, s_x, s_h, SPH_KERNEL, NBRS,
+                 N_NBRS):
         i = declare('int')
         s_idx = declare('long')
         xij = declare('matrix((3,))')
@@ -203,7 +204,7 @@ class LoopAllEquation(Equation):
             s_idx = NBRS[i]
             xij[0] = d_x[d_idx] - s_x[s_idx]
             rij = abs(xij[0])
-            sum += s_m[s_idx]*KERNEL.kernel(xij, rij, s_h[s_idx])
+            sum += s_m[s_idx]*SPH_KERNEL.kernel(xij, rij, s_h[s_idx])
         d_rho[d_idx] += sum
 
 

--- a/pysph/sph/wc/density_correction.py
+++ b/pysph/sph/wc/density_correction.py
@@ -83,7 +83,7 @@ class ShepardFilter(Equation):
         d_rhotmp[d_idx] = d_rho[d_idx]
 
     def loop_all(self, d_idx, d_rho, d_x, d_y, d_z, s_m, s_rhotmp, s_x, s_y,
-                 s_z, d_h, s_h, KERNEL, NBRS, N_NBRS):
+                 s_z, d_h, s_h, SPH_KERNEL, NBRS, N_NBRS):
         i, s_idx = declare('int', 2)
         xij = declare('matrix(3)')
         tmp_w = 0.0
@@ -98,7 +98,7 @@ class ShepardFilter(Equation):
             xij[2] = z - s_z[s_idx]
             rij = sqrt(xij[0] * xij[0] + xij[1] * xij[1] + xij[2] * xij[2])
             hij = (d_h[d_idx] + s_h[s_idx]) * 0.5
-            wij = KERNEL.kernel(xij, rij, hij)
+            wij = SPH_KERNEL.kernel(xij, rij, hij)
             tmp_w += wij * s_m[s_idx] / s_rhotmp[s_idx]
             d_rho[d_idx] += wij * s_m[s_idx]
         d_rho[d_idx] /= tmp_w
@@ -145,7 +145,7 @@ class MLSFirstOrder2D(Equation):
         d_rhotmp[d_idx] = d_rho[d_idx]
 
     def loop_all(self, d_idx, d_rho, d_x, d_y, s_x, s_y, d_h, s_h, s_m,
-                 s_rhotmp, KERNEL, NBRS, N_NBRS):
+                 s_rhotmp, SPH_KERNEL, NBRS, N_NBRS):
         n, i, j, k, s_idx = declare('int', 5)
         n = 3
         amls = declare('matrix(9)')
@@ -162,7 +162,7 @@ class MLSFirstOrder2D(Equation):
             xij[2] = 0.
             rij = sqrt(xij[0] * xij[0] + xij[1] * xij[1])
             hij = (d_h[d_idx] + s_h[s_idx]) * 0.5
-            wij = KERNEL.kernel(xij, rij, hij)
+            wij = SPH_KERNEL.kernel(xij, rij, hij)
             for i in range(n):
                 if i == 0:
                     fac1 = 1.0
@@ -188,7 +188,7 @@ class MLSFirstOrder2D(Equation):
             xij[2] = 0.
             rij = sqrt(xij[0] * xij[0] + xij[1] * xij[1])
             hij = (d_h[d_idx] + s_h[s_idx]) * 0.5
-            wij = KERNEL.kernel(xij, rij, hij)
+            wij = SPH_KERNEL.kernel(xij, rij, hij)
             wmls = (b0 + b1 * xij[0] + b2 * xij[1]) * wij
             d_rho[d_idx] += s_m[s_idx] * wmls
 
@@ -202,7 +202,7 @@ class MLSFirstOrder3D(Equation):
         d_rhotmp[d_idx] = d_rho[d_idx]
 
     def loop_all(self, d_idx, d_rho, d_x, d_y, d_z, s_x, s_y, s_z, d_h, s_h,
-                 s_m, s_rhotmp, KERNEL, NBRS, N_NBRS):
+                 s_m, s_rhotmp, SPH_KERNEL, NBRS, N_NBRS):
         n, i, j, k, s_idx = declare('int', 5)
         n = 4
         amls = declare('matrix(16)')
@@ -220,7 +220,7 @@ class MLSFirstOrder3D(Equation):
             xij[2] = z - s_z[s_idx]
             rij = sqrt(xij[0] * xij[0] + xij[1] * xij[1] + xij[2] * xij[2])
             hij = (d_h[d_idx] + s_h[s_idx]) * 0.5
-            wij = KERNEL.kernel(xij, rij, hij)
+            wij = SPH_KERNEL.kernel(xij, rij, hij)
             for i in range(n):
                 if i == 0:
                     fac1 = 1.0
@@ -247,6 +247,6 @@ class MLSFirstOrder3D(Equation):
             xij[2] = z - s_z[s_idx]
             rij = sqrt(xij[0] * xij[0] + xij[1] * xij[1] + xij[2] * xij[2])
             hij = (d_h[d_idx] + s_h[s_idx]) * 0.5
-            wij = KERNEL.kernel(xij, rij, hij)
+            wij = SPH_KERNEL.kernel(xij, rij, hij)
             wmls = (b0 + b1 * xij[0] + b2 * xij[1] + b3 * xij[2]) * wij
             d_rho[d_idx] += s_m[s_idx] * wmls


### PR DESCRIPTION
This is important as KERNEL is used in the CLUDA headers.  So we are
renaming the `KERNEL` argument passed to the `loop_all` and other
methods to be `SPH_KERNEL`.