### PR TITLE
Misc viewer improvements

### DIFF
--- a/docs/source/tutorial/circular_patch_simple.rst
+++ b/docs/source/tutorial/circular_patch_simple.rst
@@ -394,6 +394,14 @@ a `Glyph` instance from Mayavi_. It is useful to use the `record feature
 <http://docs.enthought.com/mayavi/mayavi/mlab_changing_object_looks.html#changing-object-properties-interactively>`_
 of Mayavi to learn more about how best to script the view.
 
+The viewer will always look for a ``mayavi_config.py`` script inside the
+output directory to setup the visualization parameters. This file can be
+created by overriding the :py:class:`pysph.solver.application.Application`
+object's ``customize_output`` method. See the `dam break 3d
+<https://github.com/pypr/pysph/blob/master/pysph/examples/dam_break_3d.py>`_
+example to see this being used. Of course, this file can also be created
+manually.
+
 
 Loading output data files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/tutorial/circular_patch_simple.rst
+++ b/docs/source/tutorial/circular_patch_simple.rst
@@ -370,22 +370,22 @@ interpreter with a few useful objects available.  These are::
     >>> dir()
     ['__builtins__', '__doc__', '__name__', 'interpolator', 'mlab',
      'particle_arrays', 'scene', 'self', 'viewer']
-    >>> len(particle_arrays)
-    1
-    >>> particle_arrays[0].name
+    >>> particle_arrays['fluid'].name
     'fluid'
 
-The ``particle_arrays`` object is a list of **ParticleArrayHelpers** which is
-available in :py:class:`pysph.tools.mayavi_viewer.ParticleArrayHelper`. The
+The ``particle_arrays`` object is a dictionary of **ParticleArrayHelpers**
+which is available in
+:py:class:`pysph.tools.mayavi_viewer.ParticleArrayHelper`. The
 ``interpolator`` is an instance of
 :py:class:`pysph.tools.mayavi_viewer.InterpolatorView` that is used by the
 viewer. The other objects can be used to script the user interface if desired.
+Note that the ``particle_arrays`` can be indexed by array name or index.
 
 Here is an example of scripting the viewer. Let us say we have two particle
 arrays, `'boundary'` and `'fluid'` in that order. Let us say, we wish to make
 the boundary translucent, then we can write the following::
 
-   b = particle_arrays[0]
+   b = particle_arrays['boundary']
    b.plot.actor.property.opacity = 0.2
 
 This does require some knowledge of Mayavi_ and scripting with it. The `plot`

--- a/pysph/examples/dam_break_3d.py
+++ b/pysph/examples/dam_break_3d.py
@@ -74,6 +74,14 @@ class DamBreak3D(Application):
     def create_particles(self):
         return self.geom.create_particles()
 
+    def customize_output(self):
+        self._mayavi_config('''
+        viewer.scalar = 'u'
+        b = particle_arrays[0]
+        b.plot.actor.mapper.scalar_visibility = False
+        b.plot.actor.property.opacity = 0.1
+        ''')
+
 
 if __name__ == '__main__':
     app = DamBreak3D()

--- a/pysph/examples/dam_break_3d.py
+++ b/pysph/examples/dam_break_3d.py
@@ -77,7 +77,7 @@ class DamBreak3D(Application):
     def customize_output(self):
         self._mayavi_config('''
         viewer.scalar = 'u'
-        b = particle_arrays[0]
+        b = particle_arrays['boundary']
         b.plot.actor.mapper.scalar_visibility = False
         b.plot.actor.property.opacity = 0.1
         ''')

--- a/pysph/examples/sphysics/case5.py
+++ b/pysph/examples/sphysics/case5.py
@@ -117,8 +117,7 @@ class Case5(Application):
     def customize_output(self):
         self._mayavi_config('''
         viewer.scalar = 'vmag'
-        index = 0 if particle_arrays[0].name == 'boundary' else 1
-        b = particle_arrays[index]
+        b = particle_arrays['boundary']
         b.plot.actor.mapper.scalar_visibility = False
         b.plot.actor.property.opacity = 0.1
         ''')

--- a/pysph/examples/sphysics/case5.py
+++ b/pysph/examples/sphysics/case5.py
@@ -114,6 +114,15 @@ class Case5(Application):
         self.scheme.setup_properties([f, b])
         return [f, b]
 
+    def customize_output(self):
+        self._mayavi_config('''
+        viewer.scalar = 'vmag'
+        index = 0 if particle_arrays[0].name == 'boundary' else 1
+        b = particle_arrays[index]
+        b.plot.actor.mapper.scalar_visibility = False
+        b.plot.actor.property.opacity = 0.1
+        ''')
+
 
 if __name__ == '__main__':
     app = Case5()

--- a/pysph/examples/sphysics/dam_break.py
+++ b/pysph/examples/sphysics/dam_break.py
@@ -102,6 +102,15 @@ class DamBreak(Application):
         self.scheme.setup_properties([f, b])
         return [f, b]
 
+    def customize_output(self):
+        self._mayavi_config('''
+        viewer.scalar = 'vmag'
+        index = 0 if particle_arrays[0].name == 'boundary' else 1
+        b = particle_arrays[index]
+        b.plot.actor.mapper.scalar_visibility = False
+        b.plot.actor.property.opacity = 0.15
+        ''')
+
 
 if __name__ == '__main__':
     app = DamBreak()

--- a/pysph/examples/sphysics/dam_break.py
+++ b/pysph/examples/sphysics/dam_break.py
@@ -105,8 +105,7 @@ class DamBreak(Application):
     def customize_output(self):
         self._mayavi_config('''
         viewer.scalar = 'vmag'
-        index = 0 if particle_arrays[0].name == 'boundary' else 1
-        b = particle_arrays[index]
+        b = particle_arrays['boundary']
         b.plot.actor.mapper.scalar_visibility = False
         b.plot.actor.property.opacity = 0.15
         ''')

--- a/pysph/tools/mayavi_viewer.py
+++ b/pysph/tools/mayavi_viewer.py
@@ -1015,7 +1015,11 @@ class MayaviViewer(HasTraits):
         obj.edit_traits()
 
     def _get_shell_namespace(self):
-        return dict(viewer=self, particle_arrays=self.particle_arrays,
+        pas = {}
+        for i, x in enumerate(self.particle_arrays):
+            pas[i] = x
+            pas[x.name] = x
+        return dict(viewer=self, particle_arrays=pas,
                     interpolator=self.interpolator, scene=self.scene,
                     mlab=self.scene.mlab)
 

--- a/pysph/tools/mayavi_viewer.py
+++ b/pysph/tools/mayavi_viewer.py
@@ -210,9 +210,11 @@ class InterpolatorView(HasTraits):
 
             if self.plot is None:
                 if interp.dim == 3:
-                    plot = mlab.pipeline.scalar_cut_plane(src)
+                    plot = mlab.pipeline.scalar_cut_plane(
+                        src, colormap='viridis'
+                    )
                 else:
-                    plot = mlab.pipeline.surface(src)
+                    plot = mlab.pipeline.surface(src, colormap='viridis')
                 self.plot = plot
                 scm = plot.module_manager.scalar_lut_manager
                 scm.set(show_legend=self.show_legend,
@@ -399,7 +401,9 @@ class ParticleArrayHelper(HasTraits):
             old_empty = len(old_x) == 0
         if p is None and not empty:
             src = mlab.pipeline.scalar_scatter(x, y, z, s)
-            p = mlab.pipeline.glyph(src, mode='point', scale_mode='none')
+            p = mlab.pipeline.glyph(
+                src, mode='point', scale_mode='none', colormap='viridis'
+            )
             p.actor.property.point_size = 6
             scm = p.module_manager.scalar_lut_manager
             scm.set(show_legend=self.show_legend,
@@ -505,7 +509,8 @@ class ParticleArrayHelper(HasTraits):
             pv = self.scene.mlab.pipeline.vectors(
                 self.plot.mlab_source.m_data,
                 mask_points=self.mask_on_ratio,
-                scale_factor=self.scale_factor
+                scale_factor=self.scale_factor,
+                colormap='viridis'
             )
             self.plot_vectors = pv
 

--- a/pysph/tools/mayavi_viewer.py
+++ b/pysph/tools/mayavi_viewer.py
@@ -1029,6 +1029,9 @@ class MayaviViewer(HasTraits):
             self.file_count = min(self.file_count, len(files))
         else:
             pass
+        config_file = os.path.join(d, 'mayavi_config.py')
+        if os.path.exists(config_file):
+            self.run_script(config_file)
 
     def _live_mode_changed(self, value):
         if value:
@@ -1173,6 +1176,9 @@ def main(args=None):
                 if len(_files) == 0:
                     _files = glob.glob(os.path.join(arg, '*.npz'))
                 files.extend(_files)
+                config_file = os.path.join(arg, 'mayavi_config.py')
+                if os.path.exists(config_file):
+                    scripts.append(config_file)
                 continue
             else:
                 usage()


### PR DESCRIPTION
- Use viridis colormap by default.
- Add an Application.customize_output method. This method can be used to configure the output visualization.  The pysph mayavi viewer now looks for a mayavi_config.py file which can be
generated by overloading Application.customize_output and calling Application._mayavi_config(...).  What this does is to setup the default visualization options so users don't have to do this each time.  