### PR TITLE
Fix Adami bc

### DIFF
--- a/pysph/examples/cavity.py
+++ b/pysph/examples/cavity.py
@@ -7,7 +7,8 @@ import os
 from pysph.base.utils import get_particle_array
 from pysph.solver.application import Application
 
-from pysph.sph.scheme import TVFScheme
+from pysph.sph.scheme import TVFScheme, SchemeChooser
+from pysph.sph.wc.edac import EDACScheme
 
 # numpy
 import numpy as np
@@ -56,14 +57,22 @@ class LidDrivenCavity(Application):
 
     def configure_scheme(self):
         h0 = hdx * self.dx
-        self.scheme.configure(h0=h0, nu=self.nu)
+        if self.options.scheme == 'tvf':
+            self.scheme.configure(h0=h0, nu=self.nu)
+        elif self.options.scheme == 'edac':
+            self.scheme.configure(h=h0, nu=self.nu)
         self.scheme.configure_solver(tf=self.tf, dt=self.dt, pfreq=500)
 
     def create_scheme(self):
-        s = TVFScheme(
+        tvf = TVFScheme(
             ['fluid'], ['solid'], dim=2, rho0=rho0, c0=c0, nu=None,
             p0=p0, pb=p0, h0=hdx
         )
+        edac = EDACScheme(
+            fluids=['fluid'], solids=['solid'], dim=2, c0=c0, rho0=rho0,
+            nu=0.0, pb=p0, eps=0.0, h=0.0,
+        )
+        s = SchemeChooser(default='tvf', tvf=tvf, edac=edac)
         return s
 
     def create_particles(self):

--- a/pysph/examples/cavity.py
+++ b/pysph/examples/cavity.py
@@ -99,9 +99,7 @@ class LidDrivenCavity(Application):
         fluid.set_name('fluid')
         solid.remove_particles(indices)
 
-        print("Lid driven cavity :: Re = %d, nfluid = %d, nsolid=%d, dt = %g" % (
-            self.re, fluid.get_number_of_particles(),
-            solid.get_number_of_particles(), self.dt))
+        print("Lid driven cavity :: Re = %d, dt = %g" % (self.re, self.dt))
 
         # add requisite properties to the arrays:
         self.scheme.setup_properties([fluid, solid])

--- a/pysph/sph/scheme.py
+++ b/pysph/sph/scheme.py
@@ -774,7 +774,7 @@ class AdamiHuAdamsScheme(TVFScheme):
         from pysph.sph.wc.basic import TaitEOS
         from pysph.sph.basic_equations import XSPHCorrection
         from pysph.sph.wc.transport_velocity import (
-            ContinuityEquation,
+            ContinuityEquation, ContinuitySolid,
             MomentumEquationPressureGradient,
             MomentumEquationViscosity, MomentumEquationArtificialViscosity,
             SolidWallPressureBC, SolidWallNoSlipBC, SetWallVelocity,
@@ -809,8 +809,12 @@ class AdamiHuAdamsScheme(TVFScheme):
         g4 = []
         for fluid in self.fluids:
             g4.append(
-                ContinuityEquation(dest=fluid, sources=all)
+                ContinuityEquation(dest=fluid, sources=self.fluids)
             )
+            if self.solids:
+                g4.append(
+                    ContinuitySolid(dest=fluid, sources=self.solids)
+                )
             g4.append(
                 MomentumEquationPressureGradient(
                     dest=fluid, sources=all, pb=0.0, gx=self.gx,

--- a/pysph/sph/wc/transport_velocity.py
+++ b/pysph/sph/wc/transport_velocity.py
@@ -59,7 +59,7 @@ class SummationDensity(Equation):
 
 
 class VolumeSummation(Equation):
-    """**Number density for volume computation**
+    r"""**Number density for volume computation**
 
     See `SummationDensity`
 

--- a/pysph/sph/wc/transport_velocity.py
+++ b/pysph/sph/wc/transport_velocity.py
@@ -149,9 +149,28 @@ class ContinuityEquation(Equation):
     def initialize(self, d_idx, d_arho):
         d_arho[d_idx] = 0.0
 
-    def loop(self, d_idx, s_idx, d_arho, s_V, d_rho, VIJ, DWIJ):
+    def loop(self, d_idx, s_idx, d_arho, s_m, s_rho, d_rho, VIJ, DWIJ):
         vijdotdwij = VIJ[0] * DWIJ[0] + VIJ[1] * DWIJ[1] + VIJ[2] * DWIJ[2]
-        d_arho[d_idx] += d_rho[d_idx] * vijdotdwij / s_V[s_idx]
+        d_arho[d_idx] += d_rho[d_idx] * vijdotdwij * s_m[s_idx] / s_rho[s_idx]
+
+
+class ContinuitySolid(Equation):
+    """Continuity equation for the solid's ghost particles.
+
+    The key difference is that we use the ghost velocity ug, and not the
+    particle velocity u.
+
+    """
+    def loop(self, d_idx, s_idx, d_rho, d_u, d_v, d_w, d_arho,
+             s_m, s_rho, s_ug, s_vg, s_wg, DWIJ):
+        Vj = s_m[s_idx] / s_rho[s_idx]
+        rhoi = d_rho[d_idx]
+        uij = d_u[d_idx] - s_ug[s_idx]
+        vij = d_v[d_idx] - s_vg[s_idx]
+        wij = d_w[d_idx] - s_wg[s_idx]
+        vij_dot_dwij = uij*DWIJ[0] + vij*DWIJ[1] + wij*DWIJ[2]
+
+        d_arho[d_idx] += rhoi*Vj*vij_dot_dwij
 
 
 class StateEquation(Equation):


### PR DESCRIPTION
The implementation of the boundary condition with the approach of Adami
et al. (2012) uses ghost velocities and it is this velocity that should
be used for the continuity equation and not the usual u, v, and w.  This
is now fixed.