### PR TITLE
Multi stage equations

### DIFF
--- a/docs/source/reference/equations.rst
+++ b/docs/source/reference/equations.rst
@@ -20,6 +20,18 @@ SPH equations
    :members:
    :undoc-members:
 
+.. automodule:: pysph.sph.wc.density_correction
+   :members:
+   :undoc-members:
+
+.. automodule:: pysph.sph.wc.kernel_correction
+   :members:
+   :undoc-members:
+
+.. automodule:: pysph.sph.wc.crksph
+   :members:
+   :undoc-members:
+
 .. automodule:: pysph.sph.boundary_equations
    :members:
    :undoc-members:
@@ -79,3 +91,5 @@ Group of equations
 .. autoclass:: pysph.sph.equation.Group
    :special-members:
 
+.. autoclass:: pysph.sph.equation.MultiStageEquations
+   :special-members:

--- a/pysph/solver/solver.py
+++ b/pysph/solver/solver.py
@@ -1,5 +1,5 @@
 """ An implementation of a general solver base class """
-
+from __future__ import print_function
 # System library imports.
 import os
 import numpy
@@ -15,6 +15,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 EPSILON = numpy.finfo(float).eps*2
+
 
 class Solver(object):
     """Base class for all PySPH Solvers
@@ -169,9 +170,8 @@ class Solver(object):
             if hasattr(self, attr):
                 setattr(self, attr, value)
             else:
-                msg = 'Unknown keyword arg "%s" passed to constructor'%attr
+                msg = 'Unknown keyword arg "%s" passed to constructor' % attr
                 raise TypeError(msg)
-
 
     ##########################################################################
     # Public interface.
@@ -200,9 +200,9 @@ class Solver(object):
 
         sep = '-'*70
         eqn_info = '[\n' + ',\n'.join([str(e) for e in equations]) + '\n]'
-        logger.info('Using equations:\n%s\n%s\n%s'%(sep, eqn_info, sep))
+        logger.info('Using equations:\n%s\n%s\n%s' % (sep, eqn_info, sep))
         logger.info(
-            'Using integrator:\n%s\n  %s\n%s'%(sep, self.integrator, sep)
+            'Using integrator:\n%s\n  %s\n%s' % (sep, self.integrator, sep)
         )
 
         sph_compiler = SPHCompiler(
@@ -222,7 +222,7 @@ class Solver(object):
 
         # set integrator option for constant smoothing length
         self.fixed_h = fixed_h
-        self.integrator.set_fixed_h( fixed_h )
+        self.integrator.set_fixed_h(fixed_h)
 
         logger.debug("Solver setup complete.")
 
@@ -237,7 +237,7 @@ class Solver(object):
 
         >>> def post_stage_callback_function(t, dt, stage):
         >>>     # This function is called after every stage of integrator.
-        >>>     print t, dt, stage
+        >>>     print(t, dt, stage)
         >>>     # Do something
         >>> solver.add_post_stage_callback(post_stage_callback_function)
         """
@@ -253,7 +253,7 @@ class Solver(object):
 
         >>> def post_step_callback_function(solver):
         >>>     # This function is called after every time step.
-        >>>     print solver.t, solver.dt
+        >>>     print(solver.t, solver.dt)
         >>>     # Do something
         >>> solver.add_post_step_callback(post_step_callback_function)
         """
@@ -269,7 +269,7 @@ class Solver(object):
 
         >>> def pre_step_callback_function(solver):
         >>>     # This function is called before every time step.
-        >>>     print solver.t, solver.dt
+        >>>     print(solver.t, solver.dt)
         >>>     # Do something
         >>> solver.add_pre_step_callback(pre_step_callback_function)
         """
@@ -334,8 +334,8 @@ class Solver(object):
 
         if array_names:
             for name in array_names:
-                if not name in available_arrays:
-                    raise RuntimeError("Array %s not availabe"%(name))
+                if name not in available_arrays:
+                    raise RuntimeError("Array %s not availabe" % (name))
 
                 for arr in self.particles:
                     if arr.name == name:
@@ -426,7 +426,7 @@ class Solver(object):
 
         # Initial solution
         self.dump_output()
-        self.barrier() # everybody waits for this to complete
+        self.barrier()  # everybody waits for this to complete
 
         # Compute the accelerations once for the predictor corrector
         # integrator to work correctly at the first time step.
@@ -445,11 +445,11 @@ class Solver(object):
 
             if self.rank == 0:
                 logger.debug(
-                    "Iteration=%d, time=%f, timestep=%f" % \
-                        (self.count, self.t, self.dt)
+                    "Iteration=%d, time=%f, timestep=%f" %
+                    (self.count, self.t, self.dt)
                 )
             # perform the integration and update the time.
-            #print 'Solver Iteration', self.count, self.dt, self.t
+            # print('Solver Iteration', self.count, self.dt, self.t)
             self.integrator.step(self.t, self.dt)
 
             # perform any post step functions
@@ -527,12 +527,12 @@ class Solver(object):
             return
 
         if self.rank == 0:
-            msg = 'Writing output at time %g, iteration %d, dt = %g'%(
+            msg = 'Writing output at time %g, iteration %d, dt = %g' % (
                 self.t, self.count, self.dt)
             logger.info(msg)
 
         fname = os.path.join(self.output_directory,
-                             self.fname  + '_' + str(self.count))
+                             self.fname + '_' + str(self.count))
 
         comm = None
         if self.parallel_output_mode == "collected" and self.in_parallel:
@@ -555,25 +555,26 @@ class Solver(object):
 
         Notes
         -----
-        Data is loaded from the :py:attr:`output_directory` using the same format
-        as stored by the :py:meth:`dump_output` method.
-        Proper functioning required that all the relevant properties of arrays be
+
+        Data is loaded from the :py:attr:`output_directory` using the same
+        format as stored by the :py:meth:`dump_output` method. Proper
+        functioning required that all the relevant properties of arrays be
         dumped.
 
         """
         # get the list of available files
-        available_files = [i.rsplit('_',1)[1][:-4]
-                            for i in os.listdir(self.output_directory)
-                             if i.startswith(self.fname) and i.endswith('.npz')]
+        available_files = [i.rsplit('_', 1)[1][:-4]
+                           for i in os.listdir(self.output_directory)
+                           if i.startswith(self.fname) and i.endswith('.npz')]
 
         if count == '?':
             return sorted(set(available_files), key=int)
 
         else:
-            if not count in available_files:
-                msg = "File with iteration count `%s` does not exist"%(count)
-                msg += "\nValid iteration counts are %s"%(sorted(set(available_files), key=int))
-                #print msg
+            if count not in available_files:
+                msg = "File with iteration count `%s` does not exist" % (count)
+                msg += "\nValid iteration counts are %s" % (
+                    sorted(set(available_files), key=int))
                 raise IOError(msg)
 
         array_names = [pa.name for pa in self.particles]
@@ -582,7 +583,7 @@ class Solver(object):
         data = load(os.path.join(self.output_directory,
                                  self.fname+'_'+str(count)+'.npz'))
 
-        arrays = [ data["arrays"][i] for i in array_names ]
+        arrays = [data["arrays"][i] for i in array_names]
 
         # set the Particle's arrays
         self.particles = arrays

--- a/pysph/solver/solver.py
+++ b/pysph/solver/solver.py
@@ -430,7 +430,7 @@ class Solver(object):
 
         # Compute the accelerations once for the predictor corrector
         # integrator to work correctly at the first time step.
-        self.acceleration_eval.compute(self.t, self.dt)
+        self.integrator.initial_acceleration(self.t, self.dt)
 
         # Now get a suitable adaptive (if requested) and damped timestep to
         # integrate with.

--- a/pysph/solver/tests/test_solver.py
+++ b/pysph/solver/tests/test_solver.py
@@ -44,12 +44,13 @@ class TestSolver(TestCase):
             output_at_times=output_at_times
         )
         solver.set_print_freq(pfreq)
-        solver.acceleration_eval = self.a_eval
+        solver.acceleration_evals = [self.a_eval]
         solver.particles = []
 
         # When
         record = []
         record_dt = []
+
         def _mock_dump_output():
             # Record the time at which the solver dumped anything
             record.append(solver.t)
@@ -64,7 +65,7 @@ class TestSolver(TestCase):
         expected = np.asarray(
             [0.0, 0.3, 0.35] + np.arange(0.45, 10.1, 0.5).tolist() + [10.05]
         )
-        error_message = "Expected %s, got %s"%(expected, record)
+        error_message = "Expected %s, got %s" % (expected, record)
         self.assertEqual(len(expected), len(record), error_message)
         self.assertTrue(
             np.max(np.abs(expected - record)) < 1e-12, error_message
@@ -86,9 +87,10 @@ class TestSolver(TestCase):
             integrator=self.integrator, tf=tf, dt=dt, adaptive_timestep=False
         )
         solver.set_print_freq(pfreq)
-        solver.acceleration_eval = self.a_eval
+        solver.acceleration_evals = [self.a_eval]
         solver.particles = []
         record = []
+
         def _mock_dump_output():
             # Record the time at which the solver dumped anything
             record.append(solver.t)
@@ -100,7 +102,7 @@ class TestSolver(TestCase):
 
         # Then
         expected = np.asarray([0.0, 0.2, 0.4, 0.6, 0.8, 1.0])
-        error_message = "Expected %s, got %s"%(expected, record)
+        error_message = "Expected %s, got %s" % (expected, record)
 
         self.assertEqual(len(expected), len(record), error_message)
         self.assertTrue(

--- a/pysph/sph/acceleration_eval.py
+++ b/pysph/sph/acceleration_eval.py
@@ -5,8 +5,9 @@ except ImportError:
     from ordereddict import OrderedDict
 
 from pysph.cpy.config import get_config
-from pysph.sph.equation import (CythonGroup, Group, OpenCLGroup,
-                                get_arrays_used_in_equation)
+from pysph.sph.equation import (
+    CythonGroup, Group, MultiStageEquations, OpenCLGroup,
+    get_arrays_used_in_equation)
 
 
 ###############################################################################
@@ -70,6 +71,23 @@ def check_equation_array_properties(equation, particle_arrays):
             msg += "Array '%s' missing properties %s.\n" % (name, missing)
         print(msg)
         raise RuntimeError(msg)
+
+
+def make_acceleration_evals(particle_arrays, equations, kernel,
+                            mode='serial', backend=None):
+    '''Returns a list of acceleration evaluators.
+
+    If a MultiStageEquations object is given the resulting list will have
+    multiple evaluators else it will have a single one.
+    '''
+    if isinstance(equations, MultiStageEquations):
+        groups = equations.groups
+    else:
+        groups = [equations]
+    return [
+        AccelerationEval(particle_arrays, group, kernel, mode, backend)
+        for group in groups
+    ]
 
 
 ###############################################################################

--- a/pysph/sph/equation.py
+++ b/pysph/sph/equation.py
@@ -833,3 +833,25 @@ class OpenCLGroup(Group):
             src = code_gen.parse_instance(eqs[cls], ignore_methods=ignore)
             wrappers.append(src)
         return '\n'.join(wrappers)
+
+
+class MultiStageEquations(object):
+    '''A class that allows a user to specify different equations
+    for different stages.
+
+    The object doesn't do much, except contain the different collections of
+    equations.
+
+    '''
+
+    def __init__(self, groups):
+        '''
+        Parameters
+        ----------
+
+        groups: list/tuple
+            A list/tuple of list of groups/equations, one for each stage.
+
+        '''
+        assert type(groups) in (list, tuple)
+        self.groups = groups

--- a/pysph/sph/integrator_cython_helper.py
+++ b/pysph/sph/integrator_cython_helper.py
@@ -43,7 +43,7 @@ class IntegratorCythonHelper(object):
     def setup_compiled_module(self, module, acceleration_eval):
         # Create the compiled module.
         cython_integrator = module.Integrator(
-            acceleration_eval, self.object.steppers
+            self.object, acceleration_eval, self.object.steppers
         )
         # Setup the integrator to use this compiled module.
         self.object.set_compiled_object(cython_integrator)

--- a/pysph/sph/sph_compiler.py
+++ b/pysph/sph/sph_compiler.py
@@ -8,65 +8,89 @@ class SPHCompiler(object):
         ----------
 
         acceleration_eval: .acceleration_eval.AccelerationEval instance
+            or list of instances.
         integrator: .integrator.Integrator instance
         """
-        self.acceleration_eval = acceleration_eval
+        if not isinstance(acceleration_eval, (list, tuple)):
+            acceleration_evals = [acceleration_eval]
+        else:
+            acceleration_evals = acceleration_eval
+
+        self.acceleration_evals = acceleration_evals
         self.integrator = integrator
-        self.backend = acceleration_eval.backend
+        if integrator is not None:
+            integrator.set_acceleration_evals(self.acceleration_evals)
+        self.backend = acceleration_evals[0].backend
         self._setup_helpers()
         self.module = None
 
     # Public interface. ####################################################
     def compile(self):
-        """Compile the generated code to an extension module and
+        """Compile the generated code to extension modules and
         setup the objects that need this by calling their
         setup_compiled_module.
         """
         if self.module is not None:
             return
-        code = self._get_code()
-        mod = self.acceleration_eval_helper.compile(code)
+
+        # We compile the first acceleration eval along with the integrator.
+        # The rest of the acceleration evals (if present) are independent.
+        code0 = self._get_code()
+        helper0 = self.acceleration_eval_helpers[0]
+        mod = helper0.compile(code0)
+        helper0.setup_compiled_module(mod)
+
         self.module = mod
-        self.acceleration_eval_helper.setup_compiled_module(mod)
+        c_accel_eval0 = self.acceleration_evals[0].c_acceleration_eval
+
         if self.backend == 'cython':
-            cython_a_eval = self.acceleration_eval.c_acceleration_eval
             if self.integrator is not None:
                 self.integrator_helper.setup_compiled_module(
-                    mod, cython_a_eval
+                    mod, c_accel_eval0
                 )
         elif self.backend == 'opencl':
             if self.integrator is not None:
-                c_a_eval = self.acceleration_eval.c_acceleration_eval
                 self.integrator_helper.setup_compiled_module(
-                    mod, c_a_eval
+                    mod, c_accel_eval0
                 )
+
+        # Setup the remaining acceleration evals.
+        for helper in self.acceleration_eval_helpers[1:]:
+            mod = helper.compile(helper.get_code())
+            helper.setup_compiled_module(mod)
 
     # Private interface. ####################################################
     def _get_code(self):
-        main = self.acceleration_eval_helper.get_code()
+        main = self.acceleration_eval_helpers[0].get_code()
         integrator_code = self.integrator_helper.get_code()
         return main + integrator_code
 
     def _setup_helpers(self):
         if self.backend == 'cython':
-            from .integrator_cython_helper import \
-                IntegratorCythonHelper
             from .acceleration_eval_cython_helper import \
                 AccelerationEvalCythonHelper
-            self.acceleration_eval_helper = AccelerationEvalCythonHelper(
-                self.acceleration_eval
-            )
-            self.integrator_helper = IntegratorCythonHelper(
-                self.integrator, self.acceleration_eval_helper
-            )
+            cls = AccelerationEvalCythonHelper
         elif self.backend == 'opencl':
             from .acceleration_eval_opencl_helper import \
                 AccelerationEvalOpenCLHelper
-            from .integrator_opencl_helper import IntegratorOpenCLHelper
+            cls = AccelerationEvalOpenCLHelper
 
-            self.acceleration_eval_helper = AccelerationEvalOpenCLHelper(
-                self.acceleration_eval
+        self.acceleration_eval_helpers = [
+            cls(a_eval)
+            for a_eval in self.acceleration_evals
+        ]
+        self._setup_integrator_helper()
+
+    def _setup_integrator_helper(self):
+        a_helper0 = self.acceleration_eval_helpers[0]
+        if self.backend == 'cython':
+            from .integrator_cython_helper import \
+                IntegratorCythonHelper
+            self.integrator_helper = IntegratorCythonHelper(
+                self.integrator, a_helper0
             )
+        elif self.backend == 'opencl':
+            from .integrator_opencl_helper import IntegratorOpenCLHelper
             self.integrator_helper = IntegratorOpenCLHelper(
-                self.integrator, self.acceleration_eval_helper
+                self.integrator, a_helper0
             )

--- a/pysph/sph/sph_compiler.py
+++ b/pysph/sph/sph_compiler.py
@@ -1,5 +1,5 @@
 class SPHCompiler(object):
-    def __init__(self, acceleration_eval, integrator):
+    def __init__(self, acceleration_evals, integrator):
         """Compiles the acceleration evaluator and integrator to produce a
         fast version using one of the supported backends. If the backend is
         not given, one is automatically chosen based on the configuration.
@@ -11,12 +11,10 @@ class SPHCompiler(object):
             or list of instances.
         integrator: .integrator.Integrator instance
         """
-        if not isinstance(acceleration_eval, (list, tuple)):
-            acceleration_evals = [acceleration_eval]
-        else:
-            acceleration_evals = acceleration_eval
+        if not isinstance(acceleration_evals, (list, tuple)):
+            acceleration_evals = [acceleration_evals]
 
-        self.acceleration_evals = acceleration_evals
+        self.acceleration_evals = list(acceleration_evals)
         self.integrator = integrator
         if integrator is not None:
             integrator.set_acceleration_evals(self.acceleration_evals)

--- a/pysph/sph/tests/test_multi_group_integrator.py
+++ b/pysph/sph/tests/test_multi_group_integrator.py
@@ -1,0 +1,106 @@
+'''Tests for integrator having different acceleration evaluators for different
+stages.
+
+'''
+import unittest
+
+import pytest
+import numpy as np
+
+from pysph.base.utils import get_particle_array
+from pysph.sph.equation import Equation, MultiStageEquations
+from pysph.sph.acceleration_eval import make_acceleration_evals
+from pysph.base.kernels import CubicSpline
+from pysph.base.nnps import LinkedListNNPS as NNPS
+from pysph.sph.sph_compiler import SPHCompiler
+from pysph.sph.integrator import Integrator
+from pysph.sph.integrator_step import IntegratorStep
+
+
+class Eq1(Equation):
+    def initialize(self, d_idx, d_au):
+        d_au[d_idx] = 1.0
+
+
+class Eq2(Equation):
+    def initialize(self, d_idx, d_au):
+        d_au[d_idx] += 1.0
+
+
+class MyStepper(IntegratorStep):
+    def stage1(self, d_idx, d_u, d_au, dt):
+        d_u[d_idx] += d_au[d_idx]*dt
+
+    def stage2(self, d_idx, d_u, d_au, dt):
+        d_u[d_idx] += d_au[d_idx]*dt
+
+
+class MyIntegrator(Integrator):
+    def one_timestep(self, t, dt):
+        self.compute_accelerations(0, update_nnps=False)
+        self.stage1()
+        self.do_post_stage(dt, 1)
+        self.compute_accelerations(1, update_nnps=False)
+        self.stage2()
+
+
+class TestMultiGroupIntegrator(unittest.TestCase):
+    def setUp(self):
+        self.dim = 1
+        n = 10
+        dx = 1.0/(n-1)
+        x = np.linspace(0, 1, n)
+        m = np.ones_like(x)
+        h = np.ones_like(x)*dx*1.05
+        pa = get_particle_array(name='fluid', x=x, h=h, m=m, au=0.0, u=0.0)
+        self.pa = pa
+        self.NNPS_cls = NNPS
+        self.backend = 'cython'
+
+    def _make_integrator(self):
+        arrays = [self.pa]
+        kernel = CubicSpline(dim=self.dim)
+        eqs = [
+            [Eq1(dest='fluid', sources=['fluid'])],
+            [Eq2(dest='fluid', sources=['fluid'])]
+        ]
+        meqs = MultiStageEquations(eqs)
+        a_evals = make_acceleration_evals(
+            arrays, meqs, kernel, backend=self.backend
+        )
+        integrator = MyIntegrator(fluid=MyStepper())
+        comp = SPHCompiler(a_evals, integrator=integrator)
+        comp.compile()
+        nnps = self.NNPS_cls(dim=kernel.dim, particles=arrays)
+        nnps.update()
+        for ae in a_evals:
+            ae.set_nnps(nnps)
+        return integrator
+
+    def test_different_accels_per_integrator(self):
+        # Given
+        pa = self.pa
+        integrator = self._make_integrator()
+
+        # When
+        integrator.step(0.0, 0.1)
+
+        # Then
+        if pa.gpu:
+            pa.gpu.pull('u', 'au')
+        one = np.ones_like(pa.x)
+        np.testing.assert_array_almost_equal(pa.au, 2.0*one)
+        np.testing.assert_array_almost_equal(pa.u, 0.3*one)
+
+
+class TestMultiGroupIntegratorGPU(TestMultiGroupIntegrator):
+    def setUp(self):
+        pytest.importorskip('pysph.base.gpu_nnps')
+        super(TestMultiGroupIntegratorGPU, self).setUp()
+        from pysph.base.gpu_nnps import ZOrderGPUNNPS
+        self.NNPS_cls = ZOrderGPUNNPS
+        self.backend = 'opencl'
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
There are schemes where the acceleration terms (the RHS) is different in
each stage of integration.  For example one may predict some properties
and then correct different ones. 

- The Python integrator now performs the `compute_accelerations` and the
  API for this now takes an optional index which defaults to zero.  The
  compiled integrator simply calls the Python integrator.  A user could
  therefore have a `self.compute_accelerations(0)` or
  `self.compute_accelerations(1)` to choose different accelerations in
  their integrator.  There is also an option called `update_nnps` which
  defaults to true in case there is a need to not update nnps.

- The solver does not directly compute the initial acceleration and
  instead the integrator has a new method called
  `initial_acceleration(t, dt)` that does this.  This makes it easy for
  a user to configure what needs to be done initially.

- The compiled integrator does not do the nnps/parallel_manager or
  compute acceleration work and delegates to the Python one.

- A `pysph.sph.equations.MultiStageEquations` can be returned in the
  `Application.create_equations` to signify that multi-stage
  accelerations are desired.
