### PR TITLE
Remove pi as predefined quantity

### DIFF
--- a/docs/source/design/equations.rst
+++ b/docs/source/design/equations.rst
@@ -331,16 +331,31 @@ following:
    destination particle with index, ``d_idx``.
 
 
-
 .. note::
 
    Note that all standard functions and constants in ``math.h`` are available
-   for use in the equations. ``pi`` is defined. Please avoid using functions
-   from ``numpy`` as these are Python functions and are slow. They also will
-   not allow PySPH to be run with OpenMP. Similarly, do not use functions or
-   constants from ``sympy`` and other libraries inside the equation methods as
-   these will significantly slow down your code.
+   for use in the equations. The value of :math:`\pi` is available as
+   ``M_PI``. Please avoid using functions from ``numpy`` as these are Python
+   functions and are slow. They also will not allow PySPH to be run with
+   OpenMP. Similarly, do not use functions or constants from ``sympy`` and
+   other libraries inside the equation methods as these will significantly
+   slow down your code.
 
+In addition, these constants from the math library are available:
+
+  - ``M_E``: value of e
+  - ``M_LOG2E``: value of log2e
+  - ``M_LOG10E``: value of log10e
+  - ``M_LN2``: value of loge2
+  - ``M_LN10``: value of loge10
+  - ``M_PI``: value of pi
+  - ``M_PI_2``: value of pi / 2
+  - ``M_PI_4``: value of pi / 4
+  - ``M_1_PI``: value of 1 / pi
+  - ``M_2_PI``: value of 2 / pi
+  - ``M_2_SQRTPI``: value of 2 / (square root of pi)
+  - ``M_SQRT2``: value of square root of 2
+  - ``M_SQRT1_2``: value of square root of 1/2
 
 In an equation, any undeclared variables are automatically declared to be
 doubles in the high-performance Cython code that is generated.  In addition

--- a/docs/source/design/overview.rst
+++ b/docs/source/design/overview.rst
@@ -582,11 +582,28 @@ the following may be passed into any of the methods of an equation:
 .. note::
 
    Note that all standard functions and constants in ``math.h`` are available
-   for use in the equations. ``pi`` is defined. Please avoid using functions
-   from ``numpy`` as these are Python functions and are slow. They also will
-   not allow PySPH to be run with OpenMP. Similarly, do not use functions or
-   constants from ``sympy`` and other libraries inside the equation methods as
-   these will significantly slow down your code.
+   for use in the equations. The value of :math:`\pi` is available in
+   ``M_PI``. Please avoid using functions from ``numpy`` as these are Python
+   functions and are slow. They also will not allow PySPH to be run with
+   OpenMP. Similarly, do not use functions or constants from ``sympy`` and
+   other libraries inside the equation methods as these will significantly
+   slow down your code.
+
+In addition, these constants from the math library are available:
+
+  - ``M_E``: value of e
+  - ``M_LOG2E``: value of log2e
+  - ``M_LOG10E``: value of log10e
+  - ``M_LN2``: value of loge2
+  - ``M_LN10``: value of loge10
+  - ``M_PI``: value of pi
+  - ``M_PI_2``: value of pi / 2
+  - ``M_PI_4``: value of pi / 4
+  - ``M_1_PI``: value of 1 / pi
+  - ``M_2_PI``: value of 2 / pi
+  - ``M_2_SQRTPI``: value of 2 / (square root of pi)
+  - ``M_SQRT2``: value of square root of 2
+  - ``M_SQRT1_2``: value of square root of 1/2
 
 In an equation, any undeclared variables are automatically declared to be
 doubles in the high-performance Cython code that is generated.  In addition

--- a/docs/source/reference/solver.rst
+++ b/docs/source/reference/solver.rst
@@ -10,8 +10,21 @@ Module solver tools
 .. automodule:: pysph.solver.tools
    :members:
 
-Module simple_inlet_outlet
-==========================
+Module boundary conditions
+===========================
 
-.. automodule:: pysph.sph.simple_inlet_outlet
+.. automodule:: pysph.sph.bc.inlet
    :members:
+   :undoc-members:
+
+.. automodule:: pysph.sph.bc.outlet
+   :members:
+   :undoc-members:
+
+.. automodule:: pysph.sph.bc.inlet_outlet_manager
+   :members:
+   :undoc-members:
+
+.. automodule:: pysph.sph.bc.simple_inlet_outlet
+   :members:
+   :undoc-members:

--- a/pysph/solver/solver.py
+++ b/pysph/solver/solver.py
@@ -760,7 +760,6 @@ class Solver(object):
         if (self.t + dt) > (self.tf - self._epsilon):
             dt = self.tf - self.t
 
-        #print(dt)
         return dt
 
     def _get_undamped_timestep(self):

--- a/pysph/solver/solver.py
+++ b/pysph/solver/solver.py
@@ -760,6 +760,7 @@ class Solver(object):
         if (self.t + dt) > (self.tf - self._epsilon):
             dt = self.tf - self.t
 
+        #print(dt)
         return dt
 
     def _get_undamped_timestep(self):

--- a/pysph/sph/acceleration_eval_cython.mako
+++ b/pysph/sph/acceleration_eval_cython.mako
@@ -139,7 +139,6 @@ ${indent(helper.get_post_call(group), 0)}
 from libc.stdio cimport printf
 from libc.math cimport *
 from libc.math cimport fabs as abs
-from libc.math cimport M_PI as pi
 cimport numpy
 import numpy
 % if not helper.config.use_openmp:

--- a/pysph/sph/acceleration_eval_opencl.mako
+++ b/pysph/sph/acceleration_eval_opencl.mako
@@ -81,7 +81,6 @@ ${helper.get_post_loop_kernel(g_idx, sg_idx, group, dest, all_eqs)}
 #define NORM2(X, Y, Z) ((X)*(X) + (Y)*(Y) + (Z)*(Z))
 #define MAX(X, Y) ((X) > (Y) ? (X) : (Y))
 
-__constant double pi=M_PI;
 ${helper.get_header()}
 #######################################################################
 ## Iterate over groups

--- a/pysph/sph/bc/inlet.py
+++ b/pysph/sph/bc/inlet.py
@@ -6,6 +6,8 @@ import numpy as np
 
 
 class Inlet(object):
+    """Defines an inlet object.
+    """
     def __init__(self, inlet_pa, dest_pa, inletinfo, kernel, dim,
                  active_stages=[1], callback=None):
         """An API to add/delete particle when moving between inlet-fluid

--- a/pysph/sph/bc/inlet_outlet_manager.py
+++ b/pysph/sph/bc/inlet_outlet_manager.py
@@ -1,9 +1,3 @@
-"""
-Inlet Outlet Manager
-"""
-# Copyright (c) 2015-2017, Prabhu Ramachandran
-# License: BSD
-
 from pysph.sph.equation import Equation
 
 

--- a/pysph/sph/integrator_cython.mako
+++ b/pysph/sph/integrator_cython.mako
@@ -7,7 +7,6 @@ ${' '*4*level}${l}
 </%def>
 
 from libc.math cimport *
-from libc.math cimport M_PI as pi
 
 from pysph.base.nnps_base cimport NNPS
 

--- a/pysph/sph/misc/advection.py
+++ b/pysph/sph/misc/advection.py
@@ -4,12 +4,15 @@ Functions for advection
 """
 
 from pysph.sph.equation import Equation
-from numpy import cos, pi
+from numpy import cos
+from numpy import pi as M_PI
+
 
 class Advect(Equation):
     def loop(self, d_idx, d_ax, d_ay, d_u, d_v):
         d_ax[d_idx] = d_u[d_idx]
         d_ay[d_idx] = d_v[d_idx]
+
 
 class MixingVelocityUpdate(Equation):
     def __init__(self, dest, sources, T):
@@ -17,5 +20,5 @@ class MixingVelocityUpdate(Equation):
         super(MixingVelocityUpdate, self).__init__(dest, sources)
 
     def loop(self, d_idx, d_u, d_v, d_u0, d_v0, t=0.1):
-        d_u[d_idx] = cos(pi*t/self.T) * d_u0[d_idx]
-        d_v[d_idx] = -cos(pi*t/self.T) * d_v0[d_idx]
+        d_u[d_idx] = cos(M_PI*t/self.T) * d_u0[d_idx]
+        d_v[d_idx] = -cos(M_PI*t/self.T) * d_v0[d_idx]

--- a/pysph/sph/wc/linalg.py
+++ b/pysph/sph/wc/linalg.py
@@ -149,15 +149,15 @@ def gj_solve(m=[1., 0.], n=3, nb=1, result=[0.0, 0.0]):
         else:
             for backColr in range(rb, augCol):
                 backCol = rb + augCol - backColr - 1
-                m[nt*rb + backCol] = float(m[nt*rb + backCol]) / m[nt*rb + rb]
+                m[nt*rb + backCol] = m[nt*rb + backCol] / m[nt*rb + rb]
             if not (rb == 0):
                 for kupr in range(rb):
                     kup = rb - kupr - 1
                     for kleftr in range(rb, augCol):
                         kleft = rb + augCol - kleftr - 1
-                        kk = -float(m[nt*kup + rb]) / float(m[nt*rb + rb])
+                        kk = -m[nt*kup + rb] / m[nt*rb + rb]
                         m[nt*kup + kleft] = (m[nt*kup + kleft] +
-                                             kk * float(m[nt*rb + kleft]))
+                                             kk * m[nt*rb + kleft])
 
     for i in range(n):
         for j in range(nb):


### PR DESCRIPTION
This is unfortunately necessary as pi is often used as a variable.
Instead users should use M_PI for the value of pi.  Also fix some issues
with the gj_solve function when transpiled to the GPU.