### PR TITLE
Fix bug with extract particles into destination...

### DIFF
--- a/pysph/base/device_helper.py
+++ b/pysph/base/device_helper.py
@@ -111,13 +111,14 @@ class ExtractParticles(Template):
 
     def template(self, i, indices, start_idx):
         '''
-        idx, s_idx, s_i, j = declare('int', 4)
+        idx, s_idx, s_i, j, start = declare('int', 5)
         idx = indices[i]
         % for prop in obj.prop_names:
         s_idx = stride_${prop} * idx
         s_i = stride_${prop} * i
+        start = stride_${prop} * start_idx
         for j in range(stride_${prop}):
-            dst_${prop}[start_idx + s_i + j] = src_${prop}[s_idx + j]
+            dst_${prop}[start + s_i + j] = src_${prop}[s_idx + j]
         % endfor
         '''
 
@@ -701,7 +702,9 @@ class DeviceHelper(object):
         else:
             prop_names = props
 
-        result_array = pysph.base.particle_array.ParticleArray()
+        result_array = pysph.base.particle_array.ParticleArray(
+            backend=self._particle_array.backend
+        )
         result_array.set_name(self._particle_array.name)
         result_array.set_device_helper(DeviceHelper(result_array,
                                                     backend=self.backend))

--- a/pysph/base/particle_array.pyx
+++ b/pysph/base/particle_array.pyx
@@ -1309,7 +1309,7 @@ cdef class ParticleArray:
             dst_prop_array = dest_array.get_carray(prop)
             stride = self.stride.get(prop, 1)
             src_prop_array.copy_values(index_array, dst_prop_array,
-                                       stride, start_idx)
+                                       stride, stride*start_idx)
 
         if align:
             dest_array.align_particles()

--- a/pysph/base/tests/test_particle_array.py
+++ b/pysph/base/tests/test_particle_array.py
@@ -938,6 +938,28 @@ class ParticleArrayTest(object):
         self.assertEqual(n.x[0], 2.0)
         numpy.testing.assert_array_equal(n.A, [2, 3])
 
+    def test_extract_particles_works_with_non_empty_dest(self):
+        # Given
+        p = particle_array.ParticleArray(name='f', x=[1, 2, 3],
+                                         backend=self.backend)
+        p.add_property('A', data=numpy.arange(6), stride=2)
+        n = p.empty_clone()
+        n.extend(2)
+        self.pull(n)
+        print(n.x)
+
+        # When.
+        p.extract_particles([1], dest_array=n)
+        self.pull(n)
+
+        # Then.
+        self.assertEqual(len(p.x), 3)
+        self.assertEqual(len(p.A), 6)
+        self.assertEqual(len(n.x), 3)
+        self.assertEqual(len(n.A), 6)
+        numpy.testing.assert_array_equal(n.x, [0.0, 0.0, 2.0])
+        numpy.testing.assert_array_equal(n.A, [0, 0, 0, 0, 2, 3])
+
     def test_extract_particles_works_with_specific_props_with_dest(self):
         # Given
         p = particle_array.ParticleArray(name='f', x=[1, 2, 3], y=[0, 0, 0],

--- a/pysph/base/tests/test_particle_array.py
+++ b/pysph/base/tests/test_particle_array.py
@@ -945,8 +945,6 @@ class ParticleArrayTest(object):
         p.add_property('A', data=numpy.arange(6), stride=2)
         n = p.empty_clone()
         n.extend(2)
-        self.pull(n)
-        print(n.x)
 
         # When.
         p.extract_particles([1], dest_array=n)


### PR DESCRIPTION
... that is not empty.  Any properties with strides > 1 were not copied
correctly.  This is now tested and fixed.