### PR TITLE
Support initialize_pair in equations.

### DIFF
--- a/pysph/sph/acceleration_eval_cython.mako
+++ b/pysph/sph/acceleration_eval_cython.mako
@@ -63,6 +63,11 @@ src = self.${source}
 ${indent(helper.get_src_array_setup(source, eq_group), 0)}
 src_array_index = src.index
 
+% if eq_group.has_initialize_pair():
+for d_idx in range(NP_DEST):
+    ${indent(eq_group.get_initialize_pair_code(helper.object.kernel), 1)}
+% endif
+
 % if eq_group.has_loop() or eq_group.has_loop_all():
 #######################################################################
 ## Iterate over destination particles.

--- a/pysph/sph/acceleration_eval_opencl.mako
+++ b/pysph/sph/acceleration_eval_opencl.mako
@@ -34,6 +34,13 @@ ${helper.get_simple_loop_kernel(g_idx, sg_idx, group, dest, eqs_with_no_source)}
 % for source, eq_group in sources.items():
 // Source ${source}.
 ###################################################################
+## Do any pairwise initializations.
+###################################################################
+% if eq_group.has_initialize_pair():
+// Initialization for destination ${dest} with source ${source}.
+${helper.get_initialize_pair_kernel(g_idx, sg_idx, group, dest, source, eq_group)}
+% endif
+###################################################################
 ## Do any loop interactions between source and destination.
 ###################################################################
 % if eq_group.has_loop() or eq_group.has_loop_all():

--- a/pysph/sph/acceleration_eval_opencl_helper.py
+++ b/pysph/sph/acceleration_eval_opencl_helper.py
@@ -472,12 +472,18 @@ class AccelerationEvalOpenCLHelper(object):
             if a in args:
                 args.remove(a)
 
-    def _get_simple_kernel(self, g_idx, sg_idx, group, dest, all_eqs, kind):
-        assert kind in ('initialize', 'post_loop', 'loop')
+    def _get_simple_kernel(self, g_idx, sg_idx, group, dest, all_eqs, kind,
+                           source=None):
+        assert kind in ('initialize', 'initialize_pair', 'post_loop', 'loop')
         sub_grp = '' if sg_idx == -1 else 's{idx}'.format(idx=sg_idx)
-        kernel = 'g{g_idx}{sub}_{dest}_{kind}'.format(
-            g_idx=g_idx, sub=sub_grp, dest=dest, kind=kind
-        )
+        if source is None:
+            kernel = 'g{g_idx}{sub}_{dest}_{kind}'.format(
+                g_idx=g_idx, sub=sub_grp, dest=dest, kind=kind
+            )
+        else:
+            kernel = 'g{g_idx}{sg}_{source}_on_{dest}_{kind}'.format(
+                g_idx=g_idx, sg=sub_grp, source=source, dest=dest, kind=kind
+            )
 
         sph_k_name = self.object.kernel.__class__.__name__
         code = [
@@ -490,9 +496,13 @@ class AccelerationEvalOpenCLHelper(object):
         code.extend(_calls)
 
         s_ary, d_ary = all_eqs.get_array_names()
-        # We only need the dest arrays here as these are simple kernels
-        # without a loop so there is no "source".
-        _args = list(d_ary)
+        if source is None:
+            # We only need the dest arrays here as these are simple kernels
+            # without a loop so there is no "source".
+            _args = list(d_ary)
+        else:
+            d_ary.update(s_ary)
+            _args = list(d_ary)
         py_args.extend(_args)
         all_args.extend(self._get_typed_args(_args))
         all_args.extend(
@@ -606,6 +616,13 @@ class AccelerationEvalOpenCLHelper(object):
     def get_initialize_kernel(self, g_idx, sg_idx, group, dest, all_eqs):
         return self._get_simple_kernel(
             g_idx, sg_idx, group, dest, all_eqs, kind='initialize'
+        )
+
+    def get_initialize_pair_kernel(self, g_idx, sg_idx, group, dest, source,
+                                   eq_group):
+        return self._get_simple_kernel(
+            g_idx, sg_idx, group, dest, eq_group, kind='initialize_pair',
+            source=source
         )
 
     def get_simple_loop_kernel(self, g_idx, sg_idx, group, dest, all_eqs):

--- a/pysph/sph/equation.py
+++ b/pysph/sph/equation.py
@@ -348,7 +348,8 @@ def get_arrays_used_in_equation(equation):
     """
     src_arrays = set()
     dest_arrays = set()
-    for meth_name in ('initialize', 'loop', 'loop_all', 'post_loop'):
+    methods = ('initialize', 'initialize_pair', 'loop', 'loop_all', 'post_loop')
+    for meth_name in methods:
         meth = getattr(equation, meth_name, None)
         if meth is not None:
             args = getfullargspec(meth).args
@@ -508,7 +509,7 @@ class Group(object):
         )
 
     def _has_code(self, kind='loop'):
-        assert kind in ('initialize', 'loop', 'loop_all',
+        assert kind in ('initialize', 'initialize_pair', 'loop', 'loop_all',
                         'post_loop', 'reduce')
         for equation in self.equations:
             if hasattr(equation, kind):
@@ -622,6 +623,9 @@ class Group(object):
     def has_initialize(self):
         return self._has_code('initialize')
 
+    def has_initialize_pair(self):
+        return self._has_code('initialize_pair')
+
     def has_loop(self):
         return self._has_code('loop')
 
@@ -671,7 +675,7 @@ class CythonGroup(Group):
         return '\n'.join(decl)
 
     def _get_code(self, kernel=None, kind='loop'):
-        assert kind in ('initialize', 'loop', 'loop_all',
+        assert kind in ('initialize', 'initialize_pair', 'loop', 'loop_all',
                         'post_loop', 'reduce')
         # We assume here that precomputed quantities are only relevant
         # for loops and not post_loops and initialization.
@@ -748,6 +752,9 @@ class CythonGroup(Group):
 
     def get_initialize_code(self, kernel=None):
         return self._get_code(kernel, kind='initialize')
+
+    def get_initialize_pair_code(self, kernel=None):
+        return self._get_code(kernel, kind='initialize_pair')
 
     def get_loop_code(self, kernel=None):
         return self._get_code(kernel, kind='loop')

--- a/pysph/sph/tests/test_acceleration_eval.py
+++ b/pysph/sph/tests/test_acceleration_eval.py
@@ -221,6 +221,13 @@ class LoopAllEquation(Equation):
         d_rho[d_idx] += sum
 
 
+class InitializePair(Equation):
+    def initialize_pair(self, d_idx, d_u, s_u):
+        # Will only work if the source/destinations are the same
+        # but should do for a test.
+        d_u[d_idx] = s_u[d_idx]*1.5
+
+
 class TestMegaGroup(unittest.TestCase):
     def test_ensure_group_retains_user_order_of_equations(self):
         # Given
@@ -388,6 +395,25 @@ class TestAccelerationEval1D(unittest.TestCase):
         # Then
         expect = np.sum(pa.m)
         self.assertAlmostEqual(pa.total_mass[0], expect, 14)
+
+    def test_should_call_initialize_pair(self):
+        # Given.
+        pa = self.pa
+        pa.u[:] = 1.0
+        if pa.gpu:
+            pa.gpu.push('u')
+        equations = [InitializePair(dest='fluid', sources=['fluid'])]
+        a_eval = self._make_accel_eval(equations)
+
+        # When
+        a_eval.compute(0.0, 0.1)
+
+        # Then
+        if pa.gpu:
+            pa.gpu.pull('u')
+        np.testing.assert_array_almost_equal(
+            pa.u, np.ones_like(pa.x)*1.5
+        )
 
     def test_should_call_py_initialize(self):
         # Given.
@@ -752,6 +778,25 @@ class TestAccelerationEval1DGPU(unittest.TestCase):
         expect = np.sum(pa.m)
         pa.gpu.pull('total_mass')
         self.assertAlmostEqual(pa.total_mass[0], expect, 14)
+
+    def test_should_call_initialize_pair_on_gpu(self):
+        # Given.
+        pa = self.pa
+        pa.u[:] = 1.0
+        if pa.gpu:
+            pa.gpu.push('u')
+        equations = [InitializePair(dest='fluid', sources=['fluid'])]
+        a_eval = self._make_accel_eval(equations)
+
+        # When
+        a_eval.compute(0.0, 0.1)
+
+        # Then
+        if pa.gpu:
+            pa.gpu.pull('u')
+        np.testing.assert_array_almost_equal(
+            pa.u, np.ones_like(pa.x)*1.5
+        )
 
     def test_should_call_py_initialize_for_gpu_backend(self):
         # Given.


### PR DESCRIPTION
This basically performs a pairwise initialization, and is called per
destination particle, once per source, but can access source arrays.
This can be handy if one needs to perform initialization pairwise, for
example if one wishes to set some property based on a source property
but without even requiring any neighbors.