### PR TITLE
Optimization for stratified SFC NNPS

### DIFF
--- a/pysph/base/stratified_sfc_nnps.pxd
+++ b/pysph/base/stratified_sfc_nnps.pxd
@@ -34,12 +34,14 @@ cdef class StratifiedSFCNNPS(NNPS):
     # Data Attributes
     ############################################################################
     cdef double radius_scale2
+    cdef bint asymmetric
 
     cdef public int num_levels
     cdef int max_num_bits
 
     cdef uint64_t* max_keys
     cdef uint64_t current_max_key
+    cdef uint64_t max_possible_key
 
     cdef double interval_size
 
@@ -55,6 +57,24 @@ cdef class StratifiedSFCNNPS(NNPS):
     cdef double** cell_sizes
     cdef double* current_cells
 
+    cdef double*** hmax
+    cdef double** current_hmax
+
+    cdef int** num_cells
+    cdef int* current_num_cells
+
+    cdef vector[int]** nbr_boxes
+    cdef vector[int]* current_nbr_boxes
+
+    cdef int*** key_to_nbr_idx
+    cdef int** current_key_to_nbr_idx
+
+    cdef int*** key_to_nbr_length
+    cdef int** current_key_to_nbr_length
+
+    cdef int* total_mask_len
+    cdef int current_mask_len
+
     cdef NNPSParticleArrayWrapper dst, src
 
     ##########################################################################
@@ -64,6 +84,27 @@ cdef class StratifiedSFCNNPS(NNPS):
 
     cpdef set_context(self, int src_index, int dst_index)
 
+    cdef inline int _get_H(self, double h_q, double h_j)
+
+    cdef inline int get_idx(self, uint64_t key, uint64_t max_key, int* key_to_idx) nogil
+
+    cdef void _fill_nbr_boxes(self)
+
+    cdef int _neighbor_boxes_func(self, int i, int j, int k, int H,
+            int* current_key_to_idx_level, uint64_t max_key,
+            double current_cell_size, double* current_hmax_level, 
+            vector[int]* nbr_boxes)
+
+    cdef int _neighbor_boxes_asym(self, int i, int j, int k, int H,
+            int* current_key_to_idx_level, uint64_t max_key,
+            double current_cell_size, double* current_hmax_level,
+            vector[int]* nbr_boxes) nogil
+
+    cdef int _neighbor_boxes_sym(self, int i, int j, int k, int H,
+            int* current_key_to_idx_level, uint64_t max_key,
+            double current_cell_size, double* current_hmax_level,
+            vector[int]* nbr_boxes) nogil
+
     cpdef double get_binning_size(self, int interval)
 
     cpdef int get_number_of_particles(self, int pa_index, int level)
@@ -72,12 +113,9 @@ cdef class StratifiedSFCNNPS(NNPS):
 
     cdef void find_nearest_neighbors(self, size_t d_idx, UIntArray nbrs) nogil
 
-    cdef inline int _neighbor_boxes(self, int i, int j, int k,
-            int* x, int* y, int* z, int H) nogil
-
     cdef void fill_array(self, NNPSParticleArrayWrapper pa_wrapper,
-            int pa_index, UIntArray indices, uint32_t* current_pids,
-            uint64_t* current_keys, double* current_cells)
+            int pa_index, uint32_t* current_pids,
+            uint64_t* current_keys, double* current_cells, int* current_num_cells)
 
     cdef inline int _get_level(self, double h) nogil
 

--- a/pysph/base/stratified_sfc_nnps.pyx
+++ b/pysph/base/stratified_sfc_nnps.pyx
@@ -114,6 +114,7 @@ cdef class StratifiedSFCNNPS(NNPS):
         cdef int** current_key_to_idx
         cdef int** current_key_to_nbr_idx
         cdef int** current_key_to_nbr_length
+        cdef double** current_hmax
         cdef int i, j
         for i from 0<=i<self.narrays:
             current_pids = self.pids[i]
@@ -121,16 +122,19 @@ cdef class StratifiedSFCNNPS(NNPS):
             current_key_to_idx = self.key_to_idx[i]
             current_key_to_nbr_idx = self.key_to_nbr_idx[i]
             current_key_to_nbr_length = self.key_to_nbr_length[i]
+            current_hmax = self.hmax[i]
             del self.nbr_boxes[i]
             for j from 0<=j<self.num_levels:
                 free(current_key_to_idx[j])
                 free(current_key_to_nbr_idx[j])
                 free(current_key_to_nbr_length[j])
+                free(current_hmax[j])
             free(current_pids)
             free(current_keys)
             free(current_key_to_idx)
             free(current_key_to_nbr_idx)
             free(current_key_to_nbr_length)
+            free(current_hmax)
             free(self.cell_sizes[i])
             free(self.num_cells[i])
         free(self.pids)
@@ -140,6 +144,9 @@ cdef class StratifiedSFCNNPS(NNPS):
         free(self.key_to_nbr_idx)
         free(self.key_to_nbr_length)
         free(self.nbr_boxes)
+        free(self.hmax)
+        free(self.total_mask_len)
+        free(self.max_keys)
 
     #### Public protocol ################################################
 

--- a/pysph/base/stratified_sfc_nnps.pyx
+++ b/pysph/base/stratified_sfc_nnps.pyx
@@ -39,11 +39,14 @@ cdef class StratifiedSFCNNPS(NNPS):
 
     def __init__(self, int dim, list particles, double radius_scale = 2.0,
             int ghost_layers = 1, domain=None, bint fixed_h = False,
-            bint cache = False, bint sort_gids = False, int num_levels = 1):
+            bint cache = False, bint sort_gids = False, int num_levels = 1,
+            bint asymmetric = True):
         NNPS.__init__(
             self, dim, particles, radius_scale, ghost_layers, domain,
             cache, sort_gids
         )
+
+        self.asymmetric = asymmetric
 
         self.radius_scale2 = radius_scale*radius_scale
         self.interval_size = 0
@@ -69,41 +72,74 @@ cdef class StratifiedSFCNNPS(NNPS):
         self.keys = <uint64_t**> malloc(narrays*sizeof(uint64_t*))
         self.key_to_idx = <int***> malloc(narrays*sizeof(int**))
         self.cell_sizes = <double**> malloc(narrays*sizeof(double*))
+        self.hmax = <double***> malloc(narrays*sizeof(double**))
         self.max_keys = <uint64_t*> malloc(narrays*sizeof(uint64_t))
+        self.num_cells = <int**> malloc(narrays*sizeof(int*))
+        self.nbr_boxes = <vector[int]**> malloc(narrays*sizeof(void*))
+        self.key_to_nbr_idx = <int***> malloc(narrays*sizeof(int**))
+        self.key_to_nbr_length = <int***> malloc(narrays*sizeof(int**))
+        self.total_mask_len = <int*> malloc(narrays*sizeof(int))
 
         cdef int i, j, num_particles
         for i from 0<=i<narrays:
             self.pids[i] = NULL
             self.keys[i] = NULL
+            self.nbr_boxes[i] = NULL
             self.key_to_idx[i] = <int**> malloc(self.num_levels*sizeof(int*))
+            self.key_to_nbr_idx[i] = <int**> malloc(self.num_levels*sizeof(int*))
+            self.key_to_nbr_length[i] = <int**> malloc(self.num_levels*sizeof(int*))
             for j from 0<=j<self.num_levels:
                 self.key_to_idx[i][j] = NULL
+                self.key_to_nbr_idx[i][j] = NULL
+                self.key_to_nbr_length[i][j] = NULL
             self.cell_sizes[i] = <double*> malloc(self.num_levels*sizeof(double))
+            self.hmax[i] = <double**> malloc(self.num_levels*sizeof(double*))
+            self.num_cells[i] = <int*> malloc(self.num_levels*sizeof(int))
+            self.total_mask_len[i] = 0
 
         self.current_pids = NULL
         self.current_keys = NULL
         self.current_key_to_idx = NULL
         self.current_cells = NULL
+        self.current_hmax = NULL
+        self.current_nbr_boxes = NULL
+        self.current_num_cells = NULL
+        self.current_key_to_nbr_idx = NULL
+        self.current_key_to_nbr_length = NULL
+        self.current_mask_len = 0
 
     def __dealloc__(self):
         cdef uint32_t* current_pids
         cdef uint64_t* current_keys
         cdef int** current_key_to_idx
+        cdef int** current_key_to_nbr_idx
+        cdef int** current_key_to_nbr_length
         cdef int i, j
         for i from 0<=i<self.narrays:
             current_pids = self.pids[i]
             current_keys = self.keys[i]
             current_key_to_idx = self.key_to_idx[i]
+            current_key_to_nbr_idx = self.key_to_nbr_idx[i]
+            current_key_to_nbr_length = self.key_to_nbr_length[i]
+            del self.nbr_boxes[i]
             for j from 0<=j<self.num_levels:
                 free(current_key_to_idx[j])
+                free(current_key_to_nbr_idx[j])
+                free(current_key_to_nbr_length[j])
             free(current_pids)
             free(current_keys)
             free(current_key_to_idx)
+            free(current_key_to_nbr_idx)
+            free(current_key_to_nbr_length)
             free(self.cell_sizes[i])
+            free(self.num_cells[i])
         free(self.pids)
         free(self.keys)
         free(self.key_to_idx)
         free(self.cell_sizes)
+        free(self.key_to_nbr_idx)
+        free(self.key_to_nbr_length)
+        free(self.nbr_boxes)
 
     #### Public protocol ################################################
 
@@ -128,7 +164,10 @@ cdef class StratifiedSFCNNPS(NNPS):
         self.current_keys = self.keys[src_index]
         self.current_cells = self.cell_sizes[src_index]
         self.current_key_to_idx = self.key_to_idx[src_index]
+        self.current_key_to_nbr_idx = self.key_to_nbr_idx[src_index]
+        self.current_key_to_nbr_length = self.key_to_nbr_length[src_index]
         self.current_max_key = self.max_keys[src_index]
+        self.current_nbr_boxes = self.nbr_boxes[src_index]
 
         self.dst = <NNPSParticleArrayWrapper> self.pa_wrappers[dst_index]
         self.src = <NNPSParticleArrayWrapper> self.pa_wrappers[src_index]
@@ -173,75 +212,67 @@ cdef class StratifiedSFCNNPS(NNPS):
 
         cdef int c_x, c_y, c_z
         cdef double* xmin = self.xmin.data
-        cdef unsigned int i, j, k, n, pid
+        cdef unsigned int i, pid
         cdef int idx
 
         cdef double xij2 = 0
-        cdef double hi2 = self.radius_scale2*h*h
+        cdef double hi2 = self.radius_scale2 * h * h
         cdef double hj2 = 0
 
-        cdef double h_max
-        cdef int H, mask_len, num_boxes
+        cdef uint64_t key
 
-        cdef int* x_boxes
-        cdef int* y_boxes
-        cdef int* z_boxes
+        cdef uint32_t q_level = self._get_level(h)
 
-        cdef uint64_t key, key_padded, level_padded
-        cdef int* key_idx_level
+        find_cell_id_raw(
+                x - xmin[0],
+                y - xmin[1],
+                z - xmin[2],
+                self.radius_scale*self.current_cells[q_level],
+                &c_x, &c_y, &c_z
+                )
 
-        for i from 0<=i<self.num_levels:
-            key_idx_level = self.current_key_to_idx[i]
-            level_padded = i << self.max_num_bits
+        cdef int* current_key_to_nbr_idx_level
+        cdef int* current_key_to_nbr_length_level
+        cdef int num_boxes, start_idx
 
-            h_max = fmax(self.radius_scale*h,
-                    self.radius_scale*self.current_cells[i])
-            H = <int> ceil(h_max/(self.radius_scale*self.current_cells[i]))
+        current_key_to_nbr_idx_level = self.current_key_to_nbr_idx[q_level]
+        current_key_to_nbr_length_level = self.current_key_to_nbr_length[q_level]
 
-            mask_len = (2*H+1) ** 3
+        find_cell_id_raw(
+                x - xmin[0],
+                y - xmin[1],
+                z - xmin[2],
+                self.radius_scale*self.current_cells[0],
+                &c_x, &c_y, &c_z
+                )
 
-            x_boxes = <int*> malloc(mask_len*sizeof(int))
-            y_boxes = <int*> malloc(mask_len*sizeof(int))
-            z_boxes = <int*> malloc(mask_len*sizeof(int))
+        key_bottom = get_key(c_x, c_y, c_z)
 
-            find_cell_id_raw(
-                    x - xmin[0],
-                    y - xmin[1],
-                    z - xmin[2],
-                    self.radius_scale*self.current_cells[i],
-                    &c_x, &c_y, &c_z
+        num_boxes = current_key_to_nbr_length_level[key_bottom]
+        start_idx = current_key_to_nbr_idx_level[key_bottom]
+
+        if not (start_idx >= 0 and num_boxes > 0):
+            return
+
+        for i from start_idx<=i<start_idx + num_boxes:
+            idx = deref(self.current_nbr_boxes)[i]
+            key = self.current_keys[idx]
+
+            while idx < num_particles and self.current_keys[idx] == key:
+                pid = self.current_pids[idx]
+
+                hj2 = self.radius_scale2*src_h_ptr[pid]*src_h_ptr[pid]
+
+                xij2 = norm2(
+                    src_x_ptr[pid] - x,
+                    src_y_ptr[pid] - y,
+                    src_z_ptr[pid] - z
                     )
 
-            num_boxes = self._neighbor_boxes(c_x, c_y, c_z,
-                    x_boxes, y_boxes, z_boxes, H)
+                if (xij2 < hi2) or (xij2 < hj2):
+                    nbrs.c_append(pid)
 
-            for j from 0<=j<num_boxes:
-                key = get_key(x_boxes[j], y_boxes[j], z_boxes[j])
-                key_padded = level_padded + key
-                idx = -1 if key >= self.current_max_key else key_idx_level[key]
-
-                if idx == -1:
-                    continue
-
-                while idx < num_particles and self.current_keys[idx] == key_padded:
-                    pid = self.current_pids[idx]
-
-                    hj2 = self.radius_scale2*src_h_ptr[pid]*src_h_ptr[pid]
-
-                    xij2 = norm2(
-                        src_x_ptr[pid] - x,
-                        src_y_ptr[pid] - y,
-                        src_z_ptr[pid] - z
-                        )
-
-                    if (xij2 < hi2) or (xij2 < hj2):
-                        nbrs.c_append(pid)
-
-                    idx += 1
-
-            free(x_boxes)
-            free(y_boxes)
-            free(z_boxes)
+                idx += 1
 
         if self.sort_gids:
             self._sort_neighbors(
@@ -249,22 +280,26 @@ cdef class StratifiedSFCNNPS(NNPS):
             )
 
     cpdef int get_number_of_particles(self, int pa_index, int level):
-        cdef int length = 1
+        cdef int length = 0
         cdef int i = 0
         cdef int num_particles = (<NNPSParticleArrayWrapper> \
                 self.pa_wrappers[pa_index]).get_number_of_particles()
-        cdef uint32_t* current_pids = self.pids[pa_index]
         cdef uint64_t* current_keys = self.keys[pa_index]
 
-        while (current_keys[i] >> self.max_num_bits) != level:
+        while i < num_particles and (current_keys[i] >> self.max_num_bits) != level:
             i += 1
 
-        while (current_keys[i] >> self.max_num_bits == \
-                current_keys[i+1] >> self.max_num_bits):
+        if i == num_particles:
+            return length
+
+        length += 1
+        i += 1
+
+        while i < num_particles and (current_keys[i] >> self.max_num_bits == \
+                current_keys[i-1] >> self.max_num_bits):
                     length += 1
                     i += 1
-                    if i == num_particles - 1:
-                        break
+
         return length
 
     #### Private protocol ################################################
@@ -279,21 +314,266 @@ cdef class StratifiedSFCNNPS(NNPS):
 
     @cython.cdivision(True)
     cdef inline int _get_level(self, double h) nogil:
-        return <int> floor((self.radius_scale*h - self.hmin)/self.interval_size)
+        return self.num_levels - <int> min(self.num_levels,
+                ceil(log2((self.cell_size + EPS)/ self.radius_scale / h)))
 
-    cdef inline int _neighbor_boxes(self, int i, int j, int k,
-            int* x, int* y, int* z, int H) nogil:
+    @cython.cdivision(True)
+    cdef inline int _get_H(self, double h_q, double h_j):
+        return <int> ceil(h_q / h_j)
+
+    cdef inline int get_idx(self, uint64_t key, uint64_t max_key, int* key_to_idx) nogil:
+        return -1 if key >= max_key else key_to_idx[key]
+
+    cdef int _neighbor_boxes_func(self, int i, int j, int k, int H,
+            int* current_key_to_idx_level, uint64_t max_key,
+            double current_cell_size, double* current_hmax_level, 
+            vector[int]* nbr_boxes):
+        if self.asymmetric:
+            return self._neighbor_boxes_asym(i, j, k, H, current_key_to_idx_level,
+                    max_key, current_cell_size, current_hmax_level, nbr_boxes)
+        else:
+            return self._neighbor_boxes_sym(i, j, k, H, current_key_to_idx_level,
+                    max_key, current_cell_size, current_hmax_level, nbr_boxes)
+
+    cdef int _neighbor_boxes_asym(self, int i, int j, int k, int H,
+            int* current_key_to_idx_level, uint64_t max_key,
+            double current_cell_size, double* current_hmax_level,
+            vector[int]* nbr_boxes) nogil:
         cdef int length = 0
-        cdef int p, q, r
-        for p from -H<=p<=H:
-            for q from -H<=q<=H:
-                for r from -H<=r<=H:
-                    if i+r>=0 and j+q>=0 and k+p>=0:
-                        x[length] = i+r
-                        y[length] = j+q
-                        z[length] = k+p
+
+        cdef uint64_t key
+        cdef int found_idx
+
+        cdef int x_temp, y_temp, z_temp
+
+        cdef int s, t, u
+
+        for s from -H<=s<=H:
+            for t from -H<=t<=H:
+                for u from -H<=u<=H:
+
+                    x_temp = i + u
+                    y_temp = j + t
+                    z_temp = k + s
+
+                    if x_temp >= 0 and y_temp >= 0 and z_temp >= 0:
+                        key = get_key(x_temp, y_temp, z_temp)
+                        found_idx = self.get_idx(key, max_key, current_key_to_idx_level)
+
+                        if found_idx == -1:
+                            continue
+
+                        nbr_boxes.push_back(found_idx)
                         length += 1
+
         return length
+
+    @cython.cdivision(True)
+    cdef int _neighbor_boxes_sym(self, int i, int j, int k, int H,
+            int* current_key_to_idx_level, uint64_t max_key,
+            double current_cell_size, double* current_hmax_level,
+            vector[int]* nbr_boxes) nogil:
+        cdef int length = 0
+
+        cdef uint64_t key
+
+        cdef int x_temp, y_temp, z_temp
+
+        cdef double h_local
+        cdef int H_eff
+
+        cdef int s, t, u
+
+        cdef uint64_t qkey = get_key(i, j, k)
+
+        for s from -H<=s<=H:
+            for t from -H<=t<=H:
+                for u from -H<=u<=H:
+
+                    x_temp = i + u
+                    y_temp = j + t
+                    z_temp = k + s
+
+                    if x_temp >= 0 and y_temp >= 0 and z_temp >= 0:
+                        key = get_key(x_temp, y_temp, z_temp)
+                        found_idx = self.get_idx(key, max_key, current_key_to_idx_level)
+
+                        if found_idx == -1:
+                            continue
+
+                        h_local = fmax(current_hmax_level[key], current_hmax_level[qkey])
+                        H_eff = <int> ceil(h_local / current_cell_size)
+
+                        if abs(u) <= H_eff and abs(t) <= H_eff and abs(s) <= H_eff:
+                            nbr_boxes.push_back(found_idx)
+                            length += 1
+
+        return length
+
+    cdef void _fill_nbr_boxes(self):
+        cdef int i, j, k
+        cdef NNPSParticleArrayWrapper pa_wrapper
+        cdef int num_particles
+
+        cdef vector[int]* current_nbr_boxes
+        cdef uint32_t* current_pids
+        cdef uint64_t* current_keys
+        cdef int** current_key_to_idx
+        cdef double** current_hmax
+
+        cdef double* x_ptr
+        cdef double* y_ptr
+        cdef double* z_ptr
+        cdef double* h_ptr
+
+        cdef int c_x, c_y, c_z
+        cdef int num_boxes
+
+        cdef int n = 0
+        cdef uint32_t pid
+
+        cdef uint64_t key, key_bottom
+        cdef uint64_t key_stripped, strip_mask, current_max_key
+        cdef int mask_length = 0
+
+        strip_mask = (1 << self.max_num_bits) - 1
+
+        for i from 0<=i<self.narrays:
+            n = 0
+            pa_wrapper = self.pa_wrappers[i]
+            num_particles = pa_wrapper.get_number_of_particles()
+            x_ptr = pa_wrapper.x.data
+            y_ptr = pa_wrapper.y.data
+            z_ptr = pa_wrapper.z.data
+            h_ptr = pa_wrapper.h.data
+            xmin = self.xmin.data
+
+            current_keys = self.keys[i]
+            current_key_to_idx = self.key_to_idx[i]
+            current_pids = self.pids[i]
+            current_nbr_boxes = self.nbr_boxes[i]
+            current_cells = self.cell_sizes[i]
+            current_hmax = self.hmax[i]
+            current_key_to_nbr_idx = self.key_to_nbr_idx[i]
+            current_key_to_nbr_length = self.key_to_nbr_length[i]
+            current_max_key = self.max_keys[i]
+
+            # init self.nbr_boxes to -1
+            for j from 0<=j<self.total_mask_len[i]:
+                deref(current_nbr_boxes)[j] = -1
+
+            for j from 0<=j<num_particles:
+                key = current_keys[j]
+                pid = current_pids[j]
+                level = key >> self.max_num_bits
+                key_stripped = key & strip_mask
+                current_hmax_level = current_hmax[level]
+                if j == 0 or key != current_keys[j-1]:
+                    current_hmax_level[key_stripped] = h_ptr[pid]
+                else:
+                    current_hmax_level[key_stripped] = fmax(current_hmax_level[key_stripped], h_ptr[pid])
+            
+            pid = current_pids[0]
+            key = current_keys[0]
+            
+            find_cell_id_raw(
+                x_ptr[pid] - xmin[0],
+                y_ptr[pid] - xmin[1],
+                z_ptr[pid] - xmin[2],
+                self.radius_scale*current_cells[0],
+                &c_x, &c_y, &c_z
+                )
+
+            key_bottom = get_key(c_x, c_y, c_z)
+
+            level = key >> self.max_num_bits
+            key_stripped = key & strip_mask
+            current_hmax_level = current_hmax[level]
+            hmax_cell = current_hmax_level[key_stripped]
+            mask_length = 0
+            
+            current_key_to_nbr_idx_level = current_key_to_nbr_idx[level]
+            current_key_to_nbr_length_level = current_key_to_nbr_length[level]
+
+            current_key_to_nbr_idx_level[key_bottom] = n
+
+            for k from 0<=k<self.num_levels:
+                if current_cells[k] == 0:
+                    continue
+
+                find_cell_id_raw(
+                    x_ptr[pid] - xmin[0],
+                    y_ptr[pid] - xmin[1],
+                    z_ptr[pid] - xmin[2],
+                    self.radius_scale*current_cells[k],
+                    &c_x, &c_y, &c_z
+                    )
+
+                H = self._get_H(hmax_cell, current_cells[k])
+                
+                num_boxes = self._neighbor_boxes_func(
+                        c_x, c_y, c_z,
+                        H, current_key_to_idx[k], current_max_key,
+                        current_cells[k], current_hmax[k],
+                        current_nbr_boxes
+                        )
+
+                n += num_boxes
+                mask_length += num_boxes
+            
+            current_key_to_nbr_length_level[key_bottom] = mask_length
+
+            # nbrs of all cids in particle array i
+            for j from 0<j<num_particles:
+                key = current_keys[j]
+                pid = current_pids[j]
+
+                find_cell_id_raw(
+                    x_ptr[pid] - xmin[0],
+                    y_ptr[pid] - xmin[1],
+                    z_ptr[pid] - xmin[2],
+                    self.radius_scale*current_cells[0],
+                    &c_x, &c_y, &c_z
+                    )
+
+                key_bottom = get_key(c_x, c_y, c_z)
+
+                level = key >> self.max_num_bits
+                key_stripped = key & strip_mask
+                current_hmax_level = current_hmax[level]
+                hmax_cell = current_hmax_level[key_stripped]
+                mask_length = 0
+                current_key_to_nbr_idx_level = current_key_to_nbr_idx[level]
+                current_key_to_nbr_length_level = current_key_to_nbr_length[level]
+                    
+                if current_key_to_nbr_idx_level[key_bottom] == -1:
+                    current_key_to_nbr_idx_level[key_bottom] = n
+ 
+                    for k from 0<=k<self.num_levels:
+                        if current_cells[k] == 0:
+                            continue
+
+                        find_cell_id_raw(
+                            x_ptr[pid] - xmin[0],
+                            y_ptr[pid] - xmin[1],
+                            z_ptr[pid] - xmin[2],
+                            self.radius_scale*current_cells[k],
+                            &c_x, &c_y, &c_z
+                            )
+
+                        H = self._get_H(hmax_cell, current_cells[k])
+                        
+                        num_boxes = self._neighbor_boxes_func(
+                                c_x, c_y, c_z,
+                                H, current_key_to_idx[k], current_max_key,
+                                current_cells[k], current_hmax[k],
+                                current_nbr_boxes
+                                )
+
+                        n += num_boxes
+                        mask_length += num_boxes
+                    
+                    current_key_to_nbr_length_level[key_bottom] = mask_length
 
     @cython.cdivision(True)
     cpdef _refresh(self):
@@ -309,6 +589,8 @@ cdef class StratifiedSFCNNPS(NNPS):
                 free(self.pids[i])
             if self.keys[i] != NULL:
                 free(self.keys[i])
+            if self.nbr_boxes[i] != NULL:
+                del self.nbr_boxes[i]
             self.pids[i] = <uint32_t*> malloc(num_particles*sizeof(uint32_t))
             self.keys[i] = <uint64_t*> malloc(num_particles*sizeof(uint64_t))
             current_cells = self.cell_sizes[i]
@@ -316,6 +598,10 @@ cdef class StratifiedSFCNNPS(NNPS):
                 current_cells[j] = 0
                 if self.key_to_idx[i][j] != NULL:
                     free(self.key_to_idx[i][j])
+                if self.key_to_nbr_idx[i][j] != NULL:
+                    free(self.key_to_nbr_idx[i][j])
+                if self.key_to_nbr_length[i][j] != NULL:
+                    free(self.key_to_nbr_length[i][j])
         self.current_pids = self.pids[self.src_index]
         self.current_cells = self.cell_sizes[self.src_index]
 
@@ -328,35 +614,92 @@ cdef class StratifiedSFCNNPS(NNPS):
 
         self.max_num_bits = 1 + 3*(<int> ceil(log2(max_num_cells)))
 
+        self.max_possible_key = 0
+
+        cdef NNPSParticleArrayWrapper pa_wrapper
+
+        cdef uint32_t* current_pids
+        cdef uint64_t* current_keys
+        cdef int** current_key_to_nbr_idx 
+        cdef int** current_key_to_nbr_length
+        cdef int* current_key_to_nbr_idx_level
+        cdef int* current_key_to_nbr_length_level
+        cdef uint64_t key_iter
+
+        cdef int H_jk, num_cells_level
+
+        for i from 0<=i<self.narrays:
+            self.total_mask_len[i] = 0
+            pa_wrapper = self.pa_wrappers[i]
+            current_cells = self.cell_sizes[i]
+            current_pids = self.pids[i]
+            current_keys = self.keys[i]
+            current_num_cells = self.num_cells[i]
+
+            self.fill_array(pa_wrapper, i, current_pids,
+                    current_keys, current_cells, current_num_cells)
+
+            current_key_to_nbr_idx = self.key_to_nbr_idx[i]
+            current_key_to_nbr_length = self.key_to_nbr_idx[i]
+            
+            for j from 0<=j<self.num_levels:
+                num_cells_level = current_num_cells[j]
+                for k from 0<=k<self.num_levels:
+                    if current_cells[j] == 0 or current_cells[k] == 0:
+                        continue
+                    H_jk = self._get_H(current_cells[j], current_cells[k])
+                    self.total_mask_len[i] += num_cells_level * (2 * H_jk + 1) ** 3
+
+            self.nbr_boxes[i] = new vector[int]()
+            self.nbr_boxes[i].reserve(self.total_mask_len[i])
+
+        self.max_possible_key += 1
+
+        for i from 0<=i<self.narrays:
+            current_key_to_nbr_idx = self.key_to_nbr_idx[i]
+            current_key_to_nbr_length = self.key_to_nbr_length[i]
+            for j from 0<=j<self.num_levels:
+                current_key_to_nbr_idx[j] = <int*> malloc(self.max_possible_key * sizeof(int))
+                current_key_to_nbr_length[j] = <int*> malloc(self.max_possible_key * sizeof(int))
+                current_key_to_nbr_idx_level = current_key_to_nbr_idx[j]
+                current_key_to_nbr_length_level = current_key_to_nbr_length[j]
+
+                for key_iter from 0<=key_iter<self.max_possible_key:
+                    current_key_to_nbr_idx_level[key_iter] = -1
+                    current_key_to_nbr_length_level[key_iter] = -1
+
+        self._fill_nbr_boxes()
+
+    @cython.cdivision(True)
     cdef void fill_array(self, NNPSParticleArrayWrapper pa_wrapper,
-            int pa_index, UIntArray indices, uint32_t* current_pids,
-            uint64_t* current_keys, double* current_cells):
+            int pa_index, uint32_t* current_pids,
+            uint64_t* current_keys, double* current_cells, int* current_num_cells):
         cdef double* x_ptr = pa_wrapper.x.data
         cdef double* y_ptr = pa_wrapper.y.data
         cdef double* z_ptr = pa_wrapper.z.data
         cdef double* h_ptr = pa_wrapper.h.data
 
+        cdef int curr_num_particles = pa_wrapper.get_number_of_particles()
+
+        cdef double* xmax = self.xmax.data
         cdef double* xmin = self.xmin.data
 
         cdef int c_x, c_y, c_z
 
-        cdef int i, j, n, level
+        cdef int i, j, level
         cdef uint64_t level_padded, key
 
         # Finds cell sizes at each level
-        for i from 0<=i<indices.length:
-            n = indices.data[i]
-            level = self._get_level(h_ptr[n])
-            current_cells[level] = fmax(h_ptr[n], current_cells[level])
+        for i from 0<=i<self.num_levels:
+            current_cells[i] = (self.cell_size / self.radius_scale) / (2 ** (self.num_levels - i - 1))
 
         cdef double cell_size
 
         cdef uint64_t max_key = 0
 
-        for i from 0<=i<indices.length:
-            n = indices.data[i]
-            current_pids[i] = n
-            level = self._get_level(h_ptr[n])
+        for i from 0<=i<curr_num_particles:
+            current_pids[i] = i
+            level = self._get_level(h_ptr[i])
             level_padded = level << self.max_num_bits
             cell_size = self.radius_scale*current_cells[level]
             find_cell_id_raw(
@@ -371,24 +714,40 @@ cdef class StratifiedSFCNNPS(NNPS):
 
             max_key = max(max_key, key)
 
+            find_cell_id_raw(
+                    x_ptr[i] - xmin[0],
+                    y_ptr[i] - xmin[1],
+                    z_ptr[i] - xmin[2],
+                    self.radius_scale*current_cells[0],
+                    &c_x, &c_y, &c_z
+                    )
+            key = get_key(c_x, c_y, c_z)
+            self.max_possible_key = max(key, self.max_possible_key)
+
         max_key += 1
 
         self.max_keys[pa_index] = max_key
 
         cdef CompareSortWrapper sort_wrapper = CompareSortWrapper(
-                current_pids, current_keys, indices.length)
+                current_pids, current_keys, curr_num_particles)
 
         sort_wrapper.compare_sort()
 
         cdef int** current_key_to_idx = self.key_to_idx[pa_index]
+        cdef double** current_hmax = self.hmax[pa_index]
         cdef int* key_idx_level
+        cdef double* hmax_level
 
         for i from 0<=i<self.num_levels:
             current_key_to_idx[i] = <int*> malloc(max_key * sizeof(int))
+            current_hmax[i] = <double*> malloc(max_key * sizeof(double))
             key_idx_level = current_key_to_idx[i]
+            hmax_level = current_hmax[i]
+            current_num_cells[i] = 0
 
             for j from 0<=j<max_key:
                 key_idx_level[j] = -1
+                hmax_level[j] = -1
 
         ################################################################
 
@@ -400,24 +759,17 @@ cdef class StratifiedSFCNNPS(NNPS):
         level = key >> self.max_num_bits
         key_stripped = key & strip_mask
         current_key_to_idx[level][key_stripped] = 0;
+        current_num_cells[level] += 1
 
-        for i from 0<i<indices.length:
+        for i from 0<i<curr_num_particles:
             key = current_keys[i]
             if key != current_keys[i-1]:
                 level = key >> self.max_num_bits
                 key_idx_level = current_key_to_idx[level]
                 key_stripped = key & strip_mask
                 key_idx_level[key_stripped] = i
-
-        ################################################################
+                current_num_cells[level] += 1
 
     @cython.cdivision(True)
     cpdef _bin(self, int pa_index, UIntArray indices):
-        cdef NNPSParticleArrayWrapper pa_wrapper = self.pa_wrappers[pa_index]
-
-        cdef double* current_cells = self.cell_sizes[pa_index]
-        cdef uint32_t* current_pids = self.pids[pa_index]
-        cdef uint64_t* current_keys = self.keys[pa_index]
-
-        self.fill_array(pa_wrapper, pa_index, indices, current_pids,
-                current_keys, current_cells)
+        pass

--- a/pysph/base/z_order_nnps.pyx
+++ b/pysph/base/z_order_nnps.pyx
@@ -304,9 +304,7 @@ cdef class ZOrderNNPS(NNPS):
         cdef uint64_t* iter_keys
         cdef int* iter_key_to_idx
 
-        cdef uint32_t* sorted_cids = <uint32_t*> malloc(
-                curr_num_particles*sizeof(uint32_t))
-
+        cdef uint32_t curr_pid = current_pids[0]
         for j from 0<=j<pa_index:
             iter_cids = self.cids[j]
             iter_keys = self.keys[j]
@@ -325,9 +323,10 @@ cdef class ZOrderNNPS(NNPS):
             found_cid = curr_cid
             curr_cid += 1
 
-        sorted_cids[0] = found_cid
+        current_cids[curr_pid] = found_cid
 
         for i from 0<i<curr_num_particles:
+            curr_pid = current_pids[i]
             if(current_keys[i] != current_keys[i-1]):
                 found_ptr = NULL
                 found_cid = UINT_MAX
@@ -350,12 +349,7 @@ cdef class ZOrderNNPS(NNPS):
                     found_cid = curr_cid
                     curr_cid += 1
 
-            sorted_cids[i] = found_cid
-
-        for i from 0<=i<curr_num_particles:
-            pid = current_pids[i]
-            current_cids[pid] = sorted_cids[i]
-        free(sorted_cids)
+            current_cids[curr_pid] = found_cid
 
         return curr_cid
 


### PR DESCRIPTION
Calculate neighbor boxes for bins instead of particles
Makes stratified SFC about 1.5x faster than octree in case of variable h with max/min ratio of 4