### PR TITLE
Fix warnings

### DIFF
--- a/pysph/base/box_sort_nnps.pxd
+++ b/pysph/base/box_sort_nnps.pxd
@@ -1,7 +1,9 @@
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 from libcpp.map cimport map
 
-from nnps_base cimport *
-from linked_list_nnps cimport *
+from .nnps_base cimport *
+from .linked_list_nnps cimport *
 
 # NNPS using the original gridding algorithm
 cdef class DictBoxSortNNPS(NNPS):
@@ -21,5 +23,3 @@ cdef class BoxSortNNPS(LinkedListNNPS):
     # Data Attributes
     ############################################################################
     cdef public map[long, int] cell_to_index  # Maps cell ID to an index
-
-

--- a/pysph/base/box_sort_nnps.pyx
+++ b/pysph/base/box_sort_nnps.pyx
@@ -1,4 +1,4 @@
-#cython: embedsignature=True
+# cython: language_level=3, language=c++, embedsignature=True
 # Library imports.
 import numpy as np
 cimport numpy as np

--- a/pysph/base/c_kernels.pyx
+++ b/pysph/base/c_kernels.pyx
@@ -1,4 +1,5 @@
-#cython: embedsignature=True
+# cython: embedsignature=True, language_level=3
+# distutils: language=c++
 
 
 from libc.math cimport *

--- a/pysph/base/c_kernels.pyx.mako
+++ b/pysph/base/c_kernels.pyx.mako
@@ -1,4 +1,5 @@
-#cython: embedsignature=True
+# cython: embedsignature=True, language_level=3
+# distutils: language=c++
 <%
 from compyle.api import CythonGenerator
 from kernels import (

--- a/pysph/base/cell_indexing_nnps.pxd
+++ b/pysph/base/cell_indexing_nnps.pxd
@@ -1,8 +1,8 @@
-# cython: embedsignature=True
+# cython: language_level=3, language=c++, embedsignature=True
 from libcpp.map cimport map
 from libcpp.pair cimport pair
 
-from nnps_base cimport *
+from .nnps_base cimport *
 
 ctypedef unsigned int u_int
 ctypedef map[u_int, pair[u_int, u_int]] key_to_idx_t
@@ -61,6 +61,3 @@ cdef class CellIndexingNNPS(NNPS):
     cpdef _refresh(self)
 
     cpdef _bin(self, int pa_index, UIntArray indices)
-
-
-

--- a/pysph/base/cell_indexing_nnps.pyx
+++ b/pysph/base/cell_indexing_nnps.pyx
@@ -1,4 +1,5 @@
-#cython: embedsignature=True
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 
 # malloc and friends
 from libc.stdlib cimport malloc, free
@@ -360,4 +361,3 @@ cdef class CellIndexingNNPS(NNPS):
         cdef key_to_idx_t* current_indices = self.key_indices[pa_index]
 
         self.fill_array(pa_wrapper, pa_index, indices, current_keys, current_indices)
-

--- a/pysph/base/gpu_nnps_base.pxd
+++ b/pysph/base/gpu_nnps_base.pxd
@@ -1,3 +1,5 @@
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 # numpy
 cimport numpy as np
 cimport cython
@@ -12,8 +14,8 @@ import pyopencl.array
 from cyarray.carray cimport UIntArray, IntArray, DoubleArray, LongArray
 
 # local imports
-from particle_array cimport ParticleArray
-from point cimport *
+from .particle_array cimport ParticleArray
+from .point cimport *
 
 from pysph.base.nnps_base cimport *
 

--- a/pysph/base/gpu_nnps_base.pyx
+++ b/pysph/base/gpu_nnps_base.pyx
@@ -1,4 +1,6 @@
-#cython: embedsignature=True
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
+
 # Library imports.
 import numpy as np
 cimport numpy as np
@@ -40,9 +42,9 @@ import compyle.array as array
 
 # Particle Tag information
 from cyarray.carray cimport BaseArray, aligned_malloc, aligned_free
-from utils import ParticleTAGS
+from .utils import ParticleTAGS
 
-from nnps_base cimport *
+from .nnps_base cimport *
 
 from pysph.base.gpu_helper_kernels import (exclusive_input, exclusive_output,
                                            get_scan)

--- a/pysph/base/linalg3.pxd
+++ b/pysph/base/linalg3.pxd
@@ -1,3 +1,6 @@
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
+
 """Routines for eigen decomposition of symmetric 3x3 matrices.
 """
 cdef double det(double a[3][3]) nogil

--- a/pysph/base/linked_list_nnps.pxd
+++ b/pysph/base/linked_list_nnps.pxd
@@ -1,7 +1,10 @@
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
+
 from libcpp.map cimport map
 from libcpp.vector cimport vector
 
-from nnps_base cimport *
+from .nnps_base cimport *
 
 # NNPS using the linked list approach
 cdef class LinkedListNNPS(NNPS):
@@ -23,5 +26,3 @@ cdef class LinkedListNNPS(NNPS):
     cdef long _get_valid_cell_index(self, int cid_x, int cid_y, int cid_z,
             int* ncells_per_dim, int dim, int n_cells) nogil
     cdef void find_nearest_neighbors(self, size_t d_idx, UIntArray nbrs) nogil
-
-

--- a/pysph/base/linked_list_nnps.pyx
+++ b/pysph/base/linked_list_nnps.pyx
@@ -1,4 +1,5 @@
-#cython: embedsignature=True
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 # Library imports.
 import numpy as np
 cimport numpy as np

--- a/pysph/base/nnps_base.pxd
+++ b/pysph/base/nnps_base.pxd
@@ -1,3 +1,5 @@
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 # numpy
 cimport numpy as np
 cimport cython
@@ -9,8 +11,8 @@ from libcpp.vector cimport vector
 from cyarray.carray cimport UIntArray, IntArray, DoubleArray, LongArray
 
 # local imports
-from particle_array cimport ParticleArray
-from point cimport *
+from .particle_array cimport ParticleArray
+from .point cimport *
 
 cdef extern from 'math.h':
     int abs(int) nogil

--- a/pysph/base/nnps_base.pyx
+++ b/pysph/base/nnps_base.pyx
@@ -1,4 +1,5 @@
-#cython: embedsignature=True
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 # Library imports.
 import numpy as np
 cimport numpy as np
@@ -55,7 +56,7 @@ IF UNAME_SYSNAME == "Windows":
 
 # Particle Tag information
 from cyarray.carray cimport BaseArray, aligned_malloc, aligned_free
-from utils import ParticleTAGS
+from .utils import ParticleTAGS
 
 cdef int Local = ParticleTAGS.Local
 cdef int Remote = ParticleTAGS.Remote
@@ -345,7 +346,7 @@ cdef class DomainManagerBase(object):
         self.mirror_in_x = mirror_in_x
         self.mirror_in_y = mirror_in_y
         self.mirror_in_z = mirror_in_z
-        
+
         self.is_periodic = periodic_in_x or periodic_in_y or periodic_in_z
         self.is_mirror = mirror_in_x or mirror_in_y or mirror_in_z
         self.n_layers = n_layers
@@ -517,7 +518,7 @@ cdef class CPUDomainManager(DomainManagerBase):
         cdef int i
         for i in range(arr.length):
             arr.data[i] *= val
-            
+
     cdef _create_ghosts_mirror(self):
         """Identify boundary particles and create images.
 
@@ -1244,7 +1245,7 @@ cdef class NeighborCache:
             arr = <UIntArray>self._neighbors[i]
             arr.c_reset()
             arr.c_reserve(
-                self._last_avg_nbr_size*np/n_threads + safety
+                <size_t>(self._last_avg_nbr_size*np/n_threads) + safety
             )
 
     #### Private protocol ################################################

--- a/pysph/base/octree.pxd
+++ b/pysph/base/octree.pxd
@@ -1,6 +1,6 @@
-#cython: embedsignature=True
-
-from nnps_base cimport *
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
+from .nnps_base cimport *
 from libcpp.vector cimport vector
 cimport cython
 
@@ -133,5 +133,3 @@ cdef class CompressedOctree(Octree):
     cdef int _c_build_tree(self, NNPSParticleArrayWrapper pa,
             vector[u_int]* indices, double* xmin, double length,
             cOctreeNode* node, int level) nogil
-
-

--- a/pysph/base/octree.pyx
+++ b/pysph/base/octree.pyx
@@ -1,6 +1,6 @@
 #cython: embedsignature=True
 
-from nnps_base cimport *
+from .nnps_base cimport *
 
 from libc.stdlib cimport malloc, free
 from libcpp.vector cimport vector
@@ -645,5 +645,3 @@ cdef class CompressedOctree(Octree):
             depth_max = <int>fmax(depth_max, depth_child)
 
         return 1 + depth_max
-
-

--- a/pysph/base/octree_gpu_nnps.pxd
+++ b/pysph/base/octree_gpu_nnps.pxd
@@ -1,3 +1,5 @@
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 from pysph.base.gpu_nnps_base cimport *
 
 

--- a/pysph/base/octree_nnps.pxd
+++ b/pysph/base/octree_nnps.pxd
@@ -1,7 +1,8 @@
-#cython: embedsignature=True
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 
-from nnps_base cimport *
-from octree cimport Octree, CompressedOctree, cOctreeNode
+from .nnps_base cimport *
+from .octree cimport Octree, CompressedOctree, cOctreeNode
 
 from libcpp.vector cimport vector
 cimport cython
@@ -57,6 +58,3 @@ cdef class CompressedOctreeNNPS(OctreeNNPS):
     cpdef _refresh(self)
 
     cpdef _bin(self, int pa_index, UIntArray indices)
-
-
-

--- a/pysph/base/octree_nnps.pyx
+++ b/pysph/base/octree_nnps.pyx
@@ -1,7 +1,7 @@
 #cython: embedsignature=True
 
-from nnps_base cimport *
-from octree cimport Octree, CompressedOctree, cOctreeNode
+from .nnps_base cimport *
+from .octree cimport Octree, CompressedOctree, cOctreeNode
 
 from libcpp.vector cimport vector
 from libc.stdlib cimport malloc, free
@@ -228,5 +228,3 @@ cdef class CompressedOctreeNNPS(OctreeNNPS):
 
     cpdef _bin(self, int pa_index, UIntArray indices):
         pass
-
-

--- a/pysph/base/particle_array.pxd
+++ b/pysph/base/particle_array.pxd
@@ -1,3 +1,4 @@
+# cython: language_level=3, language=c++, embedsignature=True
 cimport numpy as np
 
 from cyarray.carray cimport BaseArray, UIntArray, IntArray, LongArray

--- a/pysph/base/particle_array.pyx
+++ b/pysph/base/particle_array.pyx
@@ -1,4 +1,5 @@
-#cython: embedsignature=True
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 """
 A `ParticleArray` represents a collection of particles.
 

--- a/pysph/base/point.pxd
+++ b/pysph/base/point.pxd
@@ -1,3 +1,5 @@
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 cimport numpy
 
 cdef extern from "math.h":

--- a/pysph/base/spatial_hash_nnps.pxd
+++ b/pysph/base/spatial_hash_nnps.pxd
@@ -1,6 +1,8 @@
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 from libcpp.vector cimport vector
 
-from nnps_base cimport *
+from .nnps_base cimport *
 
 #Imports for SpatialHashNNPS
 cdef extern from "spatial_hash.h":
@@ -83,5 +85,3 @@ cdef class ExtendedSpatialHashNNPS(NNPS):
     cpdef _refresh(self)
 
     cpdef _bin(self, int pa_index, UIntArray indices)
-
-

--- a/pysph/base/spatial_hash_nnps.pyx
+++ b/pysph/base/spatial_hash_nnps.pyx
@@ -1,4 +1,5 @@
-#cython: embedsignature=True
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 
 # malloc and friends
 from libc.stdlib cimport malloc, free
@@ -116,7 +117,7 @@ cdef class SpatialHashNNPS(NNPS):
 
         cdef HashEntry* candidate_cell
         cdef vector[unsigned int] *candidates
-        
+
         find_cell_id_raw(
                 x - xmin[0],
                 y - xmin[1],
@@ -493,4 +494,3 @@ cdef class ExtendedSpatialHashNNPS(NNPS):
                     &c_x, &c_y, &c_z
                     )
             self._add_to_hashtable(pa_index, idx, src_h_ptr[idx], c_x, c_y, c_z)
-

--- a/pysph/base/stratified_hash_nnps.pxd
+++ b/pysph/base/stratified_hash_nnps.pxd
@@ -1,6 +1,8 @@
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 from libcpp.vector cimport vector
 
-from nnps_base cimport *
+from .nnps_base cimport *
 
 ctypedef unsigned int u_int
 
@@ -74,5 +76,3 @@ cdef class StratifiedHashNNPS(NNPS):
     cpdef _refresh(self)
 
     cpdef _bin(self, int pa_index, UIntArray indices)
-
-

--- a/pysph/base/stratified_hash_nnps.pyx
+++ b/pysph/base/stratified_hash_nnps.pyx
@@ -5,7 +5,7 @@ from libc.stdlib cimport malloc, free
 from libc.stdio cimport printf
 from libcpp.vector cimport vector
 
-from nnps_base cimport *
+from .nnps_base cimport *
 
 # Cython for compiler directives
 cimport cython
@@ -323,4 +323,3 @@ cdef class StratifiedHashNNPS(NNPS):
                     &c_x, &c_y, &c_z
                     )
             current_hash[hash_id].add(c_x, c_y, c_z, idx, src_h_ptr[idx])
-

--- a/pysph/base/stratified_sfc_gpu_nnps.pxd
+++ b/pysph/base/stratified_sfc_gpu_nnps.pxd
@@ -1,3 +1,5 @@
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 from libcpp.vector cimport vector
 from libcpp.map cimport map
 from libcpp.pair cimport pair

--- a/pysph/base/stratified_sfc_gpu_nnps.pyx
+++ b/pysph/base/stratified_sfc_gpu_nnps.pyx
@@ -1,4 +1,5 @@
-#cython: embedsignature=True
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 
 # malloc and friends
 from libc.stdlib cimport malloc, free
@@ -8,7 +9,7 @@ from libcpp.pair cimport pair
 
 from cython.operator cimport dereference as deref, preincrement as inc
 
-from gpu_nnps_helper import GPUNNPSHelper
+from .gpu_nnps_helper import GPUNNPSHelper
 
 import pyopencl as cl
 import pyopencl.array

--- a/pysph/base/stratified_sfc_nnps.pxd
+++ b/pysph/base/stratified_sfc_nnps.pxd
@@ -1,8 +1,10 @@
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 from libcpp.vector cimport vector
 from libcpp.map cimport map
 from libcpp.pair cimport pair
 
-from nnps_base cimport *
+from .nnps_base cimport *
 
 cdef extern from 'math.h':
     int abs(int) nogil
@@ -82,5 +84,3 @@ cdef class StratifiedSFCNNPS(NNPS):
     cpdef _refresh(self)
 
     cpdef _bin(self, int pa_index, UIntArray indices)
-
-

--- a/pysph/base/stratified_sfc_nnps.pyx
+++ b/pysph/base/stratified_sfc_nnps.pyx
@@ -9,7 +9,7 @@ from libc.stdio cimport printf
 
 from cython.operator cimport dereference as deref, preincrement as inc
 
-from nnps_base cimport *
+from .nnps_base cimport *
 # Cython for compiler directives
 cimport cython
 
@@ -421,5 +421,3 @@ cdef class StratifiedSFCNNPS(NNPS):
 
         self.fill_array(pa_wrapper, pa_index, indices, current_pids,
                 current_keys, current_cells)
-
-

--- a/pysph/base/tests/test_device_helper.py
+++ b/pysph/base/tests/test_device_helper.py
@@ -22,7 +22,7 @@ def check_import(backend):
         pytest.importorskip('pycuda')
 
 
-test_all_backends = pytest.mark.parametrize('backend',
+check_all_backends = pytest.mark.parametrize('backend',
                                             ['cython', 'opencl', 'cuda'])
 
 
@@ -30,7 +30,7 @@ class TestDeviceHelper(object):
     def setup(self):
         self.pa = get_particle_array(name='f', x=[0.0, 1.0], m=1.0, rho=2.0)
 
-    @test_all_backends
+    @check_all_backends
     def test_simple(self, backend):
         check_import(backend)
         self.setup()
@@ -48,7 +48,7 @@ class TestDeviceHelper(object):
         assert np.allclose(pa.rho, h.rho.get())
         assert np.allclose(pa.tag, h.tag.get())
 
-    @test_all_backends
+    @check_all_backends
     def test_push_correctly_sets_values_with_args(self, backend):
         check_import(backend)
         self.setup()
@@ -71,7 +71,7 @@ class TestDeviceHelper(object):
         assert np.allclose(pa.rho, h.rho.get())
         assert np.allclose(pa.tag, h.tag.get())
 
-    @test_all_backends
+    @check_all_backends
     def test_push_correctly_sets_values_with_no_args(self, backend):
         check_import(backend)
         self.setup()
@@ -94,7 +94,7 @@ class TestDeviceHelper(object):
         assert np.allclose(pa.rho, h.rho.get())
         assert np.allclose(pa.tag, h.tag.get())
 
-    @test_all_backends
+    @check_all_backends
     def test_pull_correctly_sets_values_with_args(self, backend):
         check_import(backend)
         self.setup()
@@ -117,7 +117,7 @@ class TestDeviceHelper(object):
         assert np.allclose(pa.rho, h.rho.get())
         assert np.allclose(pa.tag, h.tag.get())
 
-    @test_all_backends
+    @check_all_backends
     def test_pull_correctly_sets_values_with_no_args(self, backend):
         check_import(backend)
         self.setup()
@@ -140,7 +140,7 @@ class TestDeviceHelper(object):
         assert np.allclose(pa.rho, h.rho.get())
         assert np.allclose(pa.tag, h.tag.get())
 
-    @test_all_backends
+    @check_all_backends
     def test_max_provides_maximum(self, backend):
         check_import(backend)
         self.setup()
@@ -151,7 +151,7 @@ class TestDeviceHelper(object):
         # Then
         assert h.max('x') == 1.0
 
-    @test_all_backends
+    @check_all_backends
     def test_that_adding_removing_prop_to_array_updates_gpu(self, backend):
         check_import(backend)
         self.setup()
@@ -174,7 +174,7 @@ class TestDeviceHelper(object):
         assert 'test' not in h._data
         assert 'test' not in h.properties
 
-    @test_all_backends
+    @check_all_backends
     def test_resize_works(self, backend):
         check_import(backend)
         self.setup()
@@ -208,7 +208,7 @@ class TestDeviceHelper(object):
         assert np.allclose(pa.rho, h.rho.get())
         assert np.allclose(pa.tag, h.tag.get())
 
-    @test_all_backends
+    @check_all_backends
     def test_get_number_of_particles(self, backend):
         check_import(backend)
         self.setup()
@@ -228,7 +228,7 @@ class TestDeviceHelper(object):
         assert h.get_number_of_particles() == 5
         assert h.get_number_of_particles(real=True) == 3
 
-    @test_all_backends
+    @check_all_backends
     def test_align(self, backend):
         check_import(backend)
         self.setup()
@@ -256,7 +256,7 @@ class TestDeviceHelper(object):
         expect = x[::-1, :].ravel()
         assert np.all(h.force.get() == expect)
 
-    @test_all_backends
+    @check_all_backends
     def test_align_particles(self, backend):
         check_import(backend)
         self.setup()
@@ -276,7 +276,7 @@ class TestDeviceHelper(object):
         x = h.x.get()
         assert np.all(np.sort(x[:-2]) == np.array([2., 3., 5.]))
 
-    @test_all_backends
+    @check_all_backends
     def test_remove_particles(self, backend):
         check_import(backend)
         self.setup()
@@ -297,7 +297,7 @@ class TestDeviceHelper(object):
         # Then
         assert np.all(np.sort(h.x.get()) == np.array([2., 5.]))
 
-    @test_all_backends
+    @check_all_backends
     def test_remove_tagged_particles(self, backend):
         check_import(backend)
         self.setup()
@@ -316,7 +316,7 @@ class TestDeviceHelper(object):
         # Then
         assert np.all(np.sort(h.x.get()) == np.array([2., 3., 5.]))
 
-    @test_all_backends
+    @check_all_backends
     def test_add_particles(self, backend):
         check_import(backend)
         self.setup()
@@ -333,7 +333,7 @@ class TestDeviceHelper(object):
         # Then
         assert np.all(np.sort(h.x.get()) == np.array([0., 0., 0., 0., 0., 1.]))
 
-    @test_all_backends
+    @check_all_backends
     def test_extend(self, backend):
         check_import(backend)
         self.setup()
@@ -349,7 +349,7 @@ class TestDeviceHelper(object):
         # Then
         assert h.get_number_of_particles() == 6
 
-    @test_all_backends
+    @check_all_backends
     def test_append_parray(self, backend):
         check_import(backend)
         self.setup()
@@ -365,7 +365,7 @@ class TestDeviceHelper(object):
         # Then
         assert h.get_number_of_particles() == 4
 
-    @test_all_backends
+    @check_all_backends
     def test_empty_clone(self, backend):
         check_import(backend)
         self.setup()
@@ -382,7 +382,7 @@ class TestDeviceHelper(object):
         assert result_pa.gpu.get_number_of_particles() == 0
         assert result_pa.name == 'f'
 
-    @test_all_backends
+    @check_all_backends
     def test_extract_particles(self, backend):
         check_import(backend)
         self.setup()

--- a/pysph/base/z_order_gpu_nnps.pxd
+++ b/pysph/base/z_order_gpu_nnps.pxd
@@ -1,4 +1,5 @@
-# cython: embedsignature=True
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 from libcpp.map cimport map
 from libcpp.pair cimport pair
 

--- a/pysph/base/z_order_nnps.pxd
+++ b/pysph/base/z_order_nnps.pxd
@@ -1,8 +1,9 @@
-# cython: embedsignature=True
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
 from libcpp.map cimport map
 from libcpp.pair cimport pair
 
-from nnps_base cimport *
+from .nnps_base cimport *
 
 cdef extern from "math.h":
     double log2(double) nogil
@@ -126,4 +127,3 @@ cdef class ExtendedZOrderNNPS(ZOrderNNPS):
     cpdef _refresh(self)
 
     cpdef set_context(self, int src_index, int dst_index)
-

--- a/pysph/parallel/parallel_manager.pxd
+++ b/pysph/parallel/parallel_manager.pxd
@@ -1,3 +1,6 @@
+# cython: language_level=3, embedsignature=True
+# distutils: language=c++
+
 # Numpy
 cimport numpy as np
 

--- a/pysph/parallel/parallel_manager.pyx
+++ b/pysph/parallel/parallel_manager.pyx
@@ -26,10 +26,6 @@ cdef extern from 'math.h':
     cdef double floor(double) nogil
     cdef double fabs(double) nogil
 
-cdef extern from 'limits.h':
-    cdef int INT_MAX
-    cdef unsigned int UINT_MAX
-
 
 cpdef get_strided_indices(np.ndarray indices, int stride):
     cdef int j
@@ -466,7 +462,7 @@ cdef class ParallelManager:
         if cell_size < 1e-6:
             msg = """Cell size too small %g. Perhaps h = 0?
             Setting cell size to 1"""%(cell_size)
-            print msg
+            print(msg)
             cell_size = 1.0
         self.cell_size = cell_size
 
@@ -1007,7 +1003,7 @@ cdef class ParallelManager:
                             if ( (xij < hi) or (xij < hj) ):
                                 if nnbrs == nbrs.length:
                                     nbrs.resize( nbrs.length + 50 )
-                                    print """Neighbor search :: Extending the neighbor list to %d"""%(nbrs.length)
+                                    print('Neighbor search :: Extending the neighbor list to %d'%(nbrs.length))
 
                                 nbrs.data[ nnbrs ] = j
                                 nnbrs = nnbrs + 1

--- a/pysph/solver/tests/test_application.py
+++ b/pysph/solver/tests/test_application.py
@@ -18,6 +18,8 @@ from tempfile import mkdtemp
 
 from pysph.solver.application import Application
 from pysph.solver.solver import Solver
+from pysph.solver.utils import get_free_port
+from pysph.solver.solver_interfaces import MultiprocessingInterface, XMLRPCInterface
 
 
 class MockApp(Application):
@@ -98,6 +100,8 @@ class TestApplication(TestCase):
         expected = 20.0
         error_message = "Expected %f, got %f" % (expected, app.testarg)
         self.assertEqual(expected, app.testarg, error_message)
+        # No interfaces should be started by default.
+        self.assertEqual(len(app._interfaces), 0)
 
     def test_output_dir_when_moved_and_read_info_called(self):
         # Given
@@ -121,3 +125,38 @@ class TestApplication(TestCase):
         assert realpath(app.output_dir) != realpath(self.output_dir)
         assert realpath(app.output_dir) == realpath(copy_dir)
         assert app.fname == orig_fname
+
+    def test_app_stops_multi_proc_interface_at_end(self):
+        # Given
+        app = self.app
+        port = get_free_port(9000)
+
+        # When
+        args = ['--multiproc', 'auto']
+        app.run(args)
+
+        # Then
+        self.assertEqual(len(app._interfaces), 1)
+        self.assertTrue(isinstance(
+            app._interfaces[0], MultiprocessingInterface
+        ))
+        port1 = get_free_port(9000)
+        self.assertEqual(port1, port)
+
+    def test_app_stops_xml_rpc_interface_at_end(self):
+        # Given
+        app = self.app
+        port = get_free_port(9000)
+        host = '127.0.0.1'
+
+        # When
+        args = ['--xml-rpc', '%s:%s' % (host, port)]
+        app.run(args)
+
+        # Then
+        self.assertEqual(len(app._interfaces), 1)
+        self.assertTrue(isinstance(
+            app._interfaces[0], XMLRPCInterface
+        ))
+        port1 = get_free_port(9000)
+        self.assertEqual(port1, port)

--- a/pysph/solver/tests/test_application.py
+++ b/pysph/solver/tests/test_application.py
@@ -163,5 +163,6 @@ class TestApplication(TestCase):
         count = 0
         while port1 != port and count < 4:
             time.sleep(0.5)
+            port1 = get_free_port(9000)
             count += 1
         self.assertEqual(port1, port)

--- a/pysph/solver/tests/test_application.py
+++ b/pysph/solver/tests/test_application.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import sys
 from tempfile import mkdtemp
+import time
 
 from pysph.solver.application import Application
 from pysph.solver.solver import Solver
@@ -159,4 +160,8 @@ class TestApplication(TestCase):
             app._interfaces[0], XMLRPCInterface
         ))
         port1 = get_free_port(9000)
+        count = 0
+        while port1 != port and count < 4:
+            time.sleep(0.5)
+            count += 1
         self.assertEqual(port1, port)

--- a/pysph/sph/acceleration_eval_cython.mako
+++ b/pysph/sph/acceleration_eval_cython.mako
@@ -1,5 +1,6 @@
 # Automatically generated, do not edit.
-#cython: cdivision=True
+# cython: cdivision=True, language_level=3
+# distutils: language=c++
 <%def name="indent(text, level=0)" buffered="True">
 % for l in text.splitlines():
 ${' '*4*level}${l}

--- a/pysph/sph/gas_dynamics/gsph.py
+++ b/pysph/sph/gas_dynamics/gsph.py
@@ -534,7 +534,7 @@ class GSPHAcceleration(Equation):
                          (3.0/8.0)*hij4*(aij*dij + bij*cij) +
                          0.5*hij2*cij*dij)/vij
         else:
-            printf("%s", "Unknown interpolation type")
+            printf(b"%s", b"Unknown interpolation type")
 
         result[0] = vij_i2
         result[1] = vij_j2

--- a/pysph/sph/gas_dynamics/riemann_solver.py
+++ b/pysph/sph/gas_dynamics/riemann_solver.py
@@ -276,7 +276,7 @@ def exact(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0,
         pold = p
 
     if i == niter - 1:
-        printf("%s", "Divergence in Newton-Raphson Iteration")
+        printf(b"%s", b"Divergence in Newton-Raphson Iteration")
         return 1
 
     # compute the velocity in the star region 'um'
@@ -709,7 +709,7 @@ def hllc(rhol=0.0, rhor=1.0, pl=0.0, pr=1.0, ul=0.0, ur=1.0,
         ustar = ur
 
     else:
-        printf("%s", "Incorrect wave speeds")
+        printf(b"%s", b"Incorrect wave speeds")
         return 1
 
     result[0] = pstar

--- a/pysph/sph/integrator_cython.mako
+++ b/pysph/sph/integrator_cython.mako
@@ -1,5 +1,6 @@
 # Automatically generated, do not edit.
-#cython: cdivision=True
+# cython: cdivision=True, language_level=3
+# distuils: language=c++
 <%def name="indent(text, level=0)" buffered="True">
 % for l in text.splitlines():
 ${' '*4*level}${l}

--- a/pysph/sph/tests/test_linalg.py
+++ b/pysph/sph/tests/test_linalg.py
@@ -78,8 +78,8 @@ class TestLinalg(unittest.TestCase):
                [0., 0., 100., 200.]]
         b = [0.02, 1., 4., 800.]
         sing, result = gj_solve_helper(np.ravel(mat), b, n)
-        mat = np.matrix(mat)
-        new_b = mat * np.transpose(np.matrix(result))
+        mat = np.array(mat)
+        new_b = np.dot(mat, np.transpose(np.array(result)))
         new_b = np.ravel(np.array(new_b))
         assert np.allclose(new_b, np.array(b))
         self.assertAlmostEqual(sing, 0.0)
@@ -89,8 +89,8 @@ class TestLinalg(unittest.TestCase):
         mat = [[1., -2., 0.], [1., -1., 3.], [2., 5., 0.]]
         b = [-3., 1., 0.5]
         sing, result = gj_solve_helper(np.ravel(mat), b, n)
-        mat = np.matrix(mat)
-        new_b = mat * np.transpose(np.matrix(result))
+        mat = np.array(mat)
+        new_b = np.dot(mat, np.transpose(np.array(result)))
         new_b = np.ravel(np.array(new_b))
         assert np.allclose(new_b, np.array(b))
         self.assertAlmostEqual(sing, 0.0)
@@ -100,8 +100,8 @@ class TestLinalg(unittest.TestCase):
         mat = [[0.96, 4.6, -3.7], [2.7, 4.3, -0.67], [0.9, 0., -5.]]
         b = [2.4, 3.6, -5.8]
         sing, result = gj_solve_helper(np.ravel(mat), b, n)
-        mat = np.matrix(mat)
-        new_b = mat * np.transpose(np.matrix(result))
+        mat = np.array(mat)
+        new_b = np.dot(mat, np.transpose(np.array(result)))
         new_b = np.ravel(np.array(new_b))
         assert np.allclose(new_b, np.array(b))
         self.assertAlmostEqual(sing, 0.0)
@@ -112,8 +112,8 @@ class TestLinalg(unittest.TestCase):
                [0., 0., 1., -2.]]
         b = [-1., 0., 0., -5.]
         sing, result = gj_solve_helper(np.ravel(mat), b, n)
-        mat = np.matrix(mat)
-        new_b = mat * np.transpose(np.matrix(result))
+        mat = np.array(mat)
+        new_b = np.dot(mat, np.transpose(np.array(result)))
         new_b = np.ravel(np.array(new_b))
         assert np.allclose(new_b, np.array(b))
         self.assertAlmostEqual(sing, 0.0)
@@ -123,8 +123,8 @@ class TestLinalg(unittest.TestCase):
         mat = [[0.96, 4.6, -3.7], [4.6, 4.3, -0.67], [-3.7, -0.67, -5.]]
         b = [2.4, 3.6, -5.8]
         sing, result = gj_solve_helper(np.ravel(mat), b, n)
-        mat = np.matrix(mat)
-        new_b = mat * np.transpose(np.matrix(result))
+        mat = np.array(mat)
+        new_b = np.dot(mat, np.transpose(np.array(result)))
         new_b = np.ravel(np.array(new_b))
         assert np.allclose(new_b, np.array(b))
         self.assertAlmostEqual(sing, 0.0)
@@ -135,8 +135,8 @@ class TestLinalg(unittest.TestCase):
                [-1., -1., -4., 10.]]
         b = [2.4, 3.6, -5.8, 0.5]
         sing, result = gj_solve_helper(np.ravel(mat), b, n)
-        mat = np.matrix(mat)
-        new_b = mat * np.transpose(np.matrix(result))
+        mat = np.array(mat)
+        new_b = np.dot(mat, np.transpose(np.array(result)))
         new_b = np.ravel(np.array(new_b))
         assert np.allclose(new_b, np.array(b))
         self.assertAlmostEqual(sing, 0.0)

--- a/pysph/tools/geometry.py
+++ b/pysph/tools/geometry.py
@@ -4,7 +4,7 @@ import copy
 from pysph.base.nnps import LinkedListNNPS
 from pysph.base.utils import get_particle_array, get_particle_array_wcsph
 from cyarray.api import UIntArray
-from numpy.linalg import norm
+from numpy.linalg import norm, matrix_power
 
 
 def distance(point1, point2=np.array([0.0, 0.0, 0.0])):
@@ -42,13 +42,13 @@ def matrix_exp(matrix):
             [0., 1.]])
     """
 
-    matrix = np.asmatrix(matrix)
+    matrix = np.asarray(matrix)
     tol = 1.0e-16
-    result = matrix**(0)
+    result = matrix_power(matrix, 0)
     n = 1
     condition = True
     while condition:
-        adding = matrix**(n) / (1.0 * np.math.factorial(n))
+        adding = matrix_power(matrix, n) / (1.0 * np.math.factorial(n))
         result += adding
         residue = np.sqrt(np.sum(np.square(adding)) /
                           np.sum(np.square(result)))
@@ -173,12 +173,12 @@ def rotate(x, y, z, axis=np.array([0.0, 0.0, 1.0]), angle=90.0):
     theta = angle * np.pi / 180.0
     unit_vector = np.asarray(axis) / norm(np.asarray(axis))
     matrix = np.cross(np.eye(3), unit_vector * theta)
-    rotation_matrix = matrix_exp(np.matrix(matrix))
+    rotation_matrix = matrix_exp(matrix)
     new_points = []
     for xi, yi, zi in zip(np.asarray(x), np.asarray(y), np.asarray(z)):
         point = np.array([xi, yi, zi])
         new = np.dot(rotation_matrix, point)
-        new_points.append(np.asarray(new)[0])
+        new_points.append(new)
     new_points = np.array(new_points)
     x_new = new_points[:, 0]
     y_new = new_points[:, 1]

--- a/pysph/tools/tests/test_geometry.py
+++ b/pysph/tools/tests/test_geometry.py
@@ -73,12 +73,12 @@ class TestGeometry(unittest.TestCase):
         x_new, y_new, z_new = G.rotate(x, y, z, axis, angle)
         unit_vector = axis / np.linalg.norm(axis)
         mat = np.cross(np.eye(3), unit_vector * theta)
-        rotation_matrix = G.matrix_exp(np.matrix(mat))
+        rotation_matrix = G.matrix_exp(np.array(mat))
         test_points = []
         for xi, yi, zi in zip(x, y, z):
             point = np.array([xi, yi, zi])
             new = np.asarray(np.dot(rotation_matrix, point))
-            test_points.append(new[0])
+            test_points.append(new)
         test_points = np.asarray(test_points)
         x_test = test_points[:, 0]
         y_test = test_points[:, 1]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [tool:pytest]
 addopts = -m "not slow"
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+    parallel: tests that require MPI

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,9 @@ skip_missing_interpreters = True
 
 [pytest]
 addopts = -m "not slow"
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+    parallel: tests that require MPI
 
 [testenv]
 sitepackages = True


### PR DESCRIPTION
- Fix several warnings in tests.
- Do not start multi-processing interface by default.  Use ``--multiproc auto`` to start it as before.