### PR TITLE
Pure Python integrator stages and equation initializers.

### DIFF
--- a/docs/source/design/equations.rst
+++ b/docs/source/design/equations.rst
@@ -37,6 +37,10 @@ methods of a typical :py:class:`Equation` subclass::
           # Overload this only if you need to pass additional constants
           # Otherwise, no need to override __init__
 
+      def py_initialize(self, dst, t, dt):
+          # Called once per destination before initialize.
+          # This is a pure Python function and is not translated.
+
       def initialize(self, d_idx, ...):
           # Called once per destination before loop.
 
@@ -66,6 +70,13 @@ the equation is used as ``YourEquation(dest='fluid', sources=['fluid',
 'solid'])``. Now given this context, let us see what happens when this
 equation is used.  What happens is as follows:
 
+- for each destination particle array (``'fluid'`` in this case), the
+  ``py_initialize`` method is called and is passed the destination particle
+  array, ``t`` and ``dt`` (similar to ``reduce``). This function is a pure
+  Python function so you can do what you want here, including importing any
+  Python code and run anything you want. The code is NOT transpiled into
+  C/OpenCL/CUDA.
+
 - for each fluid particle, the ``initialize`` method is called with the
   required arrays.
 
@@ -86,7 +97,9 @@ equation is used.  What happens is as follows:
   required properties.
 
 - If a reduce method exists, it is called for the destination (only once, not
-  once per particle). It is passed the destination particle array.
+  once per particle). It is passed the destination particle array and the time
+  and timestep. It is transpiled when you are using Cython but is a pure
+  Python function when you run this via OpenCL or CUDA.
 
 The ``initialize, loop_all, loop, post_loop`` methods all may be called in
 separate threads (both on CPU/GPU) depending on the implementation of the
@@ -96,12 +109,14 @@ It is possible to set a scalar value in the equation as an instance attribute,
 i.e. by setting ``self.something = value`` but remember that this is just one
 value for the equation. This value must also be initialized in the
 ``__init__`` method. Also make sure that the attributes are public and not
-private. There is only one equation instance used in the code, not one
-equation per thread or particle. So if you wish to calculate a temporary
-quantity for each particle, you should create a separate property for it and
-use that instead of assuming that the initialize and loop functions run in
-serial. They do not when you use OpenMP or OpenCL. So do not create temporary
-arrays inside the equation for these sort of things.
+private (i.e. do not start with an underscore). There is only one equation
+instance used in the code, not one equation per thread or particle. So if you
+wish to calculate a temporary quantity for each particle, you should create a
+separate property for it and use that instead of assuming that the initialize
+and loop functions run in serial. They do not when you use OpenMP or OpenCL.
+So do not create temporary arrays inside the equation for these sort of
+things. In general if you need a constant per destination array, add it as a
+constant to the particle array.
 
 Now, if the group containing the equation has ``iterate`` set to True, then
 the group will be iterated until convergence is attained for all the equations
@@ -429,6 +444,35 @@ that has nothing to do with the particular backend. However, since it is
 arbitrary Python, you can choose to implement the code using any approach you
 choose to do. This should be flexible enough to customize PySPH greatly.
 
+Writing integrators
+--------------------
+
+.. py:currentmodule:: pysph.sph.integrator_step
+
+
+Similar rules apply when writing an :py:class:`IntegratorStep`. One can create
+a multi-stage integrator as follows:
+
+.. code-block:: python
+
+   class MyStepper(IntegratorStep):
+       def initialize(self, d_idx, d_x):
+           # ...
+       def py_stage1(self, dst, t, dt):
+           # ...
+       def stage1(self, d_idx, d_x, d_ax):
+           # ...
+       def py_stage2(self, dst, t, dt):
+           # ...
+       def stage2(self, d_idx, d_x, d_ax):
+           # ...
+
+In this case, the ``initialize, stage1, stage2``, methods are transpiled and
+called but the ``py_stage1, py_stage2`` are pure Python functions called
+before the respective ``stage`` functions are called. Defining the
+``py_stage1`` or ``py_stage2`` methods are optional. If you have defined them,
+they will be called automatically. They are passed the destination particle
+array, the current time, and current timestep.
 
 
 Examples to study

--- a/pysph/cpy/cython_generator.py
+++ b/pysph/cpy/cython_generator.py
@@ -326,7 +326,7 @@ class CythonGenerator(object):
     def _get_methods(self, cls):
         methods = []
         for name in dir(cls):
-            if name.startswith('_'):
+            if name.startswith(('_', 'py_')):
                 continue
             meth = getattr(cls, name)
             if callable(meth):

--- a/pysph/cpy/translator.py
+++ b/pysph/cpy/translator.py
@@ -269,7 +269,8 @@ class CConverter(ast.NodeVisitor):
         src = dedent(inspect.getsource(obj.__class__))
         ignore_methods = [] if ignore_methods is None else ignore_methods
         for method in dir(obj):
-            if not method.startswith('_') and method not in ignore_methods:
+            if not method.startswith(('_', 'py_')) \
+               and method not in ignore_methods:
                 ann = getattr(getattr(obj, method), '__annotations__', None)
                 self._annotations[method] = ann
         code += self.convert(src, ignore_methods)
@@ -516,7 +517,7 @@ class CConverter(ast.NodeVisitor):
         assert node.args.kwarg is None, \
             "Functions with kwargs not supported in line %d." % node.lineno
 
-        if self._class_name and (node.name.startswith('_') or
+        if self._class_name and (node.name.startswith(('_', 'py_')) or
                                  node.name in self._ignore_methods):
             return ''
 

--- a/pysph/sph/acceleration_eval_cython.mako
+++ b/pysph/sph/acceleration_eval_cython.mako
@@ -28,6 +28,10 @@ ${indent(helper.get_dest_array_setup(dest, eqs_with_no_source, sources, group.re
 dst_array_index = dst.index
 
 #######################################################################
+## Call py_initialize for all equations for this destination.
+#######################################################################
+${indent(all_eqs.get_py_initialize_code(), 0)}
+#######################################################################
 ## Initialize all equations for this destination.
 #######################################################################
 % if all_eqs.has_initialize():
@@ -192,6 +196,7 @@ cdef class AccelerationEval:
     # CFL time step conditions
     cdef public double dt_cfl, dt_force, dt_viscous
     cdef object groups
+    cdef object all_equations
     ${indent(helper.get_kernel_defs(), 1)}
     ${indent(helper.get_equation_defs(), 1)}
 
@@ -215,6 +220,10 @@ cdef class AccelerationEval:
 
         ${indent(helper.get_kernel_init(), 2)}
         ${indent(helper.get_equation_init(), 2)}
+        all_equations = {}
+        for equation in equations:
+            all_equations[equation.var_name] = equation
+        self.all_equations = all_equations
 
     def __dealloc__(self):
         aligned_free(self.nbrs)

--- a/pysph/sph/acceleration_eval_opencl.mako
+++ b/pysph/sph/acceleration_eval_opencl.mako
@@ -10,6 +10,8 @@
 #######################################################################
 % for dest, (eqs_with_no_source, sources, all_eqs) in group.data.items():
 // Destination ${dest}
+## Call py_initialize if it is defined for the equations.
+<% helper.call_py_initialize(all_eqs, dest) %>
 #######################################################################
 ## Initialize all equations for this destination.
 #######################################################################

--- a/pysph/sph/equation.py
+++ b/pysph/sph/equation.py
@@ -758,6 +758,15 @@ class CythonGroup(Group):
     def get_post_loop_code(self, kernel=None):
         return self._get_code(kernel, kind='post_loop')
 
+    def get_py_initialize_code(self):
+        lines = []
+        for i, equation in enumerate(self.equations):
+            if hasattr(equation, 'py_initialize'):
+                code = ('self.all_equations["{name}"].py_initialize'
+                        '(dst.array, t, dt)').format(name=equation.var_name)
+                lines.append(code)
+        return '\n'.join(lines)
+
     def get_reduce_code(self):
         return self._get_code(kernel=None, kind='reduce')
 

--- a/pysph/sph/integrator_cython.mako
+++ b/pysph/sph/integrator_cython.mako
@@ -23,11 +23,13 @@ cdef class Integrator:
     cdef public NNPS nnps
     cdef public double dt, t, orig_t
     cdef object _post_stage_callback
+    cdef object steppers
 
     ${indent(helper.get_stepper_defs(), 1)}
 
     def __init__(self, acceleration_eval, steppers):
         self.acceleration_eval = acceleration_eval
+        self.steppers = steppers
         self._post_stage_callback = None
         % for name in sorted(helper.object.steppers.keys()):
         self.${name} = acceleration_eval.${name}
@@ -93,10 +95,15 @@ cdef class Integrator:
         # ---------------------------------------------------------------------
         # Destination ${dest}.
         dst = self.${dest}
+        ##
+        ${indent(helper.get_py_stage_code(dest, method), 2)}
+        ##
+        % if helper.has_stepper_loop(dest, method):
         # Only iterate over real particles.
         NP_DEST = dst.size(real=True)
         ${indent(helper.get_array_setup(dest, method), 2)}
         for d_idx in range(NP_DEST):
             ${indent(helper.get_stepper_loop(dest, method), 3)}
+        % endif
         % endfor
     % endfor

--- a/pysph/sph/integrator_opencl_helper.py
+++ b/pysph/sph/integrator_opencl_helper.py
@@ -53,9 +53,15 @@ class OpenCLIntegrator(object):
     def _do_stage(self, method):
         # Call the appropriate kernels for either initialize/stage computation.
         call_info = self.helper.calls[method]
+        py_call_info = self.helper.py_calls['py_' + method]
         dtype = np.float64 if self._use_double else np.float32
         extra_args = [np.asarray(self.t, dtype=dtype),
                       np.asarray(self.dt, dtype=dtype)]
+        # Call the py_{method} for each destination.
+        for name, (py_meth, dest) in py_call_info.items():
+            py_meth(dest, *extra_args)
+
+        # Call the stage* method for each destination.
         for name, (call, args, dest) in call_info.items():
             n = dest.get_number_of_particles(real=True)
             args[1] = (n,)
@@ -112,7 +118,9 @@ class IntegratorOpenCLHelper(IntegratorCythonHelper):
         super(IntegratorOpenCLHelper, self).__init__(
             integrator, acceleration_eval_helper
         )
+        self.py_data = defaultdict(dict)
         self.data = defaultdict(dict)
+        self.py_calls = defaultdict(dict)
         self.calls = defaultdict(dict)
         self.program = None
 
@@ -120,18 +128,28 @@ class IntegratorOpenCLHelper(IntegratorCythonHelper):
         array_map = self.acceleration_eval_helper._array_map
         q = self.acceleration_eval_helper._queue
         calls = self.calls
+        py_calls = self.py_calls
+        steppers = self.object.steppers
+        for method, info in self.py_data.items():
+            for dest_name in info:
+                py_meth = getattr(steppers[dest_name], method)
+                dest = array_map[dest_name]
+                py_calls[method][dest] = (py_meth, dest)
+
         for method, info in self.data.items():
             for dest_name, (kernel, args) in info.items():
                 dest = array_map[dest_name]
 
-                # Note: This is done to do some late binding. Instead of just
-                # directly storing the dest.gpu.x, we compute it on the fly
-                # as the number of particles and the actual buffer may change.
+                # Note: This is done to do some late binding. Instead of
+                # just directly storing the dest.gpu.x, we compute it on
+                # the fly as the number of particles and the actual buffer
+                # may change.
                 def _getter(dest_gpu, x):
                     return getattr(dest_gpu, x).data
 
                 _args = [
-                    functools.partial(_getter, dest.gpu, x[2:]) for x in args
+                    functools.partial(_getter, dest.gpu, x[2:])
+                    for x in args
                 ]
                 all_args = [q, None, None] + _args
                 call = getattr(self.program, kernel)
@@ -149,7 +167,10 @@ class IntegratorOpenCLHelper(IntegratorCythonHelper):
             % for dest in sorted(helper.object.steppers.keys()):
             // Steppers for ${dest}
             % for method in helper.get_stepper_method_wrapper_names():
+            <% helper.get_py_stage_code(dest, method) %>
+            % if helper.has_stepper_loop(dest, method):
             ${helper.get_stepper_kernel(dest, method)}
+            % endif
             % endfor
             % endfor
             // ------------------------------------------------------------
@@ -166,6 +187,12 @@ class IntegratorOpenCLHelper(IntegratorCythonHelper):
         cython_integrator = OpenCLIntegrator(self, acceleration_eval)
         # Setup the integrator to use this compiled module.
         self.object.set_compiled_object(cython_integrator)
+
+    def get_py_stage_code(self, dest, method):
+        stepper = self.object.steppers[dest]
+        method = 'py_' + method
+        if hasattr(stepper, method):
+            self.py_data[method][dest] = dest
 
     def get_timestep_code(self):
         method = self.object.one_timestep

--- a/pysph/sph/tests/test_acceleration_eval.py
+++ b/pysph/sph/tests/test_acceleration_eval.py
@@ -184,6 +184,19 @@ class SimpleReduction(Equation):
             dst.gpu.push('total_mass')
 
 
+class PyInit(Equation):
+    def py_initialize(self, dst, t, dt):
+        self.called_with = t, dt
+        if dst.gpu:
+            dst.pull('au')
+        dst.au[:] = 1.0
+        if dst.gpu:
+            dst.push('au')
+
+    def initialize(self, d_idx, d_au):
+        d_au[d_idx] += 1.0
+
+
 class LoopAllEquation(Equation):
     def initialize(self, d_idx, d_rho):
         d_rho[d_idx] = 0.0
@@ -375,6 +388,22 @@ class TestAccelerationEval1D(unittest.TestCase):
         # Then
         expect = np.sum(pa.m)
         self.assertAlmostEqual(pa.total_mass[0], expect, 14)
+
+    def test_should_call_py_initialize(self):
+        # Given.
+        pa = self.pa
+        equations = [PyInit(dest='fluid', sources=None)]
+        a_eval = self._make_accel_eval(equations)
+
+        # When
+        a_eval.compute(0.1, 0.1)
+
+        # Then
+        if pa.gpu:
+            pa.gpu.pull('au')
+        np.testing.assert_array_almost_equal(
+            pa.au, np.ones_like(pa.x)*2.0
+        )
 
     def test_should_work_with_non_double_arrays(self):
         # Given


### PR DESCRIPTION
- Add support for Python integrator steps.  This allows one to define optional `py_stage1` or `py_stage2` which is called with `dest_particle_array, t, dt` and makes a Python call (without any code transpilation).  These are called before `stage1`, `stage2` etc.  One may choose to not have any `stage1` methods too and only the `py_stage` methods.  This will work for both CPU and GPU
backends.  Note that any methods or functions starting with `py_` are not transpiled.
- Support for py_initialize in equations. This allows a user to define a `py_initialize(self, dst, t, dt)`  method in an equation.  This is called as a pure Python (no translation) function before the initialize function is called. 