### PR TITLE
Cython Scan

### DIFF
--- a/pysph/cpy/parallel.py
+++ b/pysph/cpy/parallel.py
@@ -694,7 +694,7 @@ class Scan(object):
         self.input_func = input
         self.output_func = output
         self.is_segment_func = is_segment
-        self.complex_map=complex_map
+        self.complex_map = complex_map
         if input is not None:
             self.name = 'scan_' + input.__name__
         else:

--- a/pysph/cpy/parallel.py
+++ b/pysph/cpy/parallel.py
@@ -163,10 +163,15 @@ cdef void c_${name}(${c_arg_sig}):
     cdef ${type} a, b, temp
     # This chunksize would divide input data equally
     # between threads
-    # cdef int chunksize = (SIZE + n_thread - 1) // n_thread
-
+    % if not calc_last_item:
     # A chunk of 1 MB per thread
     cdef int chunksize = 1048576 / sz
+    % else:
+    # Process all data together. Only then can we get
+    # the last item immediately
+    cdef int chunksize = (SIZE + n_thread - 1) // n_thread
+    % endif
+
     cdef int offset = 0
     cdef ${type} global_carry = ${neutral}
     cdef ${type} last_item

--- a/pysph/cpy/tests/test_low_level.py
+++ b/pysph/cpy/tests/test_low_level.py
@@ -13,15 +13,15 @@ from ..low_level import (
 
 
 class TestKernel(unittest.TestCase):
-
     def test_simple_kernel_opencl(self):
         importorskip('pyopencl')
+
         # Given
         @annotate(gdoublep='x, y', a='float')
         def knl(x, y, a):
             i = declare('int')
-            i = GID_0*LDIM_0 + LID_0
-            y[i] = x[i]*a
+            i = GID_0 * LDIM_0 + LID_0
+            y[i] = x[i] * a
 
         x = np.linspace(0, 1, 1000)
         y = np.zeros_like(x)
@@ -34,16 +34,17 @@ class TestKernel(unittest.TestCase):
 
         # Then
         y.pull()
-        self.assertTrue(np.allclose(y.data, x.data*a))
+        self.assertTrue(np.allclose(y.data, x.data * a))
 
     def test_simple_kernel_cuda(self):
         importorskip('pycuda')
+
         # Given
         @annotate(gdoublep='x, y', a='float')
         def knl(x, y, a):
             i = declare('int')
-            i = GID_0*LDIM_0 + LID_0
-            y[i] = x[i]*a
+            i = GID_0 * LDIM_0 + LID_0
+            y[i] = x[i] * a
 
         x = np.linspace(0, 1, 1000)
         y = np.zeros_like(x)
@@ -56,22 +57,23 @@ class TestKernel(unittest.TestCase):
 
         # Then
         y.pull()
-        self.assertTrue(np.allclose(y.data, x.data*a))
+        self.assertTrue(np.allclose(y.data, x.data * a))
 
     def test_kernel_with_local_memory(self):
         importorskip('pyopencl')
+
         # Given
         @annotate(gdoublep='x, y', xc='ldoublep', a='float')
         def knl(x, y, xc, a):
             i, lid = declare('int', 2)
             lid = LID_0
-            i = GID_0*LDIM_0 + lid
+            i = GID_0 * LDIM_0 + lid
 
             xc[lid] = x[i]
 
             local_barrier()
 
-            y[i] = xc[lid]*a
+            y[i] = xc[lid] * a
 
         x = np.linspace(0, 1, 1024)
         y = np.zeros_like(x)
@@ -86,12 +88,12 @@ class TestKernel(unittest.TestCase):
 
         # Then
         y.pull()
-        self.assertTrue(np.allclose(y.data, x.data*a))
+        self.assertTrue(np.allclose(y.data, x.data * a))
 
 
 @annotate(double='x, y, a', return_='double')
 def func(x, y, a):
-    return x*y*a
+    return x * y * a
 
 
 @annotate(doublep='x, y', a='double', n='int', return_='double')
@@ -109,7 +111,7 @@ def cy_extern(x, y, a, n):
     i = declare('int')
     with nogil, parallel():
         for i in prange(n):
-            y[i] = x[i]*a
+            y[i] = x[i] * a
 
 
 class TestCython(unittest.TestCase):
@@ -125,7 +127,7 @@ class TestCython(unittest.TestCase):
         result = cy(x, y, a, n)
 
         # Then
-        self.assertAlmostEqual(result, np.sum(x*y*a))
+        self.assertAlmostEqual(result, np.sum(x * y * a))
 
     def test_cython_with_externs(self):
         # Given
@@ -141,4 +143,4 @@ class TestCython(unittest.TestCase):
         cy(x, y, a, n)
 
         # Then
-        self.assertTrue(np.allclose(y, x*a))
+        self.assertTrue(np.allclose(y, x * a))

--- a/pysph/cpy/tests/test_parallel.py
+++ b/pysph/cpy/tests/test_parallel.py
@@ -4,14 +4,13 @@ import numpy as np
 
 from pytest import importorskip
 
-from ..config import get_config
+from ..config import get_config, use_config
 from ..array import wrap
 from ..types import annotate
 from ..parallel import Elementwise, Reduction, Scan
 
 
 class TestParallelUtils(unittest.TestCase):
-
     def setUp(self):
         cfg = get_config()
         self._use_double = cfg.use_double
@@ -24,7 +23,7 @@ class TestParallelUtils(unittest.TestCase):
         # Given
         @annotate(i='int', x='doublep', y='doublep', double='a,b')
         def axpb(i, x, y, a, b):
-            y[i] = a*sin(x[i]) + b
+            y[i] = a * sin(x[i]) + b
 
         x = np.linspace(0, 1, 10000)
         y = np.zeros_like(x)
@@ -38,7 +37,7 @@ class TestParallelUtils(unittest.TestCase):
 
         # Then
         y.pull()
-        self.assertTrue(np.allclose(y.data, a*np.sin(x.data) + b))
+        self.assertTrue(np.allclose(y.data, a * np.sin(x.data) + b))
 
     def test_elementwise_works_with_cython(self):
         self._check_simple_elementwise(backend='cython')
@@ -54,7 +53,7 @@ class TestParallelUtils(unittest.TestCase):
         self._check_simple_elementwise(backend='cuda')
 
     def _check_simple_reduction(self, backend):
-        x = np.linspace(0, 1, 1000)/1000
+        x = np.linspace(0, 1, 1000) / 1000
         x = wrap(x, backend=backend)
 
         # When
@@ -65,7 +64,7 @@ class TestParallelUtils(unittest.TestCase):
         self.assertAlmostEqual(result, 0.5, 6)
 
     def _check_reduction_min(self, backend):
-        x = np.linspace(0, 1, 1000)/1000
+        x = np.linspace(0, 1, 1000) / 1000
         x = wrap(x, backend=backend)
 
         # When
@@ -78,13 +77,13 @@ class TestParallelUtils(unittest.TestCase):
     def _check_reduction_with_map(self, backend):
         # Given
         from math import cos, sin
-        x = np.linspace(0, 1, 1000)/1000
+        x = np.linspace(0, 1, 1000) / 1000
         y = x.copy()
         x, y = wrap(x, y, backend=backend)
 
         @annotate(i='int', doublep='x, y')
         def map(i=0, x=[0.0], y=[0.0]):
-            return cos(x[i])*sin(y[i])
+            return cos(x[i]) * sin(y[i])
 
         # When
         r = Reduction('a+b', map_func=map, backend=backend)
@@ -139,7 +138,7 @@ class TestParallelUtils(unittest.TestCase):
 
         @annotate(int='i, item', ary='intp')
         def output_f(i, ary, item):
-            ary[i+1] = item
+            ary[i + 1] = item
 
         # When
         s = Scan(input_f, output_f, 'a+b', dtype=np.int32, backend='opencl')
@@ -151,3 +150,143 @@ class TestParallelUtils(unittest.TestCase):
         expect = np.cumsum(data)
         # print(result, y)
         self.assertTrue(np.all(expect[:-1] == result[1:]))
+
+    def _test_scan(self, backend):
+        # Given
+        a = np.arange(10000, dtype=np.int32)
+        data = a.copy()
+        expect = np.cumsum(data)
+
+        a = wrap(a, backend=backend)
+
+        @annotate(i='int', input_ary='intp', return_='int')
+        def input_f(i, input_ary):
+            return input_ary[i]
+
+        @annotate(int='i, item', output_ary='intp')
+        def output_f(i, item, output_ary):
+            output_ary[i] = item
+
+        # When
+        scan = Scan(input_f, output_f, 'a+b', dtype=np.int32,
+                    backend=backend)
+        scan(a, a)
+
+        a.pull()
+        result = a.data
+
+        # Then
+        np.testing.assert_equal(expect, result)
+
+    def test_scan_works_cython(self):
+        self._test_scan(backend='cython')
+
+    def test_scan_works_cython_parallel(self):
+        with use_config(use_openmp=True):
+            self._test_scan(backend='cython')
+
+    def _test_unique_scan(self, backend):
+        # Given
+        a = np.random.randint(0, 100, 100, dtype=np.int32)
+        a = np.sort(a)
+        data = a.copy()
+
+        unique_ary_actual = np.sort(np.unique(data))
+        unique_count_actual = len(np.unique(data))
+
+        a = wrap(a, backend=backend)
+
+        unique_ary = np.zeros(len(a.data), dtype=np.int32)
+        unique_ary = wrap(unique_ary, backend=backend)
+
+        unique_count = np.zeros(1, dtype=np.int32)
+        unique_count = wrap(unique_count, backend=backend)
+
+        @annotate(i='int', input_ary='intp', return_='int')
+        def input_f(i, input_ary):
+            if i == 0 or input_ary[i] != input_ary[i - 1]:
+                return 1
+            else:
+                return 0
+
+        @annotate(int='i, item', ary2='intp')
+        def output_f(i, item, ary2):
+            ary2[i] = item
+
+        @annotate(int='i, prev_item, item, N', ary2='intp',
+                  unique='intp', unique_count='intp')
+        def output_f(i, prev_item, item, N, ary2, unique, unique_count):
+            if item != prev_item:
+                unique[item - 1] = ary2[i]
+            if i == N - 1:
+                unique_count[0] = item
+
+        # When
+        scan = Scan(input_f, output_f, 'a+b', dtype=np.int32, backend=backend)
+        scan(a, a, unique_ary, unique_count)
+        unique_ary.pull()
+        unique_count.pull()
+        unique_count = unique_count.data[0]
+
+        # Then
+        self.assertTrue(unique_count == unique_count_actual)
+        np.testing.assert_equal(unique_ary_actual,
+                                unique_ary.data[:unique_count])
+
+    def test_unique_scan_cython(self):
+        self._test_unique_scan(backend='cython')
+
+    def test_unique_scan_cython_parallel(self):
+        with use_config(use_openmp=True):
+            self._test_unique_scan(backend='cython')
+
+    def _get_segmented_scan_actual(self, a, segment_flags):
+        output_actual = np.zeros_like(a)
+        for i in range(len(a)):
+            if segment_flags[i] == 0 and i != 0:
+                output_actual[i] = output_actual[i - 1] + a[i]
+            else:
+                output_actual[i] = a[i]
+        return output_actual
+
+    def _test_segmented_scan(self, backend):
+        # Given
+        a = np.random.randint(0, 100, 50000, dtype=np.int32)
+        a_copy = a.copy()
+
+        seg = np.random.randint(0, 100, 50000, dtype=np.int32)
+        seg = (seg == 0).astype(np.int32)
+        seg_copy = seg.copy()
+
+        a = wrap(a, backend=backend)
+        seg = wrap(seg, backend=backend)
+
+        @annotate(i='int', input_ary='intp', return_='int')
+        def input_f(i, input_ary):
+            return input_ary[i]
+
+        @annotate(i='int', seg_flag='intp', return_='int')
+        def segment_f(i, seg_flag):
+            return seg_flag[i]
+
+        @annotate(int='i, item', output_ary='intp')
+        def output_f(i, item, output_ary):
+            output_ary[i] = item
+
+        output_actual = self._get_segmented_scan_actual(a_copy, seg_copy)
+
+        # When
+        scan = Scan(input_f, output_f, 'a+b', dtype=np.int32, backend=backend,
+                    is_segment=segment_f)
+        scan(a, seg, a)
+        a.pull()
+
+        # Then
+        np.testing.assert_equal(output_actual, a.data)
+
+    def test_segmented_scan_cython(self):
+        self._test_segmented_scan(backend='cython')
+
+    def test_segmented_scan_cython_parallel(self):
+        with use_config(use_openmp=True):
+            self._test_segmented_scan(backend='cython')

--- a/pysph/cpy/tests/test_parallel.py
+++ b/pysph/cpy/tests/test_parallel.py
@@ -215,6 +215,7 @@ class TestParallelUtils(unittest.TestCase):
             self._test_unique_scan(backend='cython')
 
     def test_unique_scan_opencl(self):
+        importorskip('pyopencl')
         self._test_unique_scan(backend='opencl')
 
     def _get_segmented_scan_actual(self, a, segment_flags):
@@ -269,6 +270,7 @@ class TestParallelUtils(unittest.TestCase):
             self._test_segmented_scan(backend='cython')
 
     def test_segmented_scan_opencl(self):
+        importorskip('pyopencl')
         self._test_segmented_scan(backend='opencl')
 
     def _test_scan_last_item(self, backend):
@@ -296,3 +298,7 @@ class TestParallelUtils(unittest.TestCase):
     def test_scan_last_item_cython_parallel(self):
         with use_config(use_openmp=True):
             self._test_scan_last_item(backend='cython')
+
+    def test_scan_last_item_opencl(self):
+        importorskip('pyopencl')
+        self._test_scan_last_item(backend='opencl')


### PR DESCRIPTION
The cpy opencl scan does not handle arguments to the segment and output expression correctly. Currently, the scan won't work if the segment or output expression takes an argument which is not also taken by the input expression.

This is the syntax I have in place right now:
```
def input(i, a, b):
    ...

def segment_expr(i, c, d):
    ...

def output(i, ... (reserved keywords) ..., e, f):
    ...

scan = Scan(input=input, output=output, is_segment=segment_expr, ...)
scan(a, b, c, d, e, f)
```

Note the order of the arguments. The input arguments are followed by the segment expression arguments which are then followed by the output arguments. Reserved keywords like item, prev_item need to be inserted before any other arguments for the output function.

I think the following syntax would work better even if it's more verbose because 
1) There is no confusion about the order of arguments 
2) The same argument can be used by both the input and output expressions
```
scan(a=a, b=b, c=c, d=d, e=e, f=f)
```