### PR TITLE
bug fix

### DIFF
--- a/pysph/base/particle_array.pyx
+++ b/pysph/base/particle_array.pyx
@@ -554,12 +554,6 @@ cdef class ParticleArray:
         prop = ''
         for prop in particle_props:
             self._check_property(prop)
-            if prop in self.stride.keys():
-                stride = self.stride[prop]
-                prop_len = len(particle_props[prop])
-                base_len = self.get_number_of_particles()
-                msg = 'Property %s length should be %d' % (prop, base_len * stride)
-                assert prop_len == base_len * stride, msg
 
         if self.gpu is not None and self.backend is not 'cython':
             gpu_particle_props = {}

--- a/pysph/base/tests/test_particle_array.py
+++ b/pysph/base/tests/test_particle_array.py
@@ -397,15 +397,6 @@ class ParticleArrayTest(object):
         self.assertEqual(check_array(p.y, [0, 1, 2, 3, 0, 0]), True)
         self.assertEqual(check_array(p.z, [0, 0, 0, 0, 0, 0]), True)
 
-        # adding particles with tags
-        p = particle_array.ParticleArray(x={'data': x}, y={'data': y},
-                                         z={'data': z}, m={'data': m},
-                                         h={'data': h},
-                                         A={'data': A, 'stride': 3},
-                                         backend=self.backend)
-
-        self.assertRaises(AssertionError, p.add_particles, A=[5, 6, 7, 8])
-
     def test_remove_tagged_particles(self):
         x = [1, 2, 3, 4.]
         y = [0., 1., 2., 3.]


### PR DESCRIPTION
taking length from existing particle is wrong. We should check length from input particle array.
Also all particles to be added must have `h` thus we can safely take length of `h` for comparison.