### PR TITLE
BUG: Fix massive leak with caching nnps.

### DIFF
--- a/pysph/base/nnps_base.pxd
+++ b/pysph/base/nnps_base.pxd
@@ -246,7 +246,8 @@ cdef class NeighborCache:
     cdef UIntArray _start_stop
     cdef IntArray _cached
     cdef void **_neighbors
-    cdef list _neighbor_arrays
+    # This is made public purely for testing!
+    cdef public list _neighbor_arrays
     cdef int _last_avg_nbr_size
 
     cdef void get_neighbors_raw(self, size_t d_idx, UIntArray nbrs) nogil
@@ -265,7 +266,7 @@ cdef class NNPSBase:
     cdef public list pa_wrappers      # list of particle array wrappers
     cdef public int narrays           # Number of particle arrays
     cdef public bint use_cache        # Use cache or not.
-    cdef list cache                   # The neighbor cache.
+    cdef public list cache            # The neighbor cache.
     cdef int src_index, dst_index     # The current source and dest indices
 
     cdef public DomainManager domain  # Domain manager

--- a/pysph/base/nnps_base.pyx
+++ b/pysph/base/nnps_base.pyx
@@ -44,7 +44,7 @@ ELSE:
     cpdef int get_number_of_threads():
         return 1
     cpdef set_number_of_threads(int n):
-        print "OpenMP not available, cannot set number of threads."
+        print("OpenMP not available, cannot set number of threads.")
 
 
 IF UNAME_SYSNAME == "Windows":
@@ -1003,8 +1003,11 @@ cdef class NeighborCache:
         # This is an upper limit for the number of neighbors in a worst
         # case scenario.
         cdef size_t safety = 1024
+        cdef UIntArray arr
         for i in range(n_threads):
-            (<UIntArray>self._neighbors[i]).c_reserve(
+            arr = <UIntArray>self._neighbors[i]
+            arr.c_reset()
+            arr.c_reserve(
                 self._last_avg_nbr_size*np/n_threads + safety
             )
 

--- a/pysph/base/tests/test_nnps.py
+++ b/pysph/base/tests/test_nnps.py
@@ -1018,6 +1018,26 @@ def test_large_number_of_neighbors_linked_list():
     assert nbrs.length == len(x)
 
 
+def test_neighbor_cache_update_doesnt_leak():
+    # Given
+    x, y, z = numpy.random.random((3, 1000))
+    pa = get_particle_array(name='fluid', x=x, y=y, z=z, h=0.05)
+
+    nps = nnps.LinkedListNNPS(dim=3, particles=[pa], cache=True)
+    nps.set_context(0, 0)
+    nps.cache[0].find_all_neighbors()
+    old_length = sum(x.length for x in nps.cache[0]._neighbor_arrays)
+
+    # When
+    nps.update()
+    nps.set_context(0, 0)
+    nps.cache[0].find_all_neighbors()
+
+    # Then
+    new_length = sum(x.length for x in nps.cache[0]._neighbor_arrays)
+    assert new_length == old_length
+
+
 nnps_classes = [
     nnps.BoxSortNNPS,
     nnps.CellIndexingNNPS,


### PR DESCRIPTION
This fixes a massive leak when caching nnps results.  Earlier, the
memory usage would grow without bound because the neighbor lengths were
not reset on each update.  This is now fixed and caching is very
efficient.