### PR TITLE
Add jit module to CPy

### DIFF
--- a/examples/cpy/README.rst
+++ b/examples/cpy/README.rst
@@ -237,6 +237,40 @@ arguments and NOT for the local variables. The only caveat is you must use the
 types in ``pysph.cpy.types``, i.e. you must use ``KnownType`` instances as the
 types for things to work.
 
+JIT transpilation
+-----------------
+
+CPy also support just-in-time transpilation when annotations of a function
+are not provided. These functions are annotated at runtime when the
+call arguments are passed. The generated kernel and annotated functions
+are then cached with the types of the call arguments as key. Thus,
+the function ``f`` defined in the previous section can also be defined
+as follows::
+
+    @annotate
+    def f(i, x):
+        return x[i]*2.0
+
+While using in-built functions such as ``sin``, ``cos``, ``abs`` etc. it is
+recommended that you store the value in a variable or appropriate type
+before returning it. If not the return type will default to ``double``.
+For example,::
+
+    @annotate
+    def f(i, x):
+        return abs(x[i])
+
+This will set the return type of function ``f`` to the default
+type, ``double``. To avoid this problem, one could define ``f`` instead as,::
+
+    @annotate
+    def f(i, x):
+        y = declare('int')
+        y = abs(x[i])
+        return y
+
+Currently JIT support is only limited to the common parallel algorithms explained
+in a later section.
 
 Declaring variables
 -------------------

--- a/examples/cpy/README.rst
+++ b/examples/cpy/README.rst
@@ -261,7 +261,8 @@ For example,::
         return abs(x[i])
 
 This will set the return type of function ``f`` to the default
-type, ``double``. To avoid this problem, one could define ``f`` instead as,::
+type, ``double`` even when ``x`` is an array of integers.
+To avoid this problem, one could define ``f`` instead as,::
 
     @annotate
     def f(i, x):

--- a/examples/cpy/axpb_jit.py
+++ b/examples/cpy/axpb_jit.py
@@ -1,3 +1,8 @@
+"""Shows the use of annotate without any type information.
+The type information is extracted from the arguments passed
+and the function is annotated and compiled at runtime.
+"""
+
 from pysph.cpy.api import annotate, Elementwise, wrap, get_config
 import numpy as np
 

--- a/examples/cpy/axpb_jit.py
+++ b/examples/cpy/axpb_jit.py
@@ -3,7 +3,9 @@ from pysph.cpy.jit import ElementwiseJIT
 import numpy as np
 
 def axpb(i, x, y, a, b):
-    y[i] = a*sin(x[i]) + b
+    xi = declare('double')
+    xi = x[i]
+    y[i] = a*sin(xi) + b
 
 x = np.linspace(0, 1, 10000)
 y = np.zeros_like(x)

--- a/examples/cpy/axpb_jit.py
+++ b/examples/cpy/axpb_jit.py
@@ -1,7 +1,8 @@
 from pysph.cpy.api import Elementwise, annotate, wrap, get_config
-from pysph.cpy.jit import ElementwiseJIT
+from pysph.cpy.jit import jit, ElementwiseJIT
 import numpy as np
 
+@jit
 def axpb(i, x, y, a, b):
     xi = declare('double')
     xi = x[i]

--- a/examples/cpy/axpb_jit.py
+++ b/examples/cpy/axpb_jit.py
@@ -1,5 +1,4 @@
-from pysph.cpy.api import Elementwise, wrap, get_config
-from pysph.cpy.jit import annotate
+from pysph.cpy.api import annotate, Elementwise, wrap, get_config
 import numpy as np
 
 

--- a/examples/cpy/axpb_jit.py
+++ b/examples/cpy/axpb_jit.py
@@ -1,9 +1,9 @@
-from pysph.cpy.api import Elementwise, annotate, wrap, get_config
-from pysph.cpy.jit import jit, ElementwiseJIT
+from pysph.cpy.api import Elementwise, wrap, get_config
+from pysph.cpy.jit import annotate
 import numpy as np
 
 
-@jit
+@annotate
 def axpb(i, x, y, a, b):
     xi = declare('double')
     xi = x[i]
@@ -18,5 +18,5 @@ b = 3.0
 backend = 'opencl'
 get_config().use_openmp = True
 x, y = wrap(x, y, backend=backend)
-e = ElementwiseJIT(axpb, backend=backend)
+e = Elementwise(axpb, backend=backend)
 e(x, y, a, b)

--- a/examples/cpy/axpb_jit.py
+++ b/examples/cpy/axpb_jit.py
@@ -2,11 +2,13 @@ from pysph.cpy.api import Elementwise, annotate, wrap, get_config
 from pysph.cpy.jit import jit, ElementwiseJIT
 import numpy as np
 
+
 @jit
 def axpb(i, x, y, a, b):
     xi = declare('double')
     xi = x[i]
-    y[i] = a*sin(xi) + b
+    y[i] = a * sin(xi) + b
+
 
 x = np.linspace(0, 1, 10000)
 y = np.zeros_like(x)

--- a/examples/cpy/axpb_jit.py
+++ b/examples/cpy/axpb_jit.py
@@ -1,0 +1,17 @@
+from pysph.cpy.api import Elementwise, annotate, wrap, get_config
+from pysph.cpy.jit import ElementwiseJIT
+import numpy as np
+
+def axpb(i, x, y, a, b):
+    y[i] = a*sin(x[i]) + b
+
+x = np.linspace(0, 1, 10000)
+y = np.zeros_like(x)
+a = 2.0
+b = 3.0
+
+backend = 'opencl'
+get_config().use_openmp = True
+x, y = wrap(x, y, backend=backend)
+e = ElementwiseJIT(axpb, backend=backend)
+e(x, y, a, b)

--- a/examples/cpy/vm_elementwise_jit.py
+++ b/examples/cpy/vm_elementwise_jit.py
@@ -1,0 +1,81 @@
+import numpy as np
+from math import pi
+import time
+
+from pysph.cpy.config import get_config
+from pysph.cpy.api import declare, annotate
+from pysph.cpy.parallel import Elementwise
+from pysph.cpy.array import wrap
+from pysph.cpy.jit import jit, ElementwiseJIT
+
+
+@jit
+def point_vortex(xi, yi, xj, yj, gamma, result):
+    xij = xi - xj
+    yij = yi - yj
+    r2ij = xij*xij + yij*yij
+    if r2ij < 1e-14:
+        result[0] = 0.0
+        result[1] = 0.0
+    else:
+        tmp = gamma/(2.0*pi*r2ij)
+        result[0] = -tmp*yij
+        result[1] = tmp*xij
+
+
+@jit
+def velocity(i, x, y, gamma, u, v, nv):
+    j = declare('int')
+    tmp = declare('matrix(2)')
+    xi = x[i]
+    yi = y[i]
+    u[i] = 0.0
+    v[i] = 0.0
+    for j in range(nv):
+        point_vortex(xi, yi, x[j], y[j], gamma[j], tmp)
+        u[i] += tmp[0]
+        v[i] += tmp[1]
+
+
+def make_vortices(nv, backend):
+    x = np.linspace(-1, 1, nv)
+    y = x.copy()
+    gamma = np.ones(nv)
+    u = np.zeros_like(x)
+    v = np.zeros_like(x)
+    x, y, gamma, u, v = wrap(x, y, gamma, u, v, backend=backend)
+    return x, y, gamma, u, v, nv
+
+
+def run(nv, backend):
+    e = ElementwiseJIT(velocity, backend=backend)
+    args = make_vortices(nv, backend)
+    t1 = time.time()
+    e(*args)
+    print(time.time() - t1)
+    u = args[-3]
+    u.pull()
+    return e, args
+
+
+if __name__ == '__main__':
+    from argparse import ArgumentParser
+    p = ArgumentParser()
+    p.add_argument(
+        '-b', '--backend', action='store', dest='backend', default='cython',
+        help='Choose the backend.'
+    )
+    p.add_argument(
+        '--openmp', action='store_true', dest='openmp', default=False,
+        help='Use OpenMP.'
+    )
+    p.add_argument(
+        '--use-double', action='store_true', dest='use_double',
+        default=False,  help='Use double precision on the GPU.'
+    )
+    p.add_argument('-n', action='store', type=int, dest='n',
+                   default=10000, help='Number of particles.')
+    o = p.parse_args()
+    get_config().use_openmp = o.openmp
+    get_config().use_double = o.use_double
+    run(o.n, o.backend)

--- a/examples/cpy/vm_elementwise_jit.py
+++ b/examples/cpy/vm_elementwise_jit.py
@@ -6,10 +6,10 @@ from pysph.cpy.config import get_config
 from pysph.cpy.api import declare, annotate
 from pysph.cpy.parallel import Elementwise
 from pysph.cpy.array import wrap
-from pysph.cpy.jit import jit, ElementwiseJIT
+from pysph.cpy.jit import annotate
 
 
-@jit
+@annotate
 def point_vortex(xi, yi, xj, yj, gamma, result):
     xij = xi - xj
     yij = yi - yj
@@ -23,7 +23,7 @@ def point_vortex(xi, yi, xj, yj, gamma, result):
         result[1] = tmp*xij
 
 
-@jit
+@annotate
 def velocity(i, x, y, gamma, u, v, nv):
     j = declare('int')
     tmp = declare('matrix(2)')
@@ -48,7 +48,7 @@ def make_vortices(nv, backend):
 
 
 def run(nv, backend):
-    e = ElementwiseJIT(velocity, backend=backend)
+    e = Elementwise(velocity, backend=backend)
     args = make_vortices(nv, backend)
     t1 = time.time()
     e(*args)

--- a/examples/cpy/vm_elementwise_jit.py
+++ b/examples/cpy/vm_elementwise_jit.py
@@ -6,7 +6,6 @@ from pysph.cpy.config import get_config
 from pysph.cpy.api import declare, annotate
 from pysph.cpy.parallel import Elementwise
 from pysph.cpy.array import wrap
-from pysph.cpy.jit import annotate
 
 
 @annotate

--- a/pysph/cpy/jit.py
+++ b/pysph/cpy/jit.py
@@ -1,0 +1,74 @@
+from functools import wraps
+from textwrap import wrap
+
+from mako.template import Template
+from pytools import memoize_method
+import numpy as np
+import inspect
+
+from .config import get_config
+from .cython_generator import get_parallel_range, CythonGenerator
+from .transpiler import Transpiler, convert_to_float_if_needed
+from .types import dtype_to_ctype, annotate
+from .parallel import Elementwise
+
+import pysph.cpy.array as array
+
+
+def get_ctype_from_arg(arg):
+    if isinstance(arg, array.Array):
+        return arg.gptr_type
+    elif isinstance(arg, np.ndarray):
+        return dtype_to_ctype(arg.dtype)
+    else:
+        return False
+
+
+class ElementwiseJIT(Elementwise):
+    def __init__(self, func, backend='cython'):
+        backend = array.get_backend(backend)
+        self.tp = Transpiler(backend=backend)
+        self.backend = backend
+        self.name = func.__name__
+        self.func = func
+        self._config = get_config()
+        self.cython_gen = CythonGenerator()
+        self.queue = None
+
+    @memoize_method
+    def _generate_kernel(self, *args):
+        type_info = {'i' : 'int'}
+        c_args = []
+        arg_names = inspect.getargspec(self.func)[0]
+        arg_names.remove('i')
+        for arg, name in zip(args, arg_names):
+            if name == 'i':
+                arg_type = 'int'
+            else:
+                arg_type = get_ctype_from_arg(arg)
+            if not arg_type:
+                arg = np.asarray(arg, dtype=np.float64)
+                arg_type = 'double'
+            c_args.append(self._massage_arg(arg))
+            type_info[name] = arg_type
+
+        self.func = annotate(self.func, **type_info)
+
+        return c_args, self._generate()
+
+    def __call__(self, *args, **kw):
+        c_args, c_func = self._generate_kernel(*args)
+
+        if self.backend == 'cython':
+            size = len(c_args[0])
+            c_args.insert(0, size)
+            c_func(*c_args, **kw)
+        elif self.backend == 'opencl':
+            c_func(*c_args, **kw)
+            self.queue.finish()
+        elif self.backend == 'cuda':
+            import pycuda.driver as drv
+            event = drv.Event()
+            c_func(*c_args, **kw)
+            event.record()
+            event.synchronize()

--- a/pysph/cpy/jit.py
+++ b/pysph/cpy/jit.py
@@ -470,6 +470,7 @@ class ScanJIT(parallel.ScanBase):
         if self.input_func is not None:
             arg_types = self.get_type_info_from_kwargs(
                 self.input_func, **kwargs)
+            arg_types['return_'] = dtype_to_knowntype(self.dtype)
             helper = AnnotationHelper(self.input_func, arg_types)
             helper.annotate()
             self.input_func = helper.func
@@ -486,6 +487,7 @@ class ScanJIT(parallel.ScanBase):
         if self.is_segment_func is not None:
             arg_types = self.get_type_info_from_kwargs(
                 self.is_segment_func, **kwargs)
+            arg_types['return_'] = 'int'
             helper = AnnotationHelper(self.is_segment_func, arg_types)
             helper.annotate()
             self.is_segment_func = helper.func

--- a/pysph/cpy/jit.py
+++ b/pysph/cpy/jit.py
@@ -11,10 +11,14 @@ import sys
 
 from .config import get_config
 from .cython_generator import get_parallel_range, CythonGenerator
-from .transpiler import (Transpiler, convert_to_float_if_needed,
-        filter_calls, get_external_symbols_and_calls, BUILTINS)
+from .transpiler import (
+    Transpiler,
+    convert_to_float_if_needed,
+    filter_calls,
+    get_external_symbols_and_calls,
+    BUILTINS)
 from .types import (dtype_to_ctype, annotate, get_declare_info,
-        dtype_to_knowntype)
+                    dtype_to_knowntype)
 from .parallel import Elementwise, Reduction, Scan
 from .extern import Extern
 from .ast_utils import get_unknown_names_and_calls
@@ -61,7 +65,7 @@ def get_ctype_from_arg(arg):
         if isinstance(arg, float):
             return 'double'
         else:
-            return  'long'
+            return 'long'
 
 
 def get_binop_return_type(a, b):
@@ -78,7 +82,7 @@ def get_binop_return_type(a, b):
     idx_a = preference_order.index(a)
     idx_b = preference_order.index(b)
     return_type = preference_order[idx_a] if idx_a > idx_b else \
-            preference_order[idx_b]
+        preference_order[idx_b]
     if unsigned_a and unsigned_b:
         return_type = 'u%s' % return_type
     return return_type
@@ -112,7 +116,7 @@ class AnnotationHelper(ast.NodeVisitor):
             if node.lineno > 1:  # pragma no branch
                 msg += self._src[node.lineno - 2] + '\n'
             msg += self._src[node.lineno - 1] + '\n'
-            msg += ' '*node.col_offset + '^' + '\n\n'
+            msg += ' ' * node.col_offset + '^' + '\n\n'
         msg += message
         raise NotImplementedError(msg)
 
@@ -122,7 +126,7 @@ class AnnotationHelper(ast.NodeVisitor):
             if node.lineno > 1:  # pragma no branch
                 msg += self._src[node.lineno - 2] + '\n'
             msg += self._src[node.lineno - 1] + '\n'
-            msg += ' '*node.col_offset + '^' + '\n\n'
+            msg += ' ' * node.col_offset + '^' + '\n\n'
         msg += message
         warnings.warn(msg)
 
@@ -136,7 +140,7 @@ class AnnotationHelper(ast.NodeVisitor):
             return None
         if node.func.id in self.children:
             return self.children[node.func.id].arg_types.get(
-                    'return_', None)
+                'return_', None)
         if isinstance(node.func, ast.Name) and \
                 node.func.id not in BUILTINS:
             if f is None or isinstance(f, Extern):
@@ -147,10 +151,10 @@ class AnnotationHelper(ast.NodeVisitor):
                     arg_type = self.visit(arg)
                     if not arg_type:
                         msg = "Function called is not marked by the jit "\
-                                "decorator. Argument type defaulting to "\
-                                "'double'. If the type is not 'double', "\
-                                "store the value in a variable of "\
-                                "appropriate type and pass the variable"
+                            "decorator. Argument type defaulting to "\
+                            "'double'. If the type is not 'double', "\
+                            "store the value in a variable of "\
+                            "appropriate type and pass the variable"
                         self.warn(msg, arg)
                         arg_type = 'double'
                     arg_types.append(arg_type)
@@ -218,14 +222,14 @@ class AnnotationHelper(ast.NodeVisitor):
                 self.arg_types['return_'] = self.visit(node.value)
             else:
                 msg = "Function called is not marked by the jit "\
-                        "decorator. Return value defaulting to 'double'."\
-                        "If the return type is not 'double', store the value "\
-                        "in a variable of appropriate type and return the "\
-                        "variable"
+                    "decorator. Return value defaulting to 'double'."\
+                    "If the return type is not 'double', store the value "\
+                    "in a variable of appropriate type and return the "\
+                    "variable"
                 self.warn(msg, node.value)
                 self.arg_types['return_'] = 'double'
         else:
-            self.warn("Unknown type for return value. "\
+            self.warn("Unknown type for return value. "
                       "Return value defaulting to 'double'", node)
             self.arg_types['return_'] = 'double'
 
@@ -439,7 +443,7 @@ class ScanJIT(Scan):
         self.cython_gen = CythonGenerator()
         self.queue = None
         builtin_symbols = ['item', 'prev_item', 'last_item']
-        self.builtin_types = {'i' : 'int', 'N' : 'int'}
+        self.builtin_types = {'i': 'int', 'N': 'int'}
         for sym in builtin_symbols:
             self.builtin_types[sym] = dtype_to_knowntype(self.dtype)
 
@@ -464,7 +468,7 @@ class ScanJIT(Scan):
         external_funcs = {}
         if self.input_func is not None:
             arg_types = self.get_type_info_from_kwargs(
-                    self.input_func, **kwargs)
+                self.input_func, **kwargs)
             helper = AnnotationHelper(self.input_func, arg_types)
             helper.annotate()
             self.input_func = helper.func
@@ -472,7 +476,7 @@ class ScanJIT(Scan):
 
         if self.output_func is not None:
             arg_types = self.get_type_info_from_kwargs(
-                    self.output_func, **kwargs)
+                self.output_func, **kwargs)
             helper = AnnotationHelper(self.output_func, arg_types)
             helper.annotate()
             self.output_func = helper.func
@@ -480,7 +484,7 @@ class ScanJIT(Scan):
 
         if self.is_segment_func is not None:
             arg_types = self.get_type_info_from_kwargs(
-                    self.is_segment_func, **kwargs)
+                self.is_segment_func, **kwargs)
             helper = AnnotationHelper(self.is_segment_func, arg_types)
             helper.annotate()
             self.is_segment_func = helper.func

--- a/pysph/cpy/jit.py
+++ b/pysph/cpy/jit.py
@@ -38,7 +38,10 @@ def get_ctype_from_arg(arg):
     elif isinstance(arg, np.ndarray):
         return dtype_to_ctype(arg.dtype)
     else:
-        return False
+        if isinstance(arg, float):
+            return 'double'
+        else:
+            return  'long'
 
 
 def memoize(f):
@@ -289,7 +292,7 @@ class ElementwiseJIT(Elementwise):
         elif isinstance(x, np.ndarray):
             return x
         else:
-            return np.asarray(x, dtype=np.float64)
+            return np.asarray(x)
 
     def __call__(self, *args, **kw):
         c_func = self._generate_kernel(*args)
@@ -365,7 +368,7 @@ class ReductionJIT(Reduction):
         elif isinstance(x, np.ndarray):
             return x
         else:
-            return np.asarray(x, dtype=np.float64)
+            return np.asarray(x)
 
     def __call__(self, *args, **kw):
         c_func = self._generate_kernel(*args)
@@ -473,7 +476,7 @@ class ScanJIT(Scan):
         elif isinstance(x, np.ndarray):
             return x
         else:
-            return np.asarray(x, dtype=np.float64)
+            return np.asarray(x)
 
     def __call__(self, **kwargs):
         c_func = self._generate_kernel(**kwargs)

--- a/pysph/cpy/jit.py
+++ b/pysph/cpy/jit.py
@@ -1,16 +1,20 @@
 from functools import wraps
-from textwrap import wrap
+from textwrap import dedent, wrap
 
 from mako.template import Template
 from pytools import memoize_method
 import numpy as np
 import inspect
+import ast
+import importlib
 
 from .config import get_config
 from .cython_generator import get_parallel_range, CythonGenerator
-from .transpiler import Transpiler, convert_to_float_if_needed
-from .types import dtype_to_ctype, annotate
+from .transpiler import Transpiler, convert_to_float_if_needed, \
+        filter_calls, BUILTINS
+from .types import dtype_to_ctype, annotate, get_declare_info
 from .parallel import Elementwise
+from .extern import Extern
 
 import pysph.cpy.array as array
 
@@ -22,6 +26,109 @@ def get_ctype_from_arg(arg):
         return dtype_to_ctype(arg.dtype)
     else:
         return False
+
+
+class JITHelper(ast.NodeVisitor):
+    def __init__(self, func):
+        self.func = func
+        self.calls = set()
+        self.arg_types = {}
+
+    def annotate(self, *args):
+        func, self.type_info = self.annotate_func(*args)
+        self.annotate_external_funcs()
+        return func
+
+    def annotate_func(self, *args):
+        type_info = {'i' : 'int'}
+        arg_names = inspect.getargspec(self.func)[0]
+        arg_names.remove('i')
+        for arg, name in zip(args, arg_names):
+            arg_type = get_ctype_from_arg(arg)
+            if not arg_type:
+                arg_type = 'double'
+            type_info[name] = arg_type
+
+        self.func = annotate(self.func, **type_info)
+        return self.func, type_info
+
+    def get_type(self, type_str):
+        kind, address_space, ctype, shape = get_declare_info(type_str)
+        if kind == 'matrix':
+            ctype = '%sp' % ctype
+        return ctype
+
+    def annotate_external_funcs(self):
+        src = dedent('\n'.join(inspect.getsourcelines(self.func)[0]))
+        self._src = src.splitlines()
+        code = ast.parse(src)
+        self.visit(code)
+
+        mod = importlib.import_module(self.func.__module__)
+        calls = filter_calls(self.calls)
+        undefined = []
+        for call in calls:
+            f = getattr(mod, call, None)
+            if f is None:
+                undefined.append(call)
+            elif not isinstance(f, Extern):
+                f_arg_names = inspect.getargspec(f)[0]
+                annotations = dict(zip(f_arg_names, self.arg_types[call]))
+                new_f = annotate(f, **annotations)
+                setattr(mod, call, new_f)
+        if undefined:
+            msg = 'The following functions are not defined:\n %s ' % (
+                ', '.join(undefined)
+            )
+            raise NameError(msg)
+
+    def error(self, message, node):
+        msg = '\nError in code in line %d:\n' % node.lineno
+        if self._src:  # pragma: no branch
+            if node.lineno > 1:  # pragma no branch
+                msg += self._src[node.lineno - 2] + '\n'
+            msg += self._src[node.lineno - 1] + '\n'
+            msg += ' '*node.col_offset + '^' + '\n\n'
+        msg += message
+        raise NotImplementedError(msg)
+
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Name) and \
+                node.func.id not in BUILTINS:
+            self.calls.add(node.func.id)
+            arg_types = []
+            for arg in node.args:
+                arg_type = self.visit(arg)
+                arg_types.append(arg_type)
+            self.arg_types[node.func.id] = arg_types
+
+    def visit_Subscript(self, node):
+        base_type = self.visit(node.value)
+        if base_type.startswith('g'):
+            base_type = base_type[1:]
+        return base_type[:-1]
+
+    def visit_Name(self, node):
+        node_type = self.type_info.get(node.id, 'double')
+        return node_type
+
+    def visit_Assign(self, node):
+        if len(node.targets) != 1:
+            self.error("Assignments can have only one target.", node)
+        left, right = node.targets[0], node.value
+        if isinstance(right, ast.Call) and \
+           isinstance(right.func, ast.Name) and right.func.id == 'declare':
+            if not isinstance(right.args[0], ast.Str):
+                self.error("Argument to declare should be a string.", node)
+            type = right.args[0].s
+            if isinstance(left, ast.Name):
+                if left.id in self.type_info:
+                    self.error("Redeclaring variable not allowed")
+                self.type_info[left.id] = self.get_type(type)
+            elif isinstance(left, ast.Tuple):
+                names = [x.id for x in left.elts]
+                for name in names:
+                    self.type_info[name] = self.get_type(type)
 
 
 class ElementwiseJIT(Elementwise):
@@ -37,27 +144,23 @@ class ElementwiseJIT(Elementwise):
 
     @memoize_method
     def _generate_kernel(self, *args):
-        type_info = {'i' : 'int'}
-        c_args = []
-        arg_names = inspect.getargspec(self.func)[0]
-        arg_names.remove('i')
-        for arg, name in zip(args, arg_names):
-            if name == 'i':
-                arg_type = 'int'
-            else:
-                arg_type = get_ctype_from_arg(arg)
-            if not arg_type:
-                arg = np.asarray(arg, dtype=np.float64)
-                arg_type = 'double'
-            c_args.append(self._massage_arg(arg))
-            type_info[name] = arg_type
+        # FIXME: Memoization doesn't work with np.ndarray as argument
+        self.helper = JITHelper(self.func)
+        self.func = self.helper.annotate(*args)
 
-        self.func = annotate(self.func, **type_info)
+        return self._generate()
 
-        return c_args, self._generate()
+    def _massage_arg(self, x):
+        if isinstance(x, array.Array):
+            return x.dev
+        elif isinstance(x, np.ndarray):
+            return x
+        else:
+            return np.asarray(x, dtype=np.float64)
 
     def __call__(self, *args, **kw):
-        c_args, c_func = self._generate_kernel(*args)
+        c_func = self._generate_kernel(*args)
+        c_args = [self._massage_arg(x) for x in args]
 
         if self.backend == 'cython':
             size = len(c_args[0])

--- a/pysph/cpy/jit.py
+++ b/pysph/cpy/jit.py
@@ -215,7 +215,7 @@ def gather_external_funcs(f_helper, external_f):
     node_name = f_helper.func.__name__
     if node_name not in external_f:
         external_f[node_name] = []
-    for name, child in f_helper.children.iteritems():
+    for name, child in f_helper.children.items():
         external_f[node_name].append(child.func)
         gather_external_funcs(child, external_f)
 

--- a/pysph/cpy/jit.py
+++ b/pysph/cpy/jit.py
@@ -12,8 +12,8 @@ from .config import get_config
 from .cython_generator import get_parallel_range, CythonGenerator
 from .transpiler import (Transpiler, convert_to_float_if_needed,
         filter_calls, get_external_symbols_and_calls, BUILTINS)
-from .types import dtype_to_ctype, annotate, get_declare_info, \
-        dtype_to_knowntype
+from .types import (dtype_to_ctype, annotate, get_declare_info,
+        dtype_to_knowntype)
 from .parallel import Elementwise, Reduction, Scan
 from .extern import Extern
 from .ast_utils import get_unknown_names_and_calls
@@ -32,18 +32,6 @@ def jit(func):
         return wrapper(func)
 
 
-def get_ctype_from_arg(arg):
-    if isinstance(arg, array.Array):
-        return arg.gptr_type
-    elif isinstance(arg, np.ndarray):
-        return dtype_to_ctype(arg.dtype)
-    else:
-        if isinstance(arg, float):
-            return 'double'
-        else:
-            return  'long'
-
-
 def memoize(f):
     @wraps(f)
     def wrapper(obj, *args, **kwargs):
@@ -54,6 +42,18 @@ def memoize(f):
             obj.cache[key] = f(obj, *args, **kwargs)
         return obj.cache[key]
     return wrapper
+
+
+def get_ctype_from_arg(arg):
+    if isinstance(arg, array.Array):
+        return arg.gptr_type
+    elif isinstance(arg, np.ndarray):
+        return dtype_to_ctype(arg.dtype)
+    else:
+        if isinstance(arg, float):
+            return 'double'
+        else:
+            return  'long'
 
 
 def get_binop_return_type(a, b):

--- a/pysph/cpy/jit.py
+++ b/pysph/cpy/jit.py
@@ -119,6 +119,8 @@ class AnnotationHelper(ast.NodeVisitor):
         warnings.warn(msg)
 
     def visit_Call(self, node):
+        # FIXME: External functions have to be at the module level
+        # for this to work
         mod = importlib.import_module(self.func.__module__)
         f = getattr(mod, node.func.id, None)
         if not hasattr(f, 'is_jit'):
@@ -181,6 +183,7 @@ class AnnotationHelper(ast.NodeVisitor):
         if isinstance(node.n, float):
             return_type = 'double'
         else:
+            print node.n
             if node.n > 2147483648:
                 return_type = 'long'
             else:

--- a/pysph/cpy/jit.py
+++ b/pysph/cpy/jit.py
@@ -55,7 +55,7 @@ class AnnotationHelper(ast.NodeVisitor):
         return ctype
 
     def get_type_info_for_external_funcs(self):
-        self.type_info = getattr(self.func, '__annotations__')
+        self.type_info = getattr(self.func, 'type_info')
         src = dedent('\n'.join(inspect.getsourcelines(self.func)[0]))
         self._src = src.splitlines()
         code = ast.parse(src)
@@ -122,8 +122,6 @@ class AnnotationHelper(ast.NodeVisitor):
                 self.error("Argument to declare should be a string.", node)
             type = right.args[0].s
             if isinstance(left, ast.Name):
-                if left.id in self.type_info:
-                    self.error("Redeclaring variable not allowed")
                 self.type_info[left.id] = self.get_type(type)
             elif isinstance(left, ast.Tuple):
                 names = [x.id for x in left.elts]

--- a/pysph/cpy/jit.py
+++ b/pysph/cpy/jit.py
@@ -2,7 +2,6 @@ from functools import wraps
 from textwrap import dedent, wrap
 
 from mako.template import Template
-from pytools import memoize_method
 import numpy as np
 import inspect
 import ast
@@ -13,7 +12,7 @@ from .cython_generator import get_parallel_range, CythonGenerator
 from .transpiler import Transpiler, convert_to_float_if_needed, \
         filter_calls, BUILTINS
 from .types import dtype_to_ctype, annotate, get_declare_info
-from .parallel import Elementwise
+from .parallel import Elementwise, Reduction, Scan
 from .extern import Extern
 
 import pysph.cpy.array as array
@@ -46,23 +45,12 @@ class JITHelper(ast.NodeVisitor):
         self.calls = set()
         self.arg_types = {}
 
-    def annotate(self, *args):
-        func, self.type_info = self.annotate_func(*args)
-        self.annotate_external_funcs()
-        return func
-
-    def annotate_func(self, *args):
-        type_info = {'i' : 'int'}
-        arg_names = inspect.getargspec(self.func)[0]
-        arg_names.remove('i')
-        for arg, name in zip(args, arg_names):
-            arg_type = get_ctype_from_arg(arg)
-            if not arg_type:
-                arg_type = 'double'
-            type_info[name] = arg_type
-
+    def annotate(self, type_info):
+        self.type_info = type_info
         self.func = annotate(self.func, **type_info)
-        return self.func, type_info
+        mod = importlib.import_module(self.func.__module__)
+        setattr(mod, self.func.__name__, self.func)
+        self.annotate_external_funcs()
 
     def get_type(self, type_str):
         kind, address_space, ctype, shape = get_declare_info(type_str)
@@ -86,8 +74,8 @@ class JITHelper(ast.NodeVisitor):
             elif not isinstance(f, Extern):
                 f_arg_names = inspect.getargspec(f)[0]
                 annotations = dict(zip(f_arg_names, self.arg_types[call]))
-                new_f = annotate(f, **annotations)
-                setattr(mod, call, new_f)
+                helper = JITHelper(f)
+                helper.annotate(annotations)
         if undefined:
             msg = 'The following functions are not defined:\n %s ' % (
                 ', '.join(undefined)
@@ -154,11 +142,25 @@ class ElementwiseJIT(Elementwise):
         self.cython_gen = CythonGenerator()
         self.queue = None
 
+    def get_type_info_from_args(self, *args):
+        type_info = {}
+        arg_names = inspect.getargspec(self.func)[0]
+        if 'i' in arg_names:
+            arg_names.remove('i')
+            type_info['i'] = 'int'
+        for arg, name in zip(args, arg_names):
+            arg_type = get_ctype_from_arg(arg)
+            if not arg_type:
+                arg_type = 'double'
+            type_info[name] = arg_type
+        return type_info
+
     @memoize
     def _generate_kernel(self, *args):
-        # FIXME: Memoization doesn't work with np.ndarray as argument
-        self.helper = JITHelper(self.func)
-        self.func = self.helper.annotate(*args)
+        if self.func is not None:
+            annotations = self.get_type_info_from_args(*args)
+            self.helper = JITHelper(self.func)
+            self.helper.annotate(annotations)
         return self._generate()
 
     def _massage_arg(self, x):
@@ -186,3 +188,79 @@ class ElementwiseJIT(Elementwise):
             c_func(*c_args, **kw)
             event.record()
             event.synchronize()
+
+
+class ReductionJIT(Reduction):
+    def __init__(self, reduce_expr, map_func=None, dtype_out=np.float64,
+                 neutral='0', backend='cython'):
+        backend = array.get_backend(backend)
+        self.tp = Transpiler(backend=backend)
+        self.backend = backend
+        self.func = map_func
+        if map_func is not None:
+            self.name = 'reduce_' + map_func.__name__
+        else:
+            self.name = 'reduce'
+        self.reduce_expr = reduce_expr
+        self.dtype_out = dtype_out
+        self.type = dtype_to_ctype(dtype_out)
+        if backend == 'cython':
+            # On Windows, INFINITY is not defined so we use INFTY which we
+            # internally define.
+            self.neutral = neutral.replace('INFINITY', 'INFTY')
+        else:
+            self.neutral = neutral
+        self._config = get_config()
+        self.cython_gen = CythonGenerator()
+        self.queue = None
+        #self._generate()
+
+    def get_type_info_from_args(self, *args):
+        type_info = {}
+        arg_names = inspect.getargspec(self.func)[0]
+        if 'i' in arg_names:
+            arg_names.remove('i')
+            type_info['i'] = 'int'
+        for arg, name in zip(args, arg_names):
+            arg_type = get_ctype_from_arg(arg)
+            if not arg_type:
+                arg_type = 'double'
+            type_info[name] = arg_type
+        return type_info
+
+    @memoize
+    def _generate_kernel(self, *args):
+        if self.func is not None:
+            annotations = self.get_type_info_from_args(*args)
+            self.helper = JITHelper(self.func)
+            self.helper.annotate(annotations)
+        return self._generate()
+
+    def _massage_arg(self, x):
+        if isinstance(x, array.Array):
+            return x.dev
+        elif isinstance(x, np.ndarray):
+            return x
+        else:
+            return np.asarray(x, dtype=np.float64)
+
+    def __call__(self, *args, **kw):
+        c_func = self._generate_kernel(*args)
+        c_args = [self._massage_arg(x) for x in args]
+
+        if self.backend == 'cython':
+            size = len(c_args[0])
+            c_args.insert(0, size)
+            return c_func(*c_args, **kw)
+        elif self.backend == 'opencl':
+            result = c_func(*c_args, **kw)
+            self.queue.finish()
+            return result.get()
+        elif self.backend == 'cuda':
+            import pycuda.driver as drv
+            event = drv.Event()
+            result = c_func(*c_args, **kw)
+            event.record()
+            event.synchronize()
+            return result.get()
+

--- a/pysph/cpy/jit.py
+++ b/pysph/cpy/jit.py
@@ -183,7 +183,6 @@ class AnnotationHelper(ast.NodeVisitor):
         if isinstance(node.n, float):
             return_type = 'double'
         else:
-            print node.n
             if node.n > 2147483648:
                 return_type = 'long'
             else:

--- a/pysph/cpy/jit.py
+++ b/pysph/cpy/jit.py
@@ -6,12 +6,14 @@ import numpy as np
 import inspect
 import ast
 import importlib
+import warnings
 
 from .config import get_config
 from .cython_generator import get_parallel_range, CythonGenerator
 from .transpiler import Transpiler, convert_to_float_if_needed, \
         filter_calls, BUILTINS
-from .types import dtype_to_ctype, annotate, get_declare_info
+from .types import dtype_to_ctype, annotate, get_declare_info, \
+        dtype_to_knowntype
 from .parallel import Elementwise, Reduction, Scan
 from .extern import Extern
 
@@ -47,10 +49,11 @@ class JITHelper(ast.NodeVisitor):
 
     def annotate(self, type_info):
         self.type_info = type_info
-        self.func = annotate(self.func, **type_info)
-        mod = importlib.import_module(self.func.__module__)
-        setattr(mod, self.func.__name__, self.func)
         self.annotate_external_funcs()
+        mod = importlib.import_module(self.func.__module__)
+        print self.type_info
+        self.func = annotate(self.func, **self.type_info)
+        setattr(mod, self.func.__name__, self.func)
 
     def get_type(self, type_str):
         kind, address_space, ctype, shape = get_declare_info(type_str)
@@ -92,6 +95,16 @@ class JITHelper(ast.NodeVisitor):
         msg += message
         raise NotImplementedError(msg)
 
+    def warn(self, message, node):
+        msg = '\nIn code in line %d:\n' % node.lineno
+        if self._src:  # pragma: no branch
+            if node.lineno > 1:  # pragma no branch
+                msg += self._src[node.lineno - 2] + '\n'
+            msg += self._src[node.lineno - 1] + '\n'
+            msg += ' '*node.col_offset + '^' + '\n\n'
+        msg += message
+        warnings.warn(msg)
+
     def visit_Call(self, node):
         if isinstance(node.func, ast.Name) and \
                 node.func.id not in BUILTINS:
@@ -130,6 +143,16 @@ class JITHelper(ast.NodeVisitor):
                 for name in names:
                     self.type_info[name] = self.get_type(type)
 
+    def visit_Return(self, node):
+        if isinstance(node.value, ast.Name) or \
+                isinstance(node.value, ast.Subscript):
+            self.type_info['return_'] = self.visit(node.value)
+        else:
+            self.warn("Return value should be a variable or a "\
+                    "subscript. Return value will default to 'double' "\
+                    "otherwise", node)
+            self.type_info['return_'] = 'double'
+
 
 class ElementwiseJIT(Elementwise):
     def __init__(self, func, backend='cython'):
@@ -159,8 +182,8 @@ class ElementwiseJIT(Elementwise):
     def _generate_kernel(self, *args):
         if self.func is not None:
             annotations = self.get_type_info_from_args(*args)
-            self.helper = JITHelper(self.func)
-            self.helper.annotate(annotations)
+            helper = JITHelper(self.func)
+            helper.annotate(annotations)
         return self._generate()
 
     def _massage_arg(self, x):
@@ -232,8 +255,8 @@ class ReductionJIT(Reduction):
     def _generate_kernel(self, *args):
         if self.func is not None:
             annotations = self.get_type_info_from_args(*args)
-            self.helper = JITHelper(self.func)
-            self.helper.annotate(annotations)
+            helper = JITHelper(self.func)
+            helper.annotate(annotations)
         return self._generate()
 
     def _massage_arg(self, x):
@@ -264,3 +287,88 @@ class ReductionJIT(Reduction):
             event.synchronize()
             return result.get()
 
+
+class ScanJIT(Scan):
+    def __init__(self, input=None, output=None, scan_expr="a+b",
+                 is_segment=None, dtype=np.float64, neutral='0',
+                 complex_map=False, backend='opencl'):
+        backend = array.get_backend(backend)
+        self.tp = Transpiler(backend=backend, incl_cluda=False)
+        self.backend = backend
+        self.input_func = input
+        self.output_func = output
+        self.is_segment_func = is_segment
+        self.complex_map = complex_map
+        if input is not None:
+            self.name = 'scan_' + input.__name__
+        else:
+            self.name = 'scan'
+        self.scan_expr = scan_expr
+        self.dtype = dtype
+        self.type = dtype_to_ctype(dtype)
+        self.arg_keys = None
+        if backend == 'cython':
+            # On Windows, INFINITY is not defined so we use INFTY which we
+            # internally define.
+            self.neutral = neutral.replace('INFINITY', 'INFTY')
+        else:
+            self.neutral = neutral
+        self._config = get_config()
+        self.cython_gen = CythonGenerator()
+        self.queue = None
+        builtin_symbols = ['item', 'prev_item', 'last_item']
+        self.builtin_types = {'i' : 'int', 'N' : 'int'}
+        for sym in builtin_symbols:
+            self.builtin_types[sym] = dtype_to_knowntype(self.dtype)
+
+    def get_type_info_from_kwargs(self, func, **kwargs):
+        type_info = {}
+        arg_names = inspect.getargspec(func)[0]
+        for name in arg_names:
+            arg = kwargs.get(name, None)
+            if arg is None and name not in self.builtin_types:
+                raise ValueError("Argument %s not found" % name)
+            if name in self.builtin_types:
+                arg_type = self.builtin_types[name]
+            else:
+                arg_type = get_ctype_from_arg(arg)
+            if not arg_type:
+                arg_type = 'double'
+            type_info[name] = arg_type
+        return type_info
+
+    @memoize
+    def _generate_kernel(self, **kwargs):
+        funcs = [self.input_func, self.output_func, self.is_segment_func]
+        for func in funcs:
+            if func is not None:
+                annotations = self.get_type_info_from_kwargs(func, **kwargs)
+                helper = JITHelper(func)
+                helper.annotate(annotations)
+        return self._generate()
+
+    def _massage_arg(self, x):
+        if isinstance(x, array.Array):
+            return x.dev
+        elif isinstance(x, np.ndarray):
+            return x
+        else:
+            return np.asarray(x, dtype=np.float64)
+
+    def __call__(self, **kwargs):
+        c_func = self._generate_kernel(**kwargs)
+        c_args_dict = {k: self._massage_arg(x) for k, x in kwargs.items()}
+
+        if self.backend == 'cython':
+            size = len(c_args_dict[self.arg_keys[1]])
+            c_args_dict['SIZE'] = size
+            c_func(*[c_args_dict[k] for k in self.arg_keys])
+        elif self.backend == 'opencl':
+            c_func(*[c_args_dict[k] for k in self.arg_keys])
+            self.queue.finish()
+        elif self.backend == 'cuda':
+            import pycuda.driver as drv
+            event = drv.Event()
+            c_func(*[c_args_dict[k] for k in self.arg_keys])
+            event.record()
+            event.synchronize()

--- a/pysph/cpy/jit.py
+++ b/pysph/cpy/jit.py
@@ -85,7 +85,7 @@ class AnnotationHelper(ast.NodeVisitor):
         self.warning_msg = ('''
             Function called is not marked by the annotate decorator. Argument
             type defaulting to 'double'. If the type is not 'double', store
-            the value in a variable of appropriate type and pass the variable
+            the value in a variable of appropriate type and use the variable
             '''
         )
 
@@ -144,12 +144,6 @@ class AnnotationHelper(ast.NodeVisitor):
                 for arg in node.args:
                     arg_type = self.visit(arg)
                     if not arg_type:
-                        msg = ('''
-                        Function called is not marked by the jit decorator.
-                        Argument type defaulting to 'double'. If the type
-                        is not 'double',store the value in a variable of
-                        appropriate type and pass the variable'''
-                               )
                         self.warn(dedent(self.warning_msg), arg)
                         arg_type = 'double'
                     arg_types.append(arg_type)
@@ -231,9 +225,9 @@ def gather_external_funcs(f_helper, external_f):
     node_name = f_helper.func.__name__
     if node_name not in external_f:
         external_f[node_name] = []
-    for name, child in f_helper.external_funcs.items():
-        external_f[node_name].append(child.func)
-        gather_external_funcs(child, external_f)
+    for name, external in f_helper.external_funcs.items():
+        external_f[node_name].append(external.func)
+        gather_external_funcs(external, external_f)
 
 
 class TranspilerJIT(Transpiler):

--- a/pysph/cpy/parallel.py
+++ b/pysph/cpy/parallel.py
@@ -507,7 +507,7 @@ class ElementwiseBase(object):
 
 class Elementwise(object):
     def __init__(self, func, backend='cython'):
-        if hasattr(func, 'has_annotations'):
+        if getattr(func, '__annotations__', None):
             self.elementwise = ElementwiseBase(func, backend=backend)
         else:
             from pysph.cpy.jit import ElementwiseJIT
@@ -724,7 +724,7 @@ class ReductionBase(object):
 class Reduction(object):
     def __init__(self, reduce_expr, map_func=None, dtype_out=np.float64,
                  neutral='0', backend='cython'):
-        if map_func is None or hasattr(map_func, 'has_annotations'):
+        if map_func is None or getattr(map_func, '__annotations__', None):
             self.reduction = ReductionBase(reduce_expr, map_func=map_func,
                                            dtype_out=dtype_out,
                                            neutral=neutral,
@@ -1071,11 +1071,11 @@ class Scan(object):
                  is_segment=None, dtype=np.float64, neutral='0',
                  complex_map=False, backend='opencl'):
         input_base = input is None or \
-            hasattr(input, 'has_annotations')
+            getattr(input, '__annotations__', None)
         output_base = output is None or \
-            hasattr(output, 'has_annotations')
+            getattr(output, '__annotations__', None)
         is_segment_base = is_segment is None or \
-            hasattr(is_segment, 'has_annotations')
+            getattr(is_segment, '__annotations__', None)
 
         if input_base and output_base and is_segment_base:
             self.scan = ScanBase(input=input, output=output,

--- a/pysph/cpy/parallel.py
+++ b/pysph/cpy/parallel.py
@@ -375,7 +375,7 @@ def drop_duplicates(arr):
     return result
 
 
-class Elementwise(object):
+class ElementwiseBase(object):
     def __init__(self, func, backend='cython'):
         backend = array.get_backend(backend)
         self.tp = Transpiler(backend=backend)
@@ -505,6 +505,21 @@ class Elementwise(object):
             event.synchronize()
 
 
+class Elementwise(object):
+    def __init__(self, func, backend='cython'):
+        if hasattr(func, '__annotations__'):
+            self.elementwise = ElementwiseBase(func, backend=backend)
+        else:
+            from pysph.cpy.jit import ElementwiseJIT
+            self.elementwise = ElementwiseJIT(func, backend=backend)
+
+    def __getattr__(self, name):
+        return getattr(self.elementwise, name)
+
+    def __call__(self, *args, **kwargs):
+        self.elementwise(*args, **kwargs)
+
+
 def elementwise(func=None, backend=None):
     def _wrapper(function):
         return wraps(function)(Elementwise(function, backend=backend))
@@ -515,7 +530,7 @@ def elementwise(func=None, backend=None):
         return _wrapper(func)
 
 
-class Reduction(object):
+class ReductionBase(object):
     def __init__(self, reduce_expr, map_func=None, dtype_out=np.float64,
                  neutral='0', backend='cython'):
         backend = array.get_backend(backend)
@@ -706,7 +721,29 @@ class Reduction(object):
             return result.get()
 
 
-class Scan(object):
+class Reduction(object):
+    def __init__(self, reduce_expr, map_func=None, dtype_out=np.float64,
+                 neutral='0', backend='cython'):
+        if map_func is not None and hasattr(map_func, '__annotations__'):
+            self.reduction = ReductionBase(reduce_expr, map_func=map_func,
+                                           dtype_out=dtype_out,
+                                           neutral=neutral,
+                                           backend=backend)
+        else:
+            from pysph.cpy.jit import ReductionJIT
+            self.reduction = ReductionJIT(reduce_expr, map_func=map_func,
+                                          dtype_out=dtype_out,
+                                          neutral=neutral,
+                                          backend=backend)
+
+    def __getattr__(self, name):
+        return getattr(self.reduction, name)
+
+    def __call__(self, *args, **kwargs):
+        return self.reduction(*args, **kwargs)
+
+
+class ScanBase(object):
     def __init__(self, input=None, output=None, scan_expr="a+b",
                  is_segment=None, dtype=np.float64, neutral='0',
                  complex_map=False, backend='opencl'):
@@ -1027,3 +1064,37 @@ class Scan(object):
             self.c_func(*[c_args_dict[k] for k in self.arg_keys])
             event.record()
             event.synchronize()
+
+
+class Scan(object):
+    def __init__(self, input=None, output=None, scan_expr="a+b",
+                 is_segment=None, dtype=np.float64, neutral='0',
+                 complex_map=False, backend='opencl'):
+        input_base = input is not None and \
+                hasattr(input, '__annotations__')
+        output_base = output is not None and \
+                hasattr(output, '__annotations__')
+        is_segment_base = is_segment is not None and \
+                hasattr(is_segment, '__annotations__')
+
+        if input_base and output_base and is_segment_base:
+            self.scan = ScanBase(input=input, output=output,
+                                 scan_expr=scan_expr,
+                                 is_segment=is_segment,
+                                 dtype=dtype, neutral=neutral,
+                                 complex_map=complex_map,
+                                 backend=backend)
+        else:
+            from pysph.cpy.jit import ScanJIT
+            self.scan = ScanJIT(input=input, output=output,
+                                scan_expr=scan_expr,
+                                is_segment=is_segment,
+                                dtype=dtype, neutral=neutral,
+                                complex_map=complex_map,
+                                backend=backend)
+
+    def __getattr__(self, name):
+        return getattr(self.scan, name)
+
+    def __call__(self, **kwargs):
+        self.scan(**kwargs)

--- a/pysph/cpy/parallel.py
+++ b/pysph/cpy/parallel.py
@@ -538,7 +538,7 @@ class Reduction(object):
         self._config = get_config()
         self.cython_gen = CythonGenerator()
         self.queue = None
-        self._generate()
+        self.c_func = self._generate()
 
     def _generate(self):
         if self.backend == 'cython':
@@ -573,7 +573,7 @@ class Reduction(object):
             )
             self.tp.add_code(src)
             self.tp.compile()
-            self.c_func = getattr(self.tp.mod, 'py_' + self.name)
+            return getattr(self.tp.mod, 'py_' + self.name)
         elif self.backend == 'opencl':
             if self.func is not None:
                 self.tp.add(self.func)
@@ -611,7 +611,7 @@ class Reduction(object):
                 arguments=arguments,
                 preamble="\n".join([cluda_preamble, preamble])
             )
-            self.c_func = knl
+            return knl
         elif self.backend == 'cuda':
             if self.func is not None:
                 self.tp.add(self.func)
@@ -647,7 +647,7 @@ class Reduction(object):
                 arguments=arguments,
                 preamble="\n".join([cluda_preamble, preamble])
             )
-            self.c_func = knl
+            return knl
 
     def _correct_return_type(self, c_data):
         code = self.tp.blocks[-1].code.splitlines()

--- a/pysph/cpy/parallel.py
+++ b/pysph/cpy/parallel.py
@@ -1071,11 +1071,11 @@ class Scan(object):
                  is_segment=None, dtype=np.float64, neutral='0',
                  complex_map=False, backend='opencl'):
         input_base = input is not None and \
-                hasattr(input, '__annotations__')
+            hasattr(input, '__annotations__')
         output_base = output is not None and \
-                hasattr(output, '__annotations__')
+            hasattr(output, '__annotations__')
         is_segment_base = is_segment is not None and \
-                hasattr(is_segment, '__annotations__')
+            hasattr(is_segment, '__annotations__')
 
         if input_base and output_base and is_segment_base:
             self.scan = ScanBase(input=input, output=output,

--- a/pysph/cpy/parallel.py
+++ b/pysph/cpy/parallel.py
@@ -734,7 +734,7 @@ class Scan(object):
         self._config = get_config()
         self.cython_gen = CythonGenerator()
         self.queue = None
-        self._generate()
+        self.c_func = self._generate()
 
     def _correct_return_type(self, c_data, modifier):
         code = self.tp.blocks[-1].code.splitlines()
@@ -772,11 +772,11 @@ class Scan(object):
 
     def _generate(self):
         if self.backend == 'opencl':
-            self._generate_opencl_kernel()
+            return self._generate_opencl_kernel()
         elif self.backend == 'cuda':
-            self._generate_cuda_kernel()
+            return self._generate_cuda_kernel()
         elif self.backend == 'cython':
-            self._generate_cython_code()
+            return self._generate_cython_code()
 
     def _default_cython_input_function(self):
         py_data = (['int i', '{type}[:] input'.format(type=self.type)],
@@ -878,7 +878,7 @@ class Scan(object):
         )
         self.tp.add_code(src)
         self.tp.compile()
-        self.c_func = getattr(self.tp.mod, 'py_' + self.name)
+        return getattr(self.tp.mod, 'py_' + self.name)
 
     def _wrap_ocl_function(self, func, func_type=None):
         if func is not None:
@@ -959,7 +959,7 @@ class Scan(object):
             is_segment_start_expr=segment_expr,
             preamble=preamble
         )
-        self.c_func = knl
+        return knl
 
     def _generate_cuda_kernel(self):
         scan_expr, arg_defn, input_expr, output_expr, \
@@ -977,7 +977,7 @@ class Scan(object):
             is_segment_start_expr=segment_expr,
             preamble=preamble
         )
-        self.c_func = knl
+        return knl
 
     def _add_address_space(self, arg):
         if '*' in arg and 'GLOBAL_MEM' not in arg:

--- a/pysph/cpy/parallel.py
+++ b/pysph/cpy/parallel.py
@@ -507,7 +507,7 @@ class ElementwiseBase(object):
 
 class Elementwise(object):
     def __init__(self, func, backend='cython'):
-        if hasattr(func, '__annotations__'):
+        if hasattr(func, '__annotations__') and getattr(func, '__annotations__'):
             self.elementwise = ElementwiseBase(func, backend=backend)
         else:
             from pysph.cpy.jit import ElementwiseJIT
@@ -724,7 +724,8 @@ class ReductionBase(object):
 class Reduction(object):
     def __init__(self, reduce_expr, map_func=None, dtype_out=np.float64,
                  neutral='0', backend='cython'):
-        if map_func is not None and hasattr(map_func, '__annotations__'):
+        if map_func is not None and hasattr(map_func, '__annotations__') and \
+                 getattr(map_func, '__annotations__'):
             self.reduction = ReductionBase(reduce_expr, map_func=map_func,
                                            dtype_out=dtype_out,
                                            neutral=neutral,
@@ -1071,11 +1072,14 @@ class Scan(object):
                  is_segment=None, dtype=np.float64, neutral='0',
                  complex_map=False, backend='opencl'):
         input_base = input is not None and \
-            hasattr(input, '__annotations__')
+            hasattr(input, '__annotations__') and \
+            getattr(input, '__annotations__')
         output_base = output is not None and \
-            hasattr(output, '__annotations__')
+            hasattr(output, '__annotations__') and \
+            getattr(output, '__annotations__')
         is_segment_base = is_segment is not None and \
-            hasattr(is_segment, '__annotations__')
+            hasattr(is_segment, '__annotations__') and \
+            getattr(is_segment, '__annotations__')
 
         if input_base and output_base and is_segment_base:
             self.scan = ScanBase(input=input, output=output,

--- a/pysph/cpy/parallel.py
+++ b/pysph/cpy/parallel.py
@@ -507,7 +507,7 @@ class ElementwiseBase(object):
 
 class Elementwise(object):
     def __init__(self, func, backend='cython'):
-        if hasattr(func, '__annotations__') and getattr(func, '__annotations__'):
+        if hasattr(func, 'has_annotations'):
             self.elementwise = ElementwiseBase(func, backend=backend)
         else:
             from pysph.cpy.jit import ElementwiseJIT
@@ -724,8 +724,7 @@ class ReductionBase(object):
 class Reduction(object):
     def __init__(self, reduce_expr, map_func=None, dtype_out=np.float64,
                  neutral='0', backend='cython'):
-        if map_func is not None and hasattr(map_func, '__annotations__') and \
-                 getattr(map_func, '__annotations__'):
+        if map_func is None or hasattr(map_func, 'has_annotations'):
             self.reduction = ReductionBase(reduce_expr, map_func=map_func,
                                            dtype_out=dtype_out,
                                            neutral=neutral,
@@ -1071,15 +1070,12 @@ class Scan(object):
     def __init__(self, input=None, output=None, scan_expr="a+b",
                  is_segment=None, dtype=np.float64, neutral='0',
                  complex_map=False, backend='opencl'):
-        input_base = input is not None and \
-            hasattr(input, '__annotations__') and \
-            getattr(input, '__annotations__')
-        output_base = output is not None and \
-            hasattr(output, '__annotations__') and \
-            getattr(output, '__annotations__')
-        is_segment_base = is_segment is not None and \
-            hasattr(is_segment, '__annotations__') and \
-            getattr(is_segment, '__annotations__')
+        input_base = input is None or \
+            hasattr(input, 'has_annotations')
+        output_base = output is None or \
+            hasattr(output, 'has_annotations')
+        is_segment_base = is_segment is None or \
+            hasattr(is_segment, 'has_annotations')
 
         if input_base and output_base and is_segment_base:
             self.scan = ScanBase(input=input, output=output,

--- a/pysph/cpy/tests/test_jit.py
+++ b/pysph/cpy/tests/test_jit.py
@@ -1,0 +1,126 @@
+from math import sin
+import unittest
+import numpy as np
+
+from pytest import importorskip
+
+from ..config import get_config, use_config
+from ..array import wrap
+from ..types import annotate
+from ..jit import ElementwiseJIT, ReductionJIT
+
+
+class TestJIT(unittest.TestCase):
+    def setUp(self):
+        cfg = get_config()
+        self._use_double = cfg.use_double
+        cfg.use_double = True
+
+    def tearDown(self):
+        get_config().use_double = self._use_double
+
+    def _check_simple_elementwise_jit(self, backend):
+        # Given
+        def axpb(i, x, y, a, b):
+            y[i] = a * sin(x[i]) + b
+
+        x = np.linspace(0, 1, 10000)
+        y = np.zeros_like(x)
+        a = 2.0
+        b = 3.0
+        x, y = wrap(x, y, backend=backend)
+
+        # When
+        e = ElementwiseJIT(axpb, backend=backend)
+        e(x, y, a, b)
+
+        # Then
+        y.pull()
+        self.assertTrue(np.allclose(y.data, a * np.sin(x.data) + b))
+
+    def test_elementwise_jit_works_with_cython(self):
+        self._check_simple_elementwise_jit(backend='cython')
+
+    def test_elementwise_jit_works_with_opencl(self):
+        importorskip('pyopencl')
+
+        self._check_simple_elementwise_jit(backend='opencl')
+
+    def test_elementwise_jit_works_with_cuda(self):
+        importorskip('pycuda')
+
+        self._check_simple_elementwise_jit(backend='cuda')
+
+    def _check_simple_reduction_jit(self, backend):
+        x = np.linspace(0, 1, 1000) / 1000
+        x = wrap(x, backend=backend)
+
+        # When
+        r = ReductionJIT('a+b', backend=backend)
+        result = r(x)
+
+        # Then
+        self.assertAlmostEqual(result, 0.5, 6)
+
+    def _check_reduction_min_jit(self, backend):
+        x = np.linspace(0, 1, 1000) / 1000
+        x = wrap(x, backend=backend)
+
+        # When
+        r = ReductionJIT('min(a, b)', neutral='INFINITY', backend=backend)
+        result = r(x)
+
+        # Then
+        self.assertAlmostEqual(result, 0.0, 6)
+
+    def _check_reduction_with_map_jit(self, backend):
+        # Given
+        from math import cos, sin
+        x = np.linspace(0, 1, 1000) / 1000
+        y = x.copy()
+        x, y = wrap(x, y, backend=backend)
+
+        def map(i=0, x=[0.0], y=[0.0]):
+            return cos(x[i]) * sin(y[i])
+
+        # When
+        r = ReductionJIT('a+b', map_func=map, backend=backend)
+        result = r(x, y)
+
+        # Then
+        self.assertAlmostEqual(result, 0.5, 6)
+
+    def test_reduction_jit_works_without_map_cython(self):
+        self._check_simple_reduction_jit(backend='cython')
+
+    def test_reduction_jit_works_with_map_cython(self):
+        self._check_reduction_with_map_jit(backend='cython')
+
+    def test_reduction_jit_works_neutral_cython(self):
+        self._check_reduction_min_jit(backend='cython')
+
+    def test_reduction_jit_works_without_map_opencl(self):
+        importorskip('pyopencl')
+        self._check_simple_reduction_jit(backend='opencl')
+
+    def test_reduction_jit_works_with_map_opencl(self):
+        importorskip('pyopencl')
+        self._check_reduction_with_map_jit(backend='opencl')
+
+    def test_reduction_jit_works_neutral_opencl(self):
+        importorskip('pyopencl')
+        self._check_reduction_min_jit(backend='opencl')
+
+    def test_reduction_jit_works_without_map_cuda(self):
+        importorskip('pycuda')
+        self._check_simple_reduction_jit(backend='cuda')
+
+    def test_reduction_jit_works_with_map_cuda(self):
+        importorskip('pycuda')
+        self._check_reduction_with_map_jit(backend='cuda')
+
+    def test_reduction_jit_works_neutral_cuda(self):
+        importorskip('pycuda')
+        self._check_reduction_min_jit(backend='cuda')
+
+

--- a/pysph/cpy/tests/test_jit.py
+++ b/pysph/cpy/tests/test_jit.py
@@ -7,7 +7,7 @@ from pytest import importorskip
 from ..config import get_config, use_config
 from ..array import wrap
 from ..types import annotate
-from ..jit import ElementwiseJIT, ReductionJIT
+from ..jit import ElementwiseJIT, ReductionJIT, ScanJIT
 
 
 class TestJIT(unittest.TestCase):
@@ -123,4 +123,187 @@ class TestJIT(unittest.TestCase):
         importorskip('pycuda')
         self._check_reduction_min_jit(backend='cuda')
 
+    def _test_scan_jit(self, backend):
+        # Given
+        a = np.arange(10000, dtype=np.int32)
+        data = a.copy()
+        expect = np.cumsum(data)
 
+        a = wrap(a, backend=backend)
+
+        def input_f(i, ary):
+            return ary[i]
+
+        def output_f(i, item, ary):
+            ary[i] = item
+
+        # When
+        scan = ScanJIT(input_f, output_f, 'a+b', dtype=np.int32,
+                    backend=backend)
+        scan(ary=a)
+
+        a.pull()
+        result = a.data
+
+        # Then
+        np.testing.assert_equal(expect, result)
+
+    def test_scan_jit_works_cython(self):
+        self._test_scan_jit(backend='cython')
+
+    def test_scan_jit_works_cython_parallel(self):
+        with use_config(use_openmp=True):
+            self._test_scan_jit(backend='cython')
+
+    def test_scan_jit_works_opencl(self):
+        importorskip('pyopencl')
+        self._test_scan_jit(backend='opencl')
+
+    def test_scan_jit_works_cuda(self):
+        importorskip('pycuda')
+        self._test_scan_jit(backend='cuda')
+
+    def _test_unique_scan_jit(self, backend):
+        # Given
+        a = np.random.randint(0, 100, 100, dtype=np.int32)
+        a = np.sort(a)
+        data = a.copy()
+
+        unique_ary_actual = np.sort(np.unique(data))
+        unique_count_actual = len(np.unique(data))
+
+        a = wrap(a, backend=backend)
+
+        unique_ary = np.zeros(len(a.data), dtype=np.int32)
+        unique_ary = wrap(unique_ary, backend=backend)
+
+        unique_count = np.zeros(1, dtype=np.int32)
+        unique_count = wrap(unique_count, backend=backend)
+
+        def input_f(i, ary):
+            if i == 0 or ary[i] != ary[i - 1]:
+                return 1
+            else:
+                return 0
+
+        def output_f(i, prev_item, item, N, ary, unique, unique_count):
+            if item != prev_item:
+                unique[item - 1] = ary[i]
+            if i == N - 1:
+                unique_count[0] = item
+
+        # When
+        scan = ScanJIT(input_f, output_f, 'a+b', dtype=np.int32, backend=backend)
+        scan(ary=a, unique=unique_ary, unique_count=unique_count)
+        unique_ary.pull()
+        unique_count.pull()
+        unique_count = unique_count.data[0]
+
+        # Then
+        self.assertTrue(unique_count == unique_count_actual)
+        np.testing.assert_equal(unique_ary_actual,
+                                unique_ary.data[:unique_count])
+
+    def test_unique_scan_jit_cython(self):
+        self._test_unique_scan_jit(backend='cython')
+
+    def test_unique_scan_jit_cython_parallel(self):
+        with use_config(use_openmp=True):
+            self._test_unique_scan_jit(backend='cython')
+
+    def test_unique_scan_jit_opencl(self):
+        importorskip('pyopencl')
+        self._test_unique_scan_jit(backend='opencl')
+
+    def test_unique_scan_jit_cuda(self):
+        importorskip('pycuda')
+        self._test_unique_scan_jit(backend='cuda')
+
+    def _get_segmented_scan_actual(self, a, segment_flags):
+        output_actual = np.zeros_like(a)
+        for i in range(len(a)):
+            if segment_flags[i] == 0 and i != 0:
+                output_actual[i] = output_actual[i - 1] + a[i]
+            else:
+                output_actual[i] = a[i]
+        return output_actual
+
+    def _test_segmented_scan_jit(self, backend):
+        # Given
+        a = np.random.randint(0, 100, 50000, dtype=np.int32)
+        a_copy = a.copy()
+
+        seg = np.random.randint(0, 100, 50000, dtype=np.int32)
+        seg = (seg == 0).astype(np.int32)
+        seg_copy = seg.copy()
+
+        a = wrap(a, backend=backend)
+        seg = wrap(seg, backend=backend)
+
+        def input_f(i, ary):
+            return ary[i]
+
+        def segment_f(i, seg_flag):
+            return seg_flag[i]
+
+        def output_f(i, item, ary):
+            ary[i] = item
+
+        output_actual = self._get_segmented_scan_actual(a_copy, seg_copy)
+
+        # When
+        scan = ScanJIT(input_f, output_f, 'a+b', dtype=np.int32, backend=backend,
+                    is_segment=segment_f)
+        scan(ary=a, seg_flag=seg)
+        a.pull()
+
+        # Then
+        np.testing.assert_equal(output_actual, a.data)
+
+    def test_segmented_scan_jit_cython(self):
+        self._test_segmented_scan_jit(backend='cython')
+
+    def test_segmented_scan_jit_cython_parallel(self):
+        with use_config(use_openmp=True):
+            self._test_segmented_scan_jit(backend='cython')
+
+    def test_segmented_scan_jit_opencl(self):
+        importorskip('pyopencl')
+        self._test_segmented_scan_jit(backend='opencl')
+
+    def test_segmented_scan_jit_cuda(self):
+        importorskip('pycuda')
+        self._test_segmented_scan_jit(backend='cuda')
+
+    def _test_scan_jit_last_item(self, backend):
+        # Given
+        a = np.random.randint(0, 100, 50000, dtype=np.int32)
+        a_copy = a.copy()
+
+        a = wrap(a, backend=backend)
+
+        def output_f(i, last_item, item, ary):
+            ary[i] = item + last_item
+
+        expect = np.cumsum(a_copy) + np.cumsum(a_copy)[-1]
+
+        # When
+        scan = ScanJIT(output=output_f, scan_expr='a+b',
+                    dtype=np.int32, backend=backend)
+        scan(input=a, ary=a)
+        a.pull()
+
+        # Then
+        np.testing.assert_equal(expect, a.data)
+
+    def test_scan_jit_last_item_cython_parallel(self):
+        with use_config(use_openmp=True):
+            self._test_scan_jit_last_item(backend='cython')
+
+    def test_scan_jit_last_item_opencl(self):
+        importorskip('pyopencl')
+        self._test_scan_jit_last_item(backend='opencl')
+
+    def test_scan_jit_last_item_cuda(self):
+        importorskip('pycuda')
+        self._test_scan_jit_last_item(backend='cuda')

--- a/pysph/cpy/tests/test_jit.py
+++ b/pysph/cpy/tests/test_jit.py
@@ -8,7 +8,7 @@ from ..config import get_config, use_config
 from ..array import wrap
 from ..types import annotate
 from ..jit import (jit, get_binop_return_type, AnnotationHelper,
-        ElementwiseJIT, ReductionJIT, ScanJIT)
+                   ElementwiseJIT, ReductionJIT, ScanJIT)
 
 
 @jit
@@ -29,7 +29,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return g(1)
 
         # When
-        types = {'a' : 'int'}
+        types = {'a': 'int'}
         helper = AnnotationHelper(int_f, types)
         helper.annotate()
 
@@ -42,7 +42,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return g(10000000000)
 
         # When
-        types = {'a' : 'int'}
+        types = {'a': 'int'}
         helper = AnnotationHelper(long_f, types)
         helper.annotate()
 
@@ -55,7 +55,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return g(1.)
 
         # When
-        types = {'a' : 'int'}
+        types = {'a': 'int'}
         helper = AnnotationHelper(double_f, types)
         helper.annotate()
 
@@ -71,7 +71,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return g(x)
 
         # When
-        types = {'a' : 'int', 'b' : 'int'}
+        types = {'a': 'int', 'b': 'int'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -85,7 +85,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return g(a[i])
 
         # When
-        types = {'i' : 'int', 'a' : 'intp'}
+        types = {'i': 'int', 'a': 'intp'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -99,7 +99,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return g(a + b)
 
         # When
-        types = {'a' : 'int', 'b' : 'int'}
+        types = {'a': 'int', 'b': 'int'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -113,7 +113,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return g(h(a, b))
 
         # When
-        types = {'a' : 'int', 'b' : 'int'}
+        types = {'a': 'int', 'b': 'int'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -127,7 +127,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return g(h(a, b) + h(b, a))
 
         # When
-        types = {'a' : 'int', 'b' : 'int'}
+        types = {'a': 'int', 'b': 'int'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -141,7 +141,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return g(sin(a))
 
         # When
-        types = {'a' : 'int', 'b' : 'int'}
+        types = {'a': 'int', 'b': 'int'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -155,7 +155,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return a
 
         # When
-        types = {'a' : 'int'}
+        types = {'a': 'int'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -169,7 +169,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return a[i]
 
         # When
-        types = {'i' : 'int', 'a' : 'intp'}
+        types = {'i': 'int', 'a': 'intp'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -183,7 +183,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return 1
 
         # When
-        types = {'a' : 'int', 'b' : 'int'}
+        types = {'a': 'int', 'b': 'int'}
         helper = AnnotationHelper(int_f, types)
         helper.annotate()
 
@@ -196,7 +196,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return 10000000000
 
         # When
-        types = {'a' : 'int', 'b' : 'int'}
+        types = {'a': 'int', 'b': 'int'}
         helper = AnnotationHelper(long_f, types)
         helper.annotate()
 
@@ -209,7 +209,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return 1.
 
         # When
-        types = {'a' : 'int', 'b' : 'int'}
+        types = {'a': 'int', 'b': 'int'}
         helper = AnnotationHelper(double_f, types)
         helper.annotate()
 
@@ -223,7 +223,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return a + b
 
         # When
-        types = {'a' : 'int', 'b' : 'int'}
+        types = {'a': 'int', 'b': 'int'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -237,7 +237,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return g(a)
 
         # When
-        types = {'a' : 'int', 'b' : 'int'}
+        types = {'a': 'int', 'b': 'int'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -252,7 +252,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return g(a) + g(b)
 
         # When
-        types = {'a' : 'int', 'b' : 'int'}
+        types = {'a': 'int', 'b': 'int'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -266,7 +266,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return h(a, b)
 
         # When
-        types = {'a' : 'int', 'b' : 'int'}
+        types = {'a': 'int', 'b': 'int'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -282,7 +282,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return sin(a)
 
         # When
-        types = {'a' : 'int'}
+        types = {'a': 'int'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -296,7 +296,7 @@ class TestAnnotationHelper(unittest.TestCase):
             return a + b
 
         # When
-        types = {'a' : 'long', 'b' : 'int'}
+        types = {'a': 'long', 'b': 'int'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -304,7 +304,7 @@ class TestAnnotationHelper(unittest.TestCase):
         assert helper.arg_types['return_'] == 'long'
 
         # When
-        types = {'a' : 'int', 'b' : 'double'}
+        types = {'a': 'int', 'b': 'double'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -312,7 +312,7 @@ class TestAnnotationHelper(unittest.TestCase):
         assert helper.arg_types['return_'] == 'double'
 
         # When
-        types = {'a' : 'uint', 'b' : 'int'}
+        types = {'a': 'uint', 'b': 'int'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
@@ -320,12 +320,13 @@ class TestAnnotationHelper(unittest.TestCase):
         assert helper.arg_types['return_'] == 'int'
 
         # When
-        types = {'a' : 'uint', 'b' : 'ulong'}
+        types = {'a': 'uint', 'b': 'ulong'}
         helper = AnnotationHelper(f, types)
         helper.annotate()
 
         # Then
         assert helper.arg_types['return_'] == 'ulong'
+
 
 class TestParallelJIT(unittest.TestCase):
     def setUp(self):
@@ -460,7 +461,7 @@ class TestParallelJIT(unittest.TestCase):
 
         # When
         scan = ScanJIT(input_f, output_f, 'a+b', dtype=np.int32,
-                    backend=backend)
+                       backend=backend)
         scan(ary=a)
 
         a.pull()
@@ -516,7 +517,12 @@ class TestParallelJIT(unittest.TestCase):
                 unique_count[0] = item
 
         # When
-        scan = ScanJIT(input_f, output_f, 'a+b', dtype=np.int32, backend=backend)
+        scan = ScanJIT(
+            input_f,
+            output_f,
+            'a+b',
+            dtype=np.int32,
+            backend=backend)
         scan(ary=a, unique=unique_ary, unique_count=unique_count)
         unique_ary.pull()
         unique_count.pull()
@@ -578,8 +584,13 @@ class TestParallelJIT(unittest.TestCase):
         output_actual = self._get_segmented_scan_actual(a_copy, seg_copy)
 
         # When
-        scan = ScanJIT(input_f, output_f, 'a+b', dtype=np.int32, backend=backend,
-                    is_segment=segment_f)
+        scan = ScanJIT(
+            input_f,
+            output_f,
+            'a+b',
+            dtype=np.int32,
+            backend=backend,
+            is_segment=segment_f)
         scan(ary=a, seg_flag=seg)
         a.pull()
 
@@ -616,7 +627,7 @@ class TestParallelJIT(unittest.TestCase):
 
         # When
         scan = ScanJIT(output=output_f, scan_expr='a+b',
-                    dtype=np.int32, backend=backend)
+                       dtype=np.int32, backend=backend)
         scan(input=a, ary=a)
         a.pull()
 

--- a/pysph/cpy/tests/test_jit.py
+++ b/pysph/cpy/tests/test_jit.py
@@ -275,6 +275,20 @@ class TestAnnotationHelper(unittest.TestCase):
         assert 'g' in helper.children['h'].children
         assert helper.arg_types['return_'] == 'int'
 
+    def test_non_jit_call_in_return(self):
+        # Given
+        @jit
+        def f(a):
+            return sin(a)
+
+        # When
+        types = {'a' : 'int'}
+        helper = AnnotationHelper(f, types)
+        helper.annotate()
+
+        # Then
+        assert helper.arg_types['return_'] == 'double'
+
 
 class TestParallelJIT(unittest.TestCase):
     def setUp(self):

--- a/pysph/cpy/tests/test_jit.py
+++ b/pysph/cpy/tests/test_jit.py
@@ -616,7 +616,7 @@ class TestParallelJIT(unittest.TestCase):
 
         # When
         scan = Scan(output=output_f, scan_expr='a+b',
-                       dtype=np.int32, backend=backend)
+                    dtype=np.int32, backend=backend)
         scan(input=a, ary=a)
         a.pull()
 

--- a/pysph/cpy/tests/test_jit.py
+++ b/pysph/cpy/tests/test_jit.py
@@ -7,8 +7,8 @@ from pytest import importorskip
 from ..config import get_config, use_config
 from ..array import wrap
 from ..types import annotate
-from ..jit import (jit, AnnotationHelper, ElementwiseJIT,
-        ReductionJIT, ScanJIT)
+from ..jit import (jit, get_binop_return_type, AnnotationHelper,
+        ElementwiseJIT, ReductionJIT, ScanJIT)
 
 
 @jit
@@ -289,6 +289,43 @@ class TestAnnotationHelper(unittest.TestCase):
         # Then
         assert helper.arg_types['return_'] == 'double'
 
+    def test_binop_return_type(self):
+        # Given
+        @jit
+        def f(a, b):
+            return a + b
+
+        # When
+        types = {'a' : 'long', 'b' : 'int'}
+        helper = AnnotationHelper(f, types)
+        helper.annotate()
+
+        # Then
+        assert helper.arg_types['return_'] == 'long'
+
+        # When
+        types = {'a' : 'int', 'b' : 'double'}
+        helper = AnnotationHelper(f, types)
+        helper.annotate()
+
+        # Then
+        assert helper.arg_types['return_'] == 'double'
+
+        # When
+        types = {'a' : 'uint', 'b' : 'int'}
+        helper = AnnotationHelper(f, types)
+        helper.annotate()
+
+        # Then
+        assert helper.arg_types['return_'] == 'int'
+
+        # When
+        types = {'a' : 'uint', 'b' : 'ulong'}
+        helper = AnnotationHelper(f, types)
+        helper.annotate()
+
+        # Then
+        assert helper.arg_types['return_'] == 'ulong'
 
 class TestParallelJIT(unittest.TestCase):
     def setUp(self):

--- a/pysph/cpy/tests/test_jit.py
+++ b/pysph/cpy/tests/test_jit.py
@@ -134,6 +134,20 @@ class TestAnnotationHelper(unittest.TestCase):
         # Then
         assert helper.children['g'].arg_types['x'] == 'int'
 
+    def test_non_jit_call_as_call_arg(self):
+        # Given
+        @jit
+        def f(a, b):
+            return g(sin(a))
+
+        # When
+        types = {'a' : 'int', 'b' : 'int'}
+        helper = AnnotationHelper(f, types)
+        helper.annotate()
+
+        # Then
+        assert helper.children['g'].arg_types['x'] == 'double'
+
     def test_variable_in_return(self):
         # Given
         @jit

--- a/pysph/cpy/tests/test_jit.py
+++ b/pysph/cpy/tests/test_jit.py
@@ -7,7 +7,7 @@ from pytest import importorskip
 from ..config import get_config, use_config
 from ..array import wrap
 from ..types import annotate
-from ..jit import ElementwiseJIT, ReductionJIT, ScanJIT
+from ..jit import jit, ElementwiseJIT, ReductionJIT, ScanJIT
 
 
 class TestJIT(unittest.TestCase):
@@ -21,6 +21,7 @@ class TestJIT(unittest.TestCase):
 
     def _check_simple_elementwise_jit(self, backend):
         # Given
+        @jit
         def axpb(i, x, y, a, b):
             y[i] = a * sin(x[i]) + b
 
@@ -80,6 +81,7 @@ class TestJIT(unittest.TestCase):
         y = x.copy()
         x, y = wrap(x, y, backend=backend)
 
+        @jit
         def map(i=0, x=[0.0], y=[0.0]):
             return cos(x[i]) * sin(y[i])
 
@@ -131,9 +133,11 @@ class TestJIT(unittest.TestCase):
 
         a = wrap(a, backend=backend)
 
+        @jit
         def input_f(i, ary):
             return ary[i]
 
+        @jit
         def output_f(i, item, ary):
             ary[i] = item
 
@@ -180,12 +184,14 @@ class TestJIT(unittest.TestCase):
         unique_count = np.zeros(1, dtype=np.int32)
         unique_count = wrap(unique_count, backend=backend)
 
+        @jit
         def input_f(i, ary):
             if i == 0 or ary[i] != ary[i - 1]:
                 return 1
             else:
                 return 0
 
+        @jit
         def output_f(i, prev_item, item, N, ary, unique, unique_count):
             if item != prev_item:
                 unique[item - 1] = ary[i]
@@ -240,12 +246,15 @@ class TestJIT(unittest.TestCase):
         a = wrap(a, backend=backend)
         seg = wrap(seg, backend=backend)
 
+        @jit
         def input_f(i, ary):
             return ary[i]
 
+        @jit
         def segment_f(i, seg_flag):
             return seg_flag[i]
 
+        @jit
         def output_f(i, item, ary):
             ary[i] = item
 
@@ -282,6 +291,7 @@ class TestJIT(unittest.TestCase):
 
         a = wrap(a, backend=backend)
 
+        @jit
         def output_f(i, last_item, item, ary):
             ary[i] = item + last_item
 

--- a/pysph/cpy/transpiler.py
+++ b/pysph/cpy/transpiler.py
@@ -159,7 +159,7 @@ class Transpiler(object):
             #define max(x, y) fmax((double)(x), (double)(y))
 
             #ifdef __APPLE__
-            #define M_PI 3.141592654f
+            #define M_PI 3.14159265358979323846
             #endif
 
             __constant double pi=M_PI;

--- a/pysph/cpy/transpiler.py
+++ b/pysph/cpy/transpiler.py
@@ -158,6 +158,10 @@ class Transpiler(object):
             self.header = cluda + dedent('''
             #define max(x, y) fmax((double)(x), (double)(y))
 
+            #ifdef __APPLE__
+            #define M_PI 3.141592654f
+            #endif
+
             __constant double pi=M_PI;
             ''')
         elif backend == 'cuda':

--- a/pysph/cpy/types.py
+++ b/pysph/cpy/types.py
@@ -238,6 +238,7 @@ def annotate(func=None, **kw):
 
     def wrapper(func):
         func.__annotations__ = data
+        func.has_annotations = True
         return func
 
     if func is None:

--- a/pysph/cpy/types.py
+++ b/pysph/cpy/types.py
@@ -229,17 +229,21 @@ def annotate(func=None, **kw):
     """
     data = {}
 
-    for name, type in kw.items():
-        if isinstance(type, str) and ',' in type:
-            for x in type.split(','):
-                data[_clean_name(x.strip())] = _get_type(name)
-        else:
-            data[_clean_name(name)] = _get_type(type)
+    if not kw:
+        def wrapper(func):
+            func.is_jit = True
+            return func
+    else:
+        for name, type in kw.items():
+            if isinstance(type, str) and ',' in type:
+                for x in type.split(','):
+                    data[_clean_name(x.strip())] = _get_type(name)
+            else:
+                data[_clean_name(name)] = _get_type(type)
 
-    def wrapper(func):
-        func.__annotations__ = data
-        func.has_annotations = True
-        return func
+        def wrapper(func):
+            func.__annotations__ = data
+            return func
 
     if func is None:
         return wrapper

--- a/pysph/cpy/types.py
+++ b/pysph/cpy/types.py
@@ -237,7 +237,6 @@ def annotate(func=None, **kw):
 
     def wrapper(func):
         func.__annotations__ = data
-        func.type_info = kw
         return func
 
     if func is None:

--- a/pysph/cpy/types.py
+++ b/pysph/cpy/types.py
@@ -86,6 +86,7 @@ class KnownType(object):
     Smells but is convenient as the type may be one available only inside
     Cython without a corresponding Python type.
     """
+
     def __init__(self, type_str, base_type=''):
         """Constructor
 
@@ -200,8 +201,8 @@ def dtype_to_knowntype(dtype, address='scalar'):
     elif address == 'local':
         knowntype = 'l%sp' % knowntype
     elif address != 'scalar':
-        raise ValueError("address can only be scalar,"\
-                " ptr, global or local")
+        raise ValueError("address can only be scalar,"
+                         " ptr, global or local")
 
     if knowntype in TYPES:
         return knowntype

--- a/pysph/cpy/types.py
+++ b/pysph/cpy/types.py
@@ -237,6 +237,7 @@ def annotate(func=None, **kw):
 
     def wrapper(func):
         func.__annotations__ = data
+        func.type_info = kw
         return func
 
     if func is None:

--- a/pysph/cpy/types.py
+++ b/pysph/cpy/types.py
@@ -188,7 +188,7 @@ def ctype_to_dtype(ctype):
     return C_NP_TYPE_MAP[ctype]
 
 
-def dtype_to_knowntype(dtype, address=None):
+def dtype_to_knowntype(dtype, address='scalar'):
     ctype = dtype_to_ctype(dtype)
     if 'unsigned' in ctype:
         ctype = 'u%s' % ctype.replace('unsigned ', '')
@@ -199,8 +199,9 @@ def dtype_to_knowntype(dtype, address=None):
         knowntype = 'g%sp' % knowntype
     elif address == 'local':
         knowntype = 'l%sp' % knowntype
-    else:
-        raise ValueError("address can only be ptr, global or local")
+    elif address != 'scalar':
+        raise ValueError("address can only be scalar,"\
+                " ptr, global or local")
 
     if knowntype in TYPES:
         return knowntype


### PR DESCRIPTION
This module allows you to use map, reduce and scan without adding type annotations.
I don't know if you wanted this @prabhuramachandran , but I got a little carried away by the idea.