### PR TITLE
Fix issues with open sockets and files.

### DIFF
--- a/pysph/solver/application.py
+++ b/pysph/solver/application.py
@@ -1243,7 +1243,7 @@ class Application(object):
 
         if self.rank == 0:
             if sys.platform == 'win32':
-                default_host = "127.0.0.1"
+                default_host = "localhost"
             else:
                 default_host = "0.0.0.0"
             # commandline interface

--- a/pysph/solver/application.py
+++ b/pysph/solver/application.py
@@ -1242,6 +1242,10 @@ class Application(object):
             self._interfaces = []
 
         if self.rank == 0:
+            if sys.platform == 'win32':
+                default_host = "127.0.0.1"
+            else:
+                default_host = "0.0.0.0"
             # commandline interface
             if options.cmd_line:
                 from pysph.solver.solver_interfaces import CommandlineInterface
@@ -1255,7 +1259,7 @@ class Application(object):
                 from pysph.solver.solver_interfaces import XMLRPCInterface
                 addr = options.xml_rpc
                 idx = addr.find(':')
-                host = "0.0.0.0" if idx == -1 else addr[:idx]
+                host = default_host if idx == -1 else addr[:idx]
                 port = int(addr[idx + 1:])
                 interface = XMLRPCInterface((host, port))
                 self._interfaces.append(interface)
@@ -1275,7 +1279,7 @@ class Application(object):
                 authkey = "pysph" if idx == -1 else addr[:idx]
                 addr = addr[idx + 1:]
                 idx = addr.find(':')
-                host = "0.0.0.0" if idx == -1 else addr[:idx]
+                host = default_host if idx == -1 else addr[:idx]
                 port = addr[idx + 1:]
                 if port[-1] == '+':
                     port = get_free_port(int(port[:-1]), skip=_used_ports)

--- a/pysph/solver/application.py
+++ b/pysph/solver/application.py
@@ -741,12 +741,17 @@ class Application(object):
             help=("Add an XML-RPC interface to the solver;"
                   "HOST=0.0.0.0 by default"))
 
+        if sys.platform == 'win32':
+            default = "pysph@127.0.0.1:8800+"
+        else:
+            default = "pysph@0.0.0.0:8800+"
+
         interfaces.add_argument(
             "--multiproc",
             action="store",
             dest="multiproc",
             metavar='[[AUTHKEY@] HOST:] PORT[+] ',
-            default="pysph@0.0.0.0:8800+",
+            default=default,
             help=("Add a python multiprocessing interface "
                   "to the solver; "
                   "AUTHKEY=pysph, HOST=0.0.0.0, PORT=8800+ by"
@@ -1243,7 +1248,7 @@ class Application(object):
 
         if self.rank == 0:
             if sys.platform == 'win32':
-                default_host = "localhost"
+                default_host = "127.0.0.1"
             else:
                 default_host = "0.0.0.0"
             # commandline interface

--- a/pysph/solver/application.py
+++ b/pysph/solver/application.py
@@ -1237,6 +1237,10 @@ class Application(object):
         solver.set_command_handler(self.command_manager.execute_commands)
 
         _used_ports = []
+        if self._interfaces:
+            self._stop_interfaces()
+            self._interfaces = []
+
         if self.rank == 0:
             # commandline interface
             if options.cmd_line:
@@ -1391,6 +1395,10 @@ class Application(object):
 
         if is_overloaded_method(obj.post_step):
             self.solver.add_post_step_callback(obj.post_step)
+
+    def _stop_interfaces(self):
+        for interface in self._interfaces:
+            interface.stop()
 
     def _message(self, msg):
         if self.num_procs == 1:
@@ -1584,8 +1592,7 @@ class Application(object):
         self._write_info(
             self.info_filename, completed=True, cpu_time=run_duration)
 
-        for interface in self._interfaces:
-            interface.stop()
+        self._stop_interfaces()
 
     def set_args(self, args):
         self.args = args

--- a/pysph/solver/solver_interfaces.py
+++ b/pysph/solver/solver_interfaces.py
@@ -33,7 +33,7 @@ class MultiprocessingInterface(BaseManager):
         self._server = None
 
     def stop(self):
-        if self._server is not None:
+        if self._server:
             conn = self._Client(self._address, authkey=self._authkey)
             try:
                 self._server.shutdown(conn)

--- a/pysph/solver/solver_interfaces.py
+++ b/pysph/solver/solver_interfaces.py
@@ -30,9 +30,15 @@ class MultiprocessingInterface(BaseManager):
         authkey = get_authkey_bytes(authkey)
         super().__init__(address, authkey)
         self.authkey = authkey
+        self._server = None
 
     def stop(self):
-        self.shutdown()
+        if self._server is not None:
+            conn = self._Client(self._address, authkey=self._authkey)
+            try:
+                self._server.shutdown(conn)
+            finally:
+                conn.close()
 
     def get_controller(self):
         return self.controller
@@ -40,7 +46,8 @@ class MultiprocessingInterface(BaseManager):
     def start(self, controller):
         self.controller = controller
         self.register('get_controller', self.get_controller)
-        super().start()
+        self._server = self.get_server()
+        self._server.serve_forever()
 
 
 class MultiprocessingClient(BaseManager):

--- a/pysph/solver/solver_interfaces.py
+++ b/pysph/solver/solver_interfaces.py
@@ -1,6 +1,7 @@
 import threading
 import os
 import socket
+import sys
 try:
     from SimpleXMLRPCServer import (SimpleXMLRPCServer,
                                     SimpleXMLRPCRequestHandler)
@@ -39,6 +40,8 @@ class MultiprocessingInterface(BaseManager):
                 self._server.shutdown(conn)
             finally:
                 conn.close()
+        elif hasattr(self, 'shutdown'):
+            self.shutdown()
 
     def get_controller(self):
         return self.controller
@@ -46,8 +49,11 @@ class MultiprocessingInterface(BaseManager):
     def start(self, controller):
         self.controller = controller
         self.register('get_controller', self.get_controller)
-        self._server = self.get_server()
-        self._server.serve_forever()
+        if sys.platform == 'win32':
+            self.start()
+        else:
+            self._server = self.get_server()
+            self._server.serve_forever()
 
 
 class MultiprocessingClient(BaseManager):

--- a/pysph/solver/tests/test_solver_utils.py
+++ b/pysph/solver/tests/test_solver_utils.py
@@ -192,15 +192,15 @@ class TestGetFreePort(TestCase):
     def test_finds_port_not_taken(self):
         # Given
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.bind(('', 8800))
+        sock.bind(('', 9800))
         self.addCleanup(sock.close)
 
         # When
-        port = get_free_port(8800)
+        port = get_free_port(9800)
 
         # Then
-        self.assertNotEqual(port, 8800)
-        self.assertTrue(port > 8800)
+        self.assertNotEqual(port, 9800)
+        self.assertTrue(port > 9800)
 
         # When
         port1 = get_free_port(port)
@@ -211,14 +211,14 @@ class TestGetFreePort(TestCase):
 
     def test_free_port_skips_given(self):
         # Given
-        skip = (8800, 8801)
+        skip = (9800, 9801)
 
         # When
-        port = get_free_port(8800, skip=skip)
+        port = get_free_port(9800, skip=skip)
 
         # Then
         self.assertNotIn(port, skip)
-        self.assertTrue(port > 8801)
+        self.assertTrue(port > 9801)
 
 
 if __name__ == '__main__':

--- a/pysph/solver/utils.py
+++ b/pysph/solver/utils.py
@@ -3,8 +3,10 @@ Module contains some common functions.
 """
 
 # standard imports
+import errno
 from glob import glob
 import os
+import socket
 import sys
 import time
 
@@ -34,11 +36,34 @@ def _supports_unicode(fp):
             return False
         except Exception:
             try:
-                return encoding.lower().startswith('utf-') or ('U8' == encoding)
+                return (encoding.lower().startswith('utf-')
+                        or ('U8' == encoding))
             except:
                 return False
         else:
             return True
+
+
+def get_free_port(start, skip=None):
+    """Return an integer that is an available port for a service. Start at the
+    given `start` value and `skip` any specified values.
+    """
+    skip = () if skip is None else skip
+    x = start
+    while x < 65536:
+        if x in skip:
+            x += 1
+        else:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                try:
+                    s.bind(('', x))
+                    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                    return x
+                except socket.error as e:
+                    if e.errno == errno.EADDRINUSE:
+                        x += 1
+                    else:
+                        raise
 
 
 def check_array(x, y):


### PR DESCRIPTION
- Close file handles and logger handlers.
- Remove dirty way of trying for available ports in
  MultiprocessingInterface.
- Instead search for suitable ports before starting it.
- Close all interfaces when run completes.

This fixes #247.