### PR TITLE
Group loop control options

### DIFF
--- a/docs/source/design/equations.rst
+++ b/docs/source/design/equations.rst
@@ -617,6 +617,53 @@ that has nothing to do with the particular backend. However, since it is
 arbitrary Python, you can choose to implement the code using any approach you
 choose to do. This should be flexible enough to customize PySPH greatly.
 
+Controlling the looping over destination particles
+----------------------------------------------------
+
+Sometimes (this is pretty rare) you may want to only iterate over a subset of
+the particles. Usually, the iterations over the destinations are performed
+roughly like the following pure Python code:
+
+.. code-block:: python
+
+    for d_idx in range(n_destinations):
+        # ...
+
+The :py:class:`Group` class also takes a ``start_idx`` argument which defaults
+to 0 and a ``stop_idx`` which defaults to the total number of particles. One
+can pass either a number or a string with a property/constant whose first item
+will be used as the number. For example you could have this:
+
+.. code-block:: python
+
+    Group(
+        equations=[
+            SimpleEquation(dest='fluid', sources=['fluid'])
+        ],
+        start_idx=10, stop_idx=20
+    )
+
+This would iterate from the index number 10 to the index number 19, i.e.
+similar to using a ``range(10, 20)``. You could also do:
+
+.. code-block:: python
+
+    Group(
+        equations=[
+            SimpleEquation(dest='fluid', sources=['fluid'])
+        ],
+        stop_idx='n_body'
+    )
+
+Where ``'n_body'`` is a constant available in the destination particle array.
+
+Another instance where this could be useful is when you want to run an
+equation only on the ghost particles, i.e. when ``real`` is False. In this
+case, let us say there are 5000 real particles, we could simply pass
+``start_idx=5000, real=False`` and it will only iterate over the non-real
+particles.
+
+
 Writing integrators
 --------------------
 

--- a/pysph/sph/acceleration_eval.py
+++ b/pysph/sph/acceleration_eval.py
@@ -120,7 +120,8 @@ class MegaGroup(object):
 
     def _copy_props(self, group):
         for key in ('real', 'update_nnps', 'iterate', 'pre', 'post',
-                    'max_iterations', 'min_iterations', 'has_subgroups'):
+                    'max_iterations', 'min_iterations', 'has_subgroups',
+                    'loop_count'):
             setattr(self, key, getattr(group, key))
 
     def _make_data(self, group):

--- a/pysph/sph/acceleration_eval.py
+++ b/pysph/sph/acceleration_eval.py
@@ -121,7 +121,7 @@ class MegaGroup(object):
     def _copy_props(self, group):
         for key in ('real', 'update_nnps', 'iterate', 'pre', 'post',
                     'max_iterations', 'min_iterations', 'has_subgroups',
-                    'loop_count'):
+                    'start_idx', 'stop_idx'):
             setattr(self, key, getattr(group, key))
 
     def _make_data(self, group):

--- a/pysph/sph/acceleration_eval_cython.mako
+++ b/pysph/sph/acceleration_eval_cython.mako
@@ -243,7 +243,7 @@ cdef class AccelerationEval:
             getattr(self, name).set_array(pa)
 
     cpdef compute(self, double t, double dt):
-        cdef long nbr_idx, NP_SRC, NP_DEST
+        cdef long nbr_idx, NP_SRC, NP_DEST, D_START_IDX
         cdef long s_idx, d_idx
         cdef int thread_id, N_NBRS
         cdef unsigned int* NBRS

--- a/pysph/sph/acceleration_eval_cython.mako
+++ b/pysph/sph/acceleration_eval_cython.mako
@@ -25,7 +25,7 @@ ${indent(helper.get_pre_call(group), 0)}
 #######################################################################
 
 dst = self.${dest}
-${indent(helper.get_dest_array_setup(dest, eqs_with_no_source, sources, group.real), 0)}
+${indent(helper.get_dest_array_setup(dest, eqs_with_no_source, sources, group), 0)}
 dst_array_index = dst.index
 
 #######################################################################
@@ -37,7 +37,7 @@ ${indent(all_eqs.get_py_initialize_code(), 0)}
 #######################################################################
 % if all_eqs.has_initialize():
 # Initialization for destination ${dest}.
-for d_idx in ${helper.get_parallel_range("NP_DEST")}:
+for d_idx in ${helper.get_parallel_range(group)}:
     ${indent(all_eqs.get_initialize_code(helper.object.kernel), 1)}
 % endif
 #######################################################################
@@ -46,7 +46,7 @@ for d_idx in ${helper.get_parallel_range("NP_DEST")}:
 % if len(eqs_with_no_source.equations) > 0:
 % if eqs_with_no_source.has_loop():
 # SPH Equations with no sources.
-for d_idx in ${helper.get_parallel_range("NP_DEST")}:
+for d_idx in ${helper.get_parallel_range(group)}:
     ${indent(eqs_with_no_source.get_loop_code(helper.object.kernel), 1)}
 % endif
 % endif
@@ -65,7 +65,7 @@ ${indent(helper.get_src_array_setup(source, eq_group), 0)}
 src_array_index = src.index
 
 % if eq_group.has_initialize_pair():
-for d_idx in ${helper.get_parallel_range("NP_DEST")}:
+for d_idx in ${helper.get_parallel_range(group)}:
     ${indent(eq_group.get_initialize_pair_code(helper.object.kernel), 1)}
 % endif
 
@@ -78,7 +78,7 @@ nnps.set_context(src_array_index, dst_array_index)
 ${helper.get_parallel_block()}
     thread_id = threadid()
     ${indent(eq_group.get_variable_array_setup(), 1)}
-    for d_idx in ${helper.get_parallel_range("NP_DEST", nogil=False)}:
+    for d_idx in ${helper.get_parallel_range(group, nogil=False)}:
         ###############################################################
         ## Find and iterate over neighbors.
         ###############################################################
@@ -105,7 +105,7 @@ ${helper.get_parallel_block()}
 ###################################################################
 % if all_eqs.has_post_loop():
 # Post loop for destination ${dest}.
-for d_idx in ${helper.get_parallel_range("NP_DEST")}:
+for d_idx in ${helper.get_parallel_range(group)}:
     ${indent(all_eqs.get_post_loop_code(helper.object.kernel), 1)}
 % endif
 

--- a/pysph/sph/equation.py
+++ b/pysph/sph/equation.py
@@ -449,7 +449,7 @@ class Group(object):
 
     def __init__(self, equations, real=True, update_nnps=False, iterate=False,
                  max_iterations=1, min_iterations=0, pre=None, post=None,
-                 loop_count=None):
+                 start_idx=0, stop_idx=None):
         """Constructor.
 
         Parameters
@@ -486,11 +486,18 @@ class Group(object):
             A callable which is passed no arguments that is called after
             the group is completed.
 
-        loop_count: int or str
-            Instead of looping over all destination particles, loop over
-            the given number if an integer is passed. If a string is passed,
-            look for a property/constant and use its first value as the loop
-            count.
+        start_idx: int or str
+            Start looping from this destination index. Starts from the given
+            number if an integer is passed. If a string is look for a
+            property/constant and use its first value as the loop count.
+
+        stop_idx: int or str
+            Loop up to this destination index instead of over all possible
+            values. Defaults to all particles. Ends at the given number if an
+            integer is passed. If a string is passed, look for a
+            property/constant and use its first value as the loop count. Note
+            that this works like a range stop parameter so the last value is
+            not included.
 
         Notes
         -----
@@ -514,7 +521,8 @@ class Group(object):
         self.min_iterations = min_iterations
         self.pre = pre
         self.post = post
-        self.loop_count = loop_count
+        self.start_idx = start_idx
+        self.stop_idx = stop_idx
 
         only_groups = [x for x in equations if isinstance(x, Group)]
         if (len(only_groups) > 0) and (len(only_groups) != len(equations)):
@@ -537,7 +545,9 @@ class Group(object):
         cls = self.__class__.__name__
         eqs = ', \n'.join(repr(eq) for eq in self.equations)
         ignore = ['equations']
-        for prop in ['pre', 'post', 'loop_count']:
+        if self.start_idx != 0:
+            ignore.append('start_idx')
+        for prop in ['pre', 'post', 'stop_idx']:
             if getattr(self, prop) is None:
                 ignore.append(prop)
         kws = ', '.join(get_init_args(self, self.__init__, ignore))

--- a/pysph/sph/equation.py
+++ b/pysph/sph/equation.py
@@ -448,7 +448,8 @@ class Group(object):
     pre_comp = precomputed_symbols()
 
     def __init__(self, equations, real=True, update_nnps=False, iterate=False,
-                 max_iterations=1, min_iterations=0, pre=None, post=None):
+                 max_iterations=1, min_iterations=0, pre=None, post=None,
+                 loop_count=None):
         """Constructor.
 
         Parameters
@@ -481,9 +482,15 @@ class Group(object):
             A callable which is passed no arguments that is called before
             anything in the group is executed.
 
-        pre: callable
+        post: callable
             A callable which is passed no arguments that is called after
             the group is completed.
+
+        loop_count: int or str
+            Instead of looping over all destination particles, loop over
+            the given number if an integer is passed. If a string is passed,
+            look for a property/constant and use its first value as the loop
+            count.
 
         Notes
         -----
@@ -496,6 +503,7 @@ class Group(object):
         having an older density.  This is also the case for the TaitEOS.  In
         these cases the group that computes the equation should set real to
         False.
+
         """
         self.real = real
         self.update_nnps = update_nnps
@@ -506,6 +514,7 @@ class Group(object):
         self.min_iterations = min_iterations
         self.pre = pre
         self.post = post
+        self.loop_count = loop_count
 
         only_groups = [x for x in equations if isinstance(x, Group)]
         if (len(only_groups) > 0) and (len(only_groups) != len(equations)):
@@ -528,6 +537,9 @@ class Group(object):
         cls = self.__class__.__name__
         eqs = ', \n'.join(repr(eq) for eq in self.equations)
         ignore = ['equations']
+        for prop in ['pre', 'post', 'loop_count']:
+            if getattr(self, prop) is None:
+                ignore.append(prop)
         kws = ', '.join(get_init_args(self, self.__init__, ignore))
         kws = '\n'.join(wrap(kws, width=74, subsequent_indent=' '*2,
                              break_long_words=False))

--- a/pysph/sph/tests/test_acceleration_eval.py
+++ b/pysph/sph/tests/test_acceleration_eval.py
@@ -266,7 +266,7 @@ class TestMegaGroup(unittest.TestCase):
         g = Group(
             equations=[], real=False, update_nnps=True, iterate=True,
             max_iterations=20, min_iterations=2, pre=nothing, post=nothing,
-            loop_count=1
+            start_idx=1, stop_idx=2
         )
 
         # When
@@ -274,7 +274,7 @@ class TestMegaGroup(unittest.TestCase):
 
         # Then
         props = ('real update_nnps iterate max_iterations '
-                 'min_iterations pre post loop_count').split()
+                 'min_iterations pre post start_idx stop_idx').split()
         for prop in props:
             self.assertEqual(getattr(mg, prop), getattr(g, prop))
 
@@ -518,7 +518,7 @@ class TestAccelerationEval1D(unittest.TestCase):
         expect = np.asarray([7., 9., 11., 11., 11., 11., 11., 11., 9., 7.])
         self.assertListEqual(list(pa.u), list(expect))
 
-    def test_should_honor_loop_count_in_group(self):
+    def test_should_honor_start_stop_idx_in_group(self):
         # Given
         pa = self.pa
         pa.u[:] = 1.0
@@ -529,7 +529,7 @@ class TestAccelerationEval1D(unittest.TestCase):
                 equations=[
                     SimpleEquation(dest='fluid', sources=['fluid'])
                 ],
-                loop_count=1
+                start_idx=1, stop_idx=2
             )
         ]
         a_eval = self._make_accel_eval(equations)
@@ -539,14 +539,15 @@ class TestAccelerationEval1D(unittest.TestCase):
 
         # Then
         expect = np.ones_like(pa.u)
-        expect[0] = 3.0
+        expect[1] = 4.0
         self.assertListEqual(list(pa.u), list(expect))
         self.assertListEqual(list(pa.au), list(expect))
 
-    def test_should_honor_loop_count_as_str_in_group(self):
+    def test_should_honor_start_stop_idx_as_str_in_group(self):
         # Given
         pa = self.pa
-        pa.add_constant('count', 2)
+        pa.add_constant('start', 1)
+        pa.add_constant('stop', 3)
         pa.u[:] = 1.0
         pa.au[:] = 1.0
 
@@ -555,7 +556,7 @@ class TestAccelerationEval1D(unittest.TestCase):
                 equations=[
                     SimpleEquation(dest='fluid', sources=['fluid'])
                 ],
-                loop_count='count'
+                start_idx='start', stop_idx='stop'
             )
         ]
         a_eval = self._make_accel_eval(equations)
@@ -565,8 +566,8 @@ class TestAccelerationEval1D(unittest.TestCase):
 
         # Then
         expect = np.ones_like(pa.u)
-        expect[0] = 3.0
         expect[1] = 4.0
+        expect[2] = 5.0
         self.assertListEqual(list(pa.u), list(expect))
         self.assertListEqual(list(pa.au), list(expect))
 

--- a/pysph/sph/tests/test_acceleration_eval_cython_helper.py
+++ b/pysph/sph/tests/test_acceleration_eval_cython_helper.py
@@ -66,13 +66,13 @@ class TestAccelerationHelperCython(unittest.TestCase):
     def tearDown(self):
         set_config(None)
 
-    def test_parallel_range_unsets_chunksize_on_loop_count(self):
+    def test_parallel_range_unsets_chunksize_on_start_stop_idx(self):
         # Given
         pa = ParticleArray(name='f', m=[1.0], rho=[0.0])
 
         eqs = [Group(
             equations=[SummationDensity(dest='f', sources=['f'])],
-            loop_count=1
+            start_idx=1, stop_idx=2
         )]
         aeval = AccelerationEval([pa], eqs, kernel=CubicSpline(dim=1))
 
@@ -81,7 +81,7 @@ class TestAccelerationHelperCython(unittest.TestCase):
         result = helper.get_parallel_range(eqs[0])
 
         # Then
-        expect = ("prange(0, NP_DEST, 1, schedule='dynamic', "
+        expect = ("prange(D_START_IDX, NP_DEST, 1, schedule='dynamic', "
                   "nogil=True)")
         self.assertEqual(result, expect)
 
@@ -99,13 +99,13 @@ class TestAccelerationHelperCython(unittest.TestCase):
         result = helper.get_parallel_range(eqs[0])
 
         # Then
-        expect = ("prange(0, NP_DEST, 1, schedule='dynamic', "
+        expect = ("prange(D_START_IDX, NP_DEST, 1, schedule='dynamic', "
                   "chunksize=64, nogil=True)")
         self.assertEqual(result, expect)
 
         result = helper.get_parallel_range(eqs[0], nogil=False)
 
         # Then
-        expect = ("prange(0, NP_DEST, 1, schedule='dynamic', "
+        expect = ("prange(D_START_IDX, NP_DEST, 1, schedule='dynamic', "
                   "chunksize=64)")
         self.assertEqual(result, expect)

--- a/pysph/sph/tests/test_acceleration_eval_cython_helper.py
+++ b/pysph/sph/tests/test_acceleration_eval_cython_helper.py
@@ -4,12 +4,19 @@ import unittest
 # Library imports.
 import numpy as np
 
+from compyle.api import get_config, set_config
+
 # Local library imports.
 from pysph.base.particle_array import ParticleArray
 from compyle.api import KnownType
+from pysph.base.kernels import CubicSpline
 from pysph.sph.acceleration_eval_cython_helper import (
-    get_all_array_names, get_known_types_for_arrays
+    get_all_array_names, get_known_types_for_arrays,
+    AccelerationEvalCythonHelper
 )
+from pysph.sph.acceleration_eval import AccelerationEval
+from pysph.sph.basic_equations import SummationDensity
+from pysph.sph.equation import Group
 
 
 class TestGetAllArrayNames(unittest.TestCase):
@@ -49,3 +56,56 @@ class TestGetKnownTypesForAllArrays(unittest.TestCase):
                   's_x': KnownType("double*")}
         for key in expect:
             self.assertEqual(repr(result[key]), repr(expect[key]))
+
+
+class TestAccelerationHelperCython(unittest.TestCase):
+    def setUp(self):
+        cfg = get_config()
+        cfg.use_openmp = True
+
+    def tearDown(self):
+        set_config(None)
+
+    def test_parallel_range_unsets_chunksize_on_loop_count(self):
+        # Given
+        pa = ParticleArray(name='f', m=[1.0], rho=[0.0])
+
+        eqs = [Group(
+            equations=[SummationDensity(dest='f', sources=['f'])],
+            loop_count=1
+        )]
+        aeval = AccelerationEval([pa], eqs, kernel=CubicSpline(dim=1))
+
+        # When
+        helper = AccelerationEvalCythonHelper(aeval)
+        result = helper.get_parallel_range(eqs[0])
+
+        # Then
+        expect = ("prange(0, NP_DEST, 1, schedule='dynamic', "
+                  "nogil=True)")
+        self.assertEqual(result, expect)
+
+    def test_parallel_range_without_loop_count(self):
+        # Given
+        pa = ParticleArray(name='f', m=[1.0], rho=[0.0])
+
+        eqs = [Group(
+            equations=[SummationDensity(dest='f', sources=['f'])],
+        )]
+        aeval = AccelerationEval([pa], eqs, kernel=CubicSpline(dim=1))
+
+        # When
+        helper = AccelerationEvalCythonHelper(aeval)
+        result = helper.get_parallel_range(eqs[0])
+
+        # Then
+        expect = ("prange(0, NP_DEST, 1, schedule='dynamic', "
+                  "chunksize=64, nogil=True)")
+        self.assertEqual(result, expect)
+
+        result = helper.get_parallel_range(eqs[0], nogil=False)
+
+        # Then
+        expect = ("prange(0, NP_DEST, 1, schedule='dynamic', "
+                  "chunksize=64)")
+        self.assertEqual(result, expect)


### PR DESCRIPTION
Currently all equations are iterated for all the destination particles. One can iterate either over all real particles or all real and ghost particles.  By passing a `Group`,  `start_idx=n1` and `stop_idx=n2` only `n2 - n1` particles in the destination.  One can also pass a string which is treated as a property/constant which is used to set the values.  This works on the CPU and on the GPU.