### PR TITLE
Added pfreq as a default parameter to solver.

### DIFF
--- a/pysph/solver/solver.py
+++ b/pysph/solver/solver.py
@@ -24,7 +24,7 @@ class Solver(object):
                  n_damp=0, tf=1.0, dt=1e-3,
                  adaptive_timestep=False, cfl=0.3,
                  output_at_times=(),
-                 fixed_h=False, **kwargs):
+                 fixed_h=False, pfreq=100, **kwargs):
         """**Constructor**
 
         Any additional keyword args are used to set the values of any
@@ -111,7 +111,7 @@ class Solver(object):
         self.post_stage_callbacks = []
 
         # default output printing frequency
-        self.pfreq = 100
+        self.pfreq = pfreq
 
         # Compress generated files.
         self.compress_output = False


### PR DESCRIPTION
The correct way to set pfreq is by using `set_print_freq` method of
Solver class. But, this is not used by many examples, where pfreq is added
as a class parameter for which the default value is hardcoded to 100.