### PR TITLE
Minor Defect Overwriting User Input

### DIFF
--- a/pysph/examples/flow_past_cylinder_2d.py
+++ b/pysph/examples/flow_past_cylinder_2d.py
@@ -120,8 +120,8 @@ class WindTunnel(Application):
 
     def consume_user_options(self):
         self.dc = dc = self.options.dc
-        self.Lt = self.options.lt * dc
-        self.Wt = self.options.wt * dc
+        self.Lt = self.options.Lt * dc
+        self.Wt = self.options.Wt/2 * dc
         self.io_method = self.options.io_method
         nx = self.options.nx
         re = self.options.re

--- a/pysph/examples/flow_past_cylinder_2d.py
+++ b/pysph/examples/flow_past_cylinder_2d.py
@@ -120,7 +120,7 @@ class WindTunnel(Application):
 
     def consume_user_options(self):
         self.dc = dc = self.options.dc
-        self.Lt = self.options.Lt * dc
+        self.Lt = self.options.Lt/2 * dc
         self.Wt = self.options.Wt/2 * dc
         self.io_method = self.options.io_method
         nx = self.options.nx

--- a/pysph/examples/flow_past_cylinder_2d.py
+++ b/pysph/examples/flow_past_cylinder_2d.py
@@ -120,8 +120,8 @@ class WindTunnel(Application):
 
     def consume_user_options(self):
         self.dc = dc = self.options.dc
-        self.Lt = 15. * dc
-        self.Wt = 7.5 * dc
+        self.Lt = self.options.lt * dc
+        self.Wt = self.options.wt * dc
         self.io_method = self.options.io_method
         nx = self.options.nx
         re = self.options.re


### PR DESCRIPTION
When helping a coworker run the flow_past_cylinder_2d example it was noticed that changing the wind tunnel length or width resulted in no change to the simulation. Upon code inspection it was noted that the user input was overwritten by literal values.