### PR TITLE
Fix FreeBSD and other issues

### DIFF
--- a/pysph/base/nnps_base.pyx
+++ b/pysph/base/nnps_base.pyx
@@ -1279,7 +1279,7 @@ cdef class NNPS(NNPSBase):
                 _entry.second = gids[_id]
                 _data[i] = _entry
             # Sort it.
-            sort(_data.begin(), _data.end(), _compare_gids)
+            sort(_data.begin(), _data.end(), &_compare_gids)
             # Set the sorted neighbors.
             for i in range(length):
                 nbrs[i] = _data[i].first

--- a/pysph/tools/cli.py
+++ b/pysph/tools/cli.py
@@ -7,27 +7,33 @@ from argparse import ArgumentParser
 from os.path import exists, join
 import sys
 
+
 def run_viewer(args):
     from pysph.tools.mayavi_viewer import main
     main(args)
+
 
 def run_examples(args):
     from pysph.examples.run import main
     main(args)
 
+
 def output_vtk(args):
     from pysph.solver.vtk_output import main
     main(args)
+
 
 def _has_pysph_dir():
     init_py = join('pysph', '__init__.py')
     init_pyc = join('pysph', '__init__.pyc')
     return exists(init_py) or exists(init_pyc)
 
+
 def run_tests(args):
-    argv = ['--pyargs','pysph', 'pyzoltan'] + args
+    argv = ['--pyargs', 'pysph'] + args
     from pytest import cmdline
     cmdline.main(args=argv)
+
 
 def main():
     parser = ArgumentParser(description=__doc__, add_help=False)
@@ -51,7 +57,7 @@ def main():
 
     vtk_out = subparsers.add_parser(
         'dump_vtk', help='Dump VTK Output',
-         add_help=False
+        add_help=False
     )
     vtk_out.set_defaults(func=output_vtk)
     tests = subparsers.add_parser(
@@ -60,13 +66,14 @@ def main():
     )
     tests.set_defaults(func=run_tests)
 
-    if len(sys.argv) == 1 or \
-        (len(sys.argv) > 1 and sys.argv[1] in ['-h', '--help']):
+    if (len(sys.argv) == 1 or (len(sys.argv) > 1 and
+                               sys.argv[1] in ['-h', '--help'])):
         parser.print_help()
         sys.exit()
 
     args, extra = parser.parse_known_args()
     args.func(extra)
+
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,8 @@ try:
 except ImportError:
     HAVE_ZOLTAN = False
 
+base_includes = [] if sys.platform == 'win32' else ['/usr/local/include/']
+
 compiler = 'gcc'
 # compiler = 'intel'
 if compiler == 'intel':
@@ -118,6 +120,7 @@ def get_openmp_flags():
         fp.write(test_code)
     extension = Extension(
         name='check_omp', sources=[fname],
+        include_dirs=base_includes,
         extra_compile_args=omp_compile_flags,
         extra_link_args=omp_link_flags,
     )
@@ -272,6 +275,7 @@ def get_basic_extensions():
         import numpy
         include_dirs = [numpy.get_include()]
 
+    include_dirs += base_includes
     openmp_compile_args, openmp_link_args, openmp_env = get_openmp_flags()
 
     ext_modules = [
@@ -549,6 +553,8 @@ def get_parallel_extensions():
     # get the MPI flags and are not successful.
     if not HAVE_MPI:
         return []
+
+    include_dirs += base_includes
 
     MPI4PY_V2 = False if mpi4py.__version__.startswith('1.') else True
     cython_compile_time_env = {'MPI4PY_V2': MPI4PY_V2}


### PR DESCRIPTION
- Fix compilation error with clang 6.x on FreeBSD.  Fixes #152.
- Add /usr/local/include to list of includes.
- Fix pysph test and remove pyzoltan from there.