### PR TITLE
Support for defining a conditional group.

### DIFF
--- a/docs/source/design/equations.rst
+++ b/docs/source/design/equations.rst
@@ -617,6 +617,41 @@ that has nothing to do with the particular backend. However, since it is
 arbitrary Python, you can choose to implement the code using any approach you
 choose to do. This should be flexible enough to customize PySPH greatly.
 
+
+Conditional execution of groups
+--------------------------------
+
+A :py:class:`Group` takes a keyword argument called ``condition`` which can be
+any Python callable (function/method). This callable is passed the values of
+``t, dt``. If the function returns ``True`` then the group is executed,
+otherwise it is not. This is useful in situations when you say want to run a
+specific set of equations only every 20 iterations. Or you want to move an
+object only at a specified time. Here is a quick pseudo-example, we define the
+``Group`` as below::
+
+    def check_time(t, dt):
+        if int(t/dt) % 20 == 0:
+            return True
+        else:
+            return False
+
+    equations = [
+        Group( ... ),
+        Group(
+            equations=[
+                ShepardDensityFilter(dest='fluid', sources=['fluid'])
+            ],
+            condition=check_time
+        )
+    ]
+
+In the above pseudo-code the idea is that only when the ``check_time`` returns
+``True`` will the density filter group be executed. You can also pass a method
+instead of a function. The only condition is that it should accept the two
+arguments ``t, dt``.
+
+
+
 Controlling the looping over destination particles
 ----------------------------------------------------
 

--- a/pysph/sph/acceleration_eval.py
+++ b/pysph/sph/acceleration_eval.py
@@ -121,7 +121,7 @@ class MegaGroup(object):
     def _copy_props(self, group):
         for key in ('real', 'update_nnps', 'iterate', 'pre', 'post',
                     'max_iterations', 'min_iterations', 'has_subgroups',
-                    'start_idx', 'stop_idx'):
+                    'condition', 'start_idx', 'stop_idx'):
             setattr(self, key, getattr(group, key))
 
     def _make_data(self, group):

--- a/pysph/sph/acceleration_eval_cython.mako
+++ b/pysph/sph/acceleration_eval_cython.mako
@@ -291,15 +291,30 @@ cdef class AccelerationEval:
         indent_lvl += 1
         %>
         % endif
+        ## ---------------------
+        ## ---- Subgroups start
         % if group.has_subgroups:
         % for sg_idx, sub_group in enumerate(group.data):
         ${indent("# Doing subgroup " + str(sg_idx), indent_lvl)}
-        ${indent(do_group(helper, sub_group, indent_lvl), indent_lvl)}
-        % endfor
-
-        % else:
-        ${indent(do_group(helper, group, indent_lvl), indent_lvl)}
+        % if sub_group.condition is not None:
+        if ${helper.get_condition_call(sub_group)}:
+        <%
+        indent_lvl += 1
+        %>
         % endif
+        ${indent(do_group(helper, sub_group, indent_lvl), indent_lvl)}
+        % if sub_group.condition is not None:
+        <%
+        indent_lvl -= 1
+        %>
+        % endif
+        % endfor # (for sg_idx, sub_group in enumerate(group.data))
+        ## ---- Subgroups done
+        ## ---------------------
+        % else:  # No subgroups
+        ${indent(do_group(helper, group, indent_lvl), indent_lvl)}
+        % endif  # (if group.has_subgroups)
+        ## Check the iteration conditions
         % if group.iterate:
         ${indent(helper.get_iteration_check(group), indent_lvl)}
         % endif

--- a/pysph/sph/acceleration_eval_cython.mako
+++ b/pysph/sph/acceleration_eval_cython.mako
@@ -275,34 +275,34 @@ cdef class AccelerationEval:
         % if len(group.data) > 0: # No equations in this group.
         # ---------------------------------------------------------------------
         # Group ${g_idx}.
-        % if group.iterate:
-        max_iterations = ${group.max_iterations}
-        min_iterations = ${group.min_iterations}
-        _iteration_count = 1
-        while True:
+        % if group.condition is not None:
+        if ${helper.get_condition_call(group)}:
+        <%
+        indent_lvl = 3
+        %>
         % else:
-        if True:
+        <%
+        indent_lvl = 2
+        %>
         % endif
+        % if group.iterate:
+        ${indent(helper.get_iteration_init(group), indent_lvl)}
+        <%
+        indent_lvl += 1
+        %>
+        % endif
+        % if group.has_subgroups:
+        % for sg_idx, sub_group in enumerate(group.data):
+        ${indent("# Doing subgroup " + str(sg_idx), indent_lvl)}
+        ${indent(do_group(helper, sub_group, indent_lvl), indent_lvl)}
+        % endfor
 
-            % if group.has_subgroups:
-            % for sg_idx, sub_group in enumerate(group.data):
-            # Doing subgroup ${sg_idx}
-            ${indent(do_group(helper, sub_group, 3), 3)}
-            % endfor
-
-            % else:
-            ${indent(do_group(helper, group, 3), 3)}
-            % endif
-            #######################################################################
-            ## Break the iteration for the group.
-            #######################################################################
-            % if group.iterate:
-            # Check for convergence or timeout
-            if (_iteration_count >= min_iterations) and (${group.get_converged_condition()} or (_iteration_count == max_iterations)):
-                _iteration_count = 1
-                break
-            _iteration_count += 1
-            % endif
+        % else:
+        ${indent(do_group(helper, group, indent_lvl), indent_lvl)}
+        % endif
+        % if group.iterate:
+        ${indent(helper.get_iteration_check(group), indent_lvl)}
+        % endif
 
         # Group ${g_idx} done.
         # ---------------------------------------------------------------------

--- a/pysph/sph/acceleration_eval_gpu.mako
+++ b/pysph/sph/acceleration_eval_gpu.mako
@@ -74,6 +74,7 @@ ${helper.get_post_loop_kernel(g_idx, sg_idx, group, dest, all_eqs)}
 % if group.post:
 <% helper.call_post(group) %>
 % endif
+<% helper.end_group(group) %>
 </%def>
 
 #define abs fabs
@@ -89,6 +90,9 @@ ${helper.get_header()}
 % if len(group.data) > 0:
 // ------------------------------------------------------------------
 // Group${g_idx}
+% if group.condition is not None:
+<% helper.check_condition(group) %>
+% endif
 #######################################################################
 ## Start iteration if needed.
 #######################################################################
@@ -101,6 +105,9 @@ ${helper.get_header()}
 % if group.has_subgroups:
 % for sg_idx, sub_group in enumerate(group.data):
 // Subgroup ${sg_idx}
+% if sub_group.condition is not None:
+<% helper.check_condition(sub_group) %>
+% endif
 ${do_group(helper, g_idx, sg_idx, sub_group)}
 % endfor ## sg_idx
 % else:

--- a/pysph/sph/equation.py
+++ b/pysph/sph/equation.py
@@ -449,7 +449,7 @@ class Group(object):
 
     def __init__(self, equations, real=True, update_nnps=False, iterate=False,
                  max_iterations=1, min_iterations=0, pre=None, post=None,
-                 start_idx=0, stop_idx=None):
+                 condition=None, start_idx=0, stop_idx=None):
         """Constructor.
 
         Parameters
@@ -486,6 +486,12 @@ class Group(object):
             A callable which is passed no arguments that is called after
             the group is completed.
 
+        condition: callable
+            A callable that is passed (t, dt). If this callable returns True,
+            the group is executed, otherwise it is not. If condition is None,
+            the group is always executed. Note that this should work even if
+            the group has many destination arrays.
+
         start_idx: int or str
             Start looping from this destination index. Starts from the given
             number if an integer is passed. If a string is look for a
@@ -521,6 +527,7 @@ class Group(object):
         self.min_iterations = min_iterations
         self.pre = pre
         self.post = post
+        self.condition = condition
         self.start_idx = start_idx
         self.stop_idx = stop_idx
 
@@ -547,7 +554,7 @@ class Group(object):
         ignore = ['equations']
         if self.start_idx != 0:
             ignore.append('start_idx')
-        for prop in ['pre', 'post', 'stop_idx']:
+        for prop in ['pre', 'post', 'condition', 'stop_idx']:
             if getattr(self, prop) is None:
                 ignore.append(prop)
         kws = ', '.join(get_init_args(self, self.__init__, ignore))

--- a/pysph/sph/tests/test_acceleration_eval.py
+++ b/pysph/sph/tests/test_acceleration_eval.py
@@ -220,6 +220,20 @@ class LoopAllEquation(Equation):
         d_rho[d_idx] += sum
 
 
+class DumbEquation(Equation):
+    def initialize(self, d_idx, d_au):
+        d_au[d_idx] += 1
+
+    def loop(self, d_idx, d_au):
+        d_au[d_idx] += 1
+
+    def post_loop(self, d_idx, d_au):
+        d_au[d_idx] += 1
+
+    def reduce(self, dst, t, dt):
+        dst.reduce_calls[0] = dst.reduce_calls[0] + 1
+
+
 class InitializePair(Equation):
     def initialize_pair(self, d_idx, d_u, s_u):
         # Will only work if the source/destinations are the same
@@ -273,7 +287,7 @@ class TestMegaGroup(unittest.TestCase):
         mg = MegaGroup(g, CythonGroup)
 
         # Then
-        props = ('real update_nnps iterate max_iterations '
+        props = ('real update_nnps iterate max_iterations condition '
                  'min_iterations pre post start_idx stop_idx').split()
         for prop in props:
             self.assertEqual(getattr(mg, prop), getattr(g, prop))
@@ -569,6 +583,43 @@ class TestAccelerationEval1D(unittest.TestCase):
         expect[1] = 4.0
         expect[2] = 5.0
         self.assertListEqual(list(pa.u), list(expect))
+        self.assertListEqual(list(pa.au), list(expect))
+
+    def test_group_honors_condition(self):
+        # Given
+        pa = self.pa
+        pa.add_constant('reduce_calls', 0)
+        pa.au[:] = 0.0
+        call_data = []
+
+        def cond(t, dt):
+            call_data.append((t, dt))
+            return False
+
+        equations = [
+            Group(
+                equations=[
+                    DumbEquation(dest='fluid', sources=['fluid'])
+                ],
+                condition=cond
+            ),
+            Group(
+                equations=[
+                    DumbEquation(dest='fluid', sources=['fluid'])
+                ],
+            )
+        ]
+        a_eval = self._make_accel_eval(equations)
+
+        # When
+        a_eval.compute(0.0, 0.1)
+
+        # Then
+        expect = np.ones_like(pa.au)*7
+        expect[0] = expect[-1] = 5
+        expect[1] = expect[-2] = 6
+        self.assertEqual(len(call_data), 1)
+        self.assertEqual(call_data[0], (0.0, 0.1))
         self.assertListEqual(list(pa.au), list(expect))
 
 


### PR DESCRIPTION
Groups now support a `condition` keyword argument which takes a callable that is
passed `t, dt`.  If it returns `True` the group is executed, else it is not.
This is very convenient for certain schemes. This supported on the CPU and GPU.