### PR TITLE
Fix examples for GPU backends

### DIFF
--- a/pysph/base/device_helper.py
+++ b/pysph/base/device_helper.py
@@ -600,7 +600,7 @@ class DeviceHelper(object):
             prop_type = dtype_to_ctype(src_arr.dtype)
             prop_default = self._particle_array.default_values[prop_name]
             result_array.add_property(name=prop_name,
-                                      type=prop_type,
+                                      type='double' if prop_type == 'float' else prop_type,
                                       default=prop_default,
                                       stride=stride)
 

--- a/pysph/examples/_db_geometry.py
+++ b/pysph/examples/_db_geometry.py
@@ -396,11 +396,11 @@ class DamBreak3DGeometry(object):
 
             pa.rho[:] = self.rho0
 
-        nf = fluid.num_real_particles
-        nb = boundary.num_real_particles
+        nf = fluid.get_number_of_particles()
+        nb = boundary.get_number_of_particles()
 
         if self.with_obstacle:
-            no = obstacle.num_real_particles
+            no = obstacle.get_number_of_particles()
             print(
                 "3D dam break with %d fluid, %d boundary, %d obstacle particles" %
                 (nf, nb, no))

--- a/pysph/examples/cube.py
+++ b/pysph/examples/cube.py
@@ -80,6 +80,10 @@ class Cube(Application):
 
         print("Number of particles:", x.size)
         fluid.set_lb_props( list(fluid.properties.keys()) )
+
+        if fluid.gpu:
+            fluid.gpu.push()
+
         return [fluid]
 
 


### PR DESCRIPTION
This is probably not the best way to fix these issues. 
We should clean up the particle array and device helper so that users don't need to deal with push/pull of data