### PR TITLE
Fix subtle issue with automatic syncing on gpu.

### DIFF
--- a/pysph/sph/acceleration_eval_gpu_helper.py
+++ b/pysph/sph/acceleration_eval_gpu_helper.py
@@ -239,7 +239,6 @@ class GPUAccelerationEval(object):
 
     def _converged(self, equations):
         for eq in equations:
-            self._sync_from_gpu(eq)
             if not (eq.converged() > 0):
                 return False
         return True

--- a/pysph/sph/equation.py
+++ b/pysph/sph/equation.py
@@ -893,7 +893,7 @@ class OpenCLGroup(Group):
             modified_classes = self._update_for_local_memory(predefined, eqs)
 
         code_gen = self._Converter_Class(known_types=predefined)
-        ignore = ['reduce']
+        ignore = ['reduce', 'converged']
         for cls in sorted(classes.keys()):
             src = code_gen.parse_instance(eqs[cls], ignore_methods=ignore)
             wrappers.append(src)

--- a/pysph/sph/equation.py
+++ b/pysph/sph/equation.py
@@ -418,6 +418,21 @@ class Equation(object):
         """
         return 1.0
 
+    def _pull(self, *args):
+        """Pull attributes from the GPU if needed.
+
+        The GPU reduce and converged methods run on the host and not on
+        the device and this is useful to call there.  This is not useful
+        on the CPU as this does not matter which is why this is a
+        private method.
+        """
+        if hasattr(self, '_gpu'):
+            ary = self._gpu.get()
+            if len(args) == 0:
+                args = ary.dtype.names
+            for arg in args:
+                setattr(self, arg, ary[arg][0])
+
 
 ###############################################################################
 # `Group` class.

--- a/pysph/sph/tests/test_acceleration_eval.py
+++ b/pysph/sph/tests/test_acceleration_eval.py
@@ -721,6 +721,9 @@ class TestAccelerationEval1DGPU(unittest.TestCase):
                     self.conv = 1
 
             def converged(self):
+                if hasattr(self, '_pull'):
+                    # _pull is not available on CPU.
+                    self._pull('conv')
                 return self.conv
 
         equations = [Group(


### PR DESCRIPTION
The issue is that originally before we call `converged`, we'd sync the
equation data from the GPU to the host.  However, `reduce` and
`converged` are pure Python calls on the GPU so if you set `self.conv =
1` or something it sets the Python attribute and not the GPU one.  So
when the converged call synced the value from the GPU it would clobber
the Python attribute.  We therefore no longer do the syncing and it is
up to the user who will call `self._pull` in their reduce or converged
method.  Note that `self._pull` is not available on the CPU which is a
bit of a pain currently but relatively easy to work around. Setting the
GPU attribute is not typical so this is quite acceptable.