### PR TITLE
Call arbitrary python from a group

### DIFF
--- a/docs/source/design/equations.rst
+++ b/docs/source/design/equations.rst
@@ -407,6 +407,29 @@ The trace function effectively is converted into a function with signature
 ``double trace(double* x, int nx)`` and thus can be called with any
 one-dimensional array.
 
+Calling arbitrary Python functions from a Group
+------------------------------------------------
+
+Sometimes, you may need to implement something that is hard to write (at least
+initially) with the constraints that PySPH places. For example if you need to
+implement an algorithm that requires more complex data structures and you want
+to do it easily in Python. There are ways to call arbitrary Python code from
+the application already but sometimes you need to do this during every
+acceleration evaluation. To support this the :py:class:`Group` class supports
+two additional keyword arguments called ``pre`` and ``post``. These can be any
+Python callable that take no arguments. Any callable passed as ``pre`` will be
+called *before* any equation related code is executed and ``post`` will be
+executed after the entire group is finished. If the group is iterated, it
+should call those functions repeatedly.
+
+Now these functions are pure Python functions so you may choose to do anything
+in them. These are not called within an OpenMP context and if you are using
+the OpenCL or CUDA backends again this will simply be a Python function call
+that has nothing to do with the particular backend. However, since it is
+arbitrary Python, you can choose to implement the code using any approach you
+choose to do. This should be flexible enough to customize PySPH greatly.
+
+
 
 Examples to study
 ------------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -214,7 +214,7 @@ short do the following::
 If you wish to use a compiler which is not currently your default compiler,
 simply update the ``CC`` and ``CXX`` environment variables. For example, to use
 icc run the following commands `before` building PySPH::
-  
+
     $ export CC=icc
     $ export CXX=icpc
 
@@ -228,7 +228,7 @@ icc run the following commands `before` building PySPH::
     ``/path/to/icc/bin``. If you didn't get this file along with your
     installation, you can try running ``export
     LD_LIBRARY_PATH=/path/to/icc/lib``.
-    
+
 You should be set now and should skip to :ref:`downloading-pysph` and
 :ref:`building-pysph`.
 
@@ -262,13 +262,13 @@ if you installed XCode but can't find clang or gcc.
 OpenMP on OSX
 ^^^^^^^^^^^^^
 
-The default "gcc" available on OSX uses an LLVM backend and does not support 
-OpenMP_. To use OpenMP_ on OSX, you can install the GCC available on brew_ using    :: 
+The default "gcc" available on OSX uses an LLVM backend and does not support
+OpenMP_. To use OpenMP_ on OSX, you can install the GCC available on brew_ using    ::
 
     $ brew install gcc
 
-Once this is done, you need to use this as your default compiler. The ``gcc`` 
-formula on brew currently ships with gcc version 7. Therefore, you can 
+Once this is done, you need to use this as your default compiler. The ``gcc``
+formula on brew currently ships with gcc version 7. Therefore, you can
 tell Python to use the GCC installed by brew by setting::
 
     $ export CC=gcc-7
@@ -713,6 +713,12 @@ This should run all the tests that do not take a long while to complete.  If
 this fails, please contact the `pysph-users mailing list
 <https://groups.google.com/forum/#!forum/pysph-users>`_ or send us `email
 <mailto:pysph-users@googlegroups.com>`_.
+
+There are a few additional test dependencies that need to be installed when
+running the tests.  These can be installed using::
+
+   $ pip install -r requirements-test.txt
+
 
 Once you run the tests, you should see the section on
 :ref:`running-the-examples`.

--- a/pysph/sph/acceleration_eval.py
+++ b/pysph/sph/acceleration_eval.py
@@ -101,7 +101,7 @@ class MegaGroup(object):
         return self._orig_group.get_converged_condition()
 
     def _copy_props(self, group):
-        for key in ('real', 'update_nnps', 'iterate',
+        for key in ('real', 'update_nnps', 'iterate', 'pre', 'post',
                     'max_iterations', 'min_iterations', 'has_subgroups'):
             setattr(self, key, getattr(group, key))
 

--- a/pysph/sph/acceleration_eval_cython.mako
+++ b/pysph/sph/acceleration_eval_cython.mako
@@ -8,6 +8,12 @@ ${' '*4*level}${l}
 
 <%def name="do_group(helper, group, level=0)" buffered="True">
 #######################################################################
+## Call any `pre` functions
+#######################################################################
+% if group.pre:
+${indent(helper.get_pre_call(group), 0)}
+% endif
+#######################################################################
 ## Iterate over destinations in this group.
 #######################################################################
 % for dest, (eqs_with_no_source, sources, all_eqs) in group.data.items():
@@ -113,6 +119,12 @@ nnps.update()
 % endif
 
 % endfor
+#######################################################################
+## Call any `post` functions
+#######################################################################
+% if group.post:
+${indent(helper.get_post_call(group), 0)}
+% endif
 </%def>
 
 from libc.stdio cimport printf
@@ -179,11 +191,13 @@ cdef class AccelerationEval:
     cdef void **nbrs
     # CFL time step conditions
     cdef public double dt_cfl, dt_force, dt_viscous
+    cdef object groups
     ${indent(helper.get_kernel_defs(), 1)}
     ${indent(helper.get_equation_defs(), 1)}
 
-    def __init__(self, kernel, equations, particle_arrays):
+    def __init__(self, kernel, equations, particle_arrays, groups):
         self.particle_arrays = tuple(particle_arrays)
+        self.groups = groups
         self.n_threads = get_number_of_threads()
         cdef int i
         for i, pa in enumerate(particle_arrays):

--- a/pysph/sph/acceleration_eval_cython_helper.py
+++ b/pysph/sph/acceleration_eval_cython_helper.py
@@ -120,6 +120,24 @@ class AccelerationEvalCythonHelper(object):
         )
         self._ext_mod = None
         self._module = None
+        self._compute_group_map()
+
+    ##########################################################################
+    # Private interface.
+    ##########################################################################
+    def _compute_group_map(self):
+        # Given all the groups, create a mapping from the group to an index of
+        # sorts that can be used when adding the pre/post callback code.
+        mapping = {}
+        for g_idx, group in enumerate(self.object.mega_groups):
+            mapping[group] = 'self.groups[%d]' % g_idx
+            if group.has_subgroups:
+                for sg_idx, sub_group in enumerate(group.data):
+                    code = 'self.groups[{gid}].data[{sgid}]'.format(
+                        gid=g_idx, sgid=sg_idx
+                    )
+                    mapping[sub_group] = code
+        self._group_map = mapping
 
     ##########################################################################
     # Public interface.
@@ -135,7 +153,7 @@ class AccelerationEvalCythonHelper(object):
         object = self.object
         acceleration_eval = module.AccelerationEval(
             object.kernel, object.all_group.equations,
-            object.particle_arrays
+            object.particle_arrays, object.mega_groups
         )
         object.set_compiled_object(acceleration_eval)
 
@@ -260,3 +278,9 @@ class AccelerationEvalCythonHelper(object):
     def get_particle_array_names(self):
         parrays = [pa.name for pa in self.object.particle_arrays]
         return ', '.join(parrays)
+
+    def get_pre_call(self, group):
+        return self._group_map[group] + '.pre()'
+
+    def get_post_call(self, group):
+        return self._group_map[group] + '.post()'

--- a/pysph/sph/acceleration_eval_opencl.mako
+++ b/pysph/sph/acceleration_eval_opencl.mako
@@ -1,5 +1,11 @@
 <%def name="do_group(helper, g_idx, sg_idx, group)" buffered="True">
 #######################################################################
+## Call any `pre` functions
+#######################################################################
+% if group.pre:
+<% helper.call_pre(group) %>
+% endif
+#######################################################################
 ## Iterate over destinations in this group.
 #######################################################################
 % for dest, (eqs_with_no_source, sources, all_eqs) in group.data.items():
@@ -53,6 +59,12 @@ ${helper.get_post_loop_kernel(g_idx, sg_idx, group, dest, all_eqs)}
 <% helper.call_update_nnps(group) %>
 % endif
 % endfor
+#######################################################################
+## Call any `post` functions
+#######################################################################
+% if group.post:
+<% helper.call_post(group) %>
+% endif
 </%def>
 
 #define abs fabs

--- a/pysph/sph/acceleration_eval_opencl_helper.py
+++ b/pysph/sph/acceleration_eval_opencl_helper.py
@@ -191,6 +191,9 @@ class OpenCLAccelerationEval(object):
                     method(_args[0], _args[1], t, dt)
                 else:
                     method(*info.get('args'))
+            elif type == 'call':
+                func = info.get('callable')
+                func(*info.get('args'))
             elif type == 'kernel':
                 self._call_kernel(info, extra_args)
             elif type == 'start_iteration':
@@ -353,7 +356,8 @@ class AccelerationEvalOpenCLHelper(object):
                     args[0] = [x for x in grp.equations
                                if hasattr(x, 'reduce')]
                     args[1] = self._array_map[args[1]]
-
+            elif type == 'call':
+                info = dict(item)
             elif 'iteration' in type:
                 group = item['group']
                 equations = get_equations_with_converged(group._orig_group)
@@ -562,6 +566,12 @@ class AccelerationEvalOpenCLHelper(object):
             return code.replace('KERNEL(', kern).replace('GRADH(', grad_h)
         else:
             return code
+
+    def call_post(self, group):
+        self.data.append(dict(callable=group.post, type='call', args=()))
+
+    def call_pre(self, group):
+        self.data.append(dict(callable=group.pre, type='call', args=()))
 
     def call_reduce(self, all_eq_group, dest):
         self.data.append(dict(method='do_reduce', type='method',

--- a/pysph/sph/equation.py
+++ b/pysph/sph/equation.py
@@ -417,7 +417,7 @@ class Group(object):
     pre_comp = precomputed_symbols()
 
     def __init__(self, equations, real=True, update_nnps=False, iterate=False,
-                 max_iterations=1, min_iterations=0):
+                 max_iterations=1, min_iterations=0, pre=None, post=None):
         """Constructor.
 
         Parameters
@@ -446,6 +446,14 @@ class Group(object):
             specifies the minimum number of times this group should be
             iterated.
 
+        pre: callable
+            A callable which is passed no arguments that is called before
+            anything in the group is executed.
+
+        pre: callable
+            A callable which is passed no arguments that is called after
+            the group is completed.
+
         Notes
         -----
 
@@ -465,6 +473,8 @@ class Group(object):
         self.iterate = iterate
         self.max_iterations = max_iterations
         self.min_iterations = min_iterations
+        self.pre = pre
+        self.post = post
 
         only_groups = [x for x in equations if isinstance(x, Group)]
         if (len(only_groups) > 0) and (len(only_groups) != len(equations)):

--- a/pysph/sph/tests/test_acceleration_eval.py
+++ b/pysph/sph/tests/test_acceleration_eval.py
@@ -239,6 +239,24 @@ class TestMegaGroup(unittest.TestCase):
         expect = ['SimpleEquation', 'DummyEquation', 'MixedTypeEquation']
         self.assertEqual(f_eqs, expect)
 
+    def test_mega_group_copies_props_of_group(self):
+        # Given
+        def nothing():
+            pass
+        g = Group(
+            equations=[], real=False, update_nnps=True, iterate=True,
+            max_iterations=20, min_iterations=2, pre=nothing, post=nothing
+        )
+
+        # When
+        mg = MegaGroup(g, CythonGroup)
+
+        # Then
+        props = ('real update_nnps iterate max_iterations '
+                 'min_iterations pre post').split()
+        for prop in props:
+            self.assertEqual(getattr(mg, prop), getattr(g, prop))
+
 
 class TestAccelerationEval1D(unittest.TestCase):
     def setUp(self):
@@ -414,6 +432,35 @@ class TestAccelerationEval1D(unittest.TestCase):
         # Then
         expect = np.ones(10)*3.0
         self.assertListEqual(list(pa.au), list(expect))
+
+    def test_should_call_pre_post_functions_in_group(self):
+        # Given
+        pa = self.pa
+
+        def pre():
+            pa.m += 1.0
+
+        def post():
+            pa.u += 1.0
+
+        equations = [
+            Group(
+                equations=[
+                    SimpleEquation(dest='fluid', sources=['fluid'])
+                ],
+                pre=pre, post=post
+
+            )
+        ]
+        a_eval = self._make_accel_eval(equations)
+
+        # When
+        a_eval.compute(0.1, 0.1)
+
+        # Then
+        expect = np.asarray([7., 9., 11., 11., 11., 11., 11., 11.,  9.,  7.])
+        self.assertListEqual(list(pa.u), list(expect))
+
 
 
 class EqWithTime(Equation):


### PR DESCRIPTION
This allows a user to call arbitrary python code from within a group,
before or after the group executes.  This makes it easy to write
whatever one wants when the framework does not support some features.