### PR TITLE
Print handy warning when particles are diverging.

### DIFF
--- a/pysph/base/gpu_nnps_base.pxd
+++ b/pysph/base/gpu_nnps_base.pxd
@@ -74,6 +74,7 @@ cdef class GPUNNPS(NNPSBase):
     cdef public bint use_double
     cdef public dtype
     cdef public dtype_max
+    cdef public double _last_domain_size # last size of domain.
 
     cdef public np.ndarray xmin
     cdef public np.ndarray xmax

--- a/pysph/base/nnps_base.pxd
+++ b/pysph/base/nnps_base.pxd
@@ -288,6 +288,7 @@ cdef class NNPS(NNPSBase):
     cdef public DoubleArray xmin      # co-ordinate min values
     cdef public DoubleArray xmax      # co-ordinate max values
     cdef public NeighborCache current_cache  # The current cache
+    cdef public double _last_domain_size # last size of domain.
 
     cdef public bint sort_gids        # Sort neighbors by their gids.
 


### PR DESCRIPTION
Normally a user gets a very strange error message or a segfault but now
if the particles are diverging and the domain size is increasing more
than twice the last time, it prints a useful warning saying
particles are diverging.  This should hopefully make it easier when
debugging.