### PR TITLE
Fix issue with output_at_times.

### DIFF
--- a/pysph/solver/solver.py
+++ b/pysph/solver/solver.py
@@ -716,8 +716,13 @@ class Solver(object):
             # timestep.
             timestep_too_big = (tdiff > 0.0) & (tdiff < dt)
             if numpy.any(timestep_too_big):
-                index = numpy.where(timestep_too_big)[0]
+                indices = numpy.where(timestep_too_big)[0]
+                index = indices[0]
                 output_time = output_at_times[index]
+                if ((abs(output_time - self.t) < self._epsilon) and
+                   (len(indices) > 1)):
+                    index = indices[1]
+                    output_time = output_at_times[index]
                 if abs(output_time - self.t) > self._epsilon:
                     # It sometimes happens that the current time is just
                     # shy of the requested output time which results in a


### PR DESCRIPTION
There were cases when the timestep lands very close to a desired output
time and the next output is within a timestep, what happens is that the
next step is then ignored leading to problems.