### PR TITLE
ENH: Support setting load balancing weights.

### DIFF
--- a/pysph/base/nnps_base.pxd
+++ b/pysph/base/nnps_base.pxd
@@ -236,7 +236,7 @@ cdef class Cell:
     cdef cPoint boxmax                  # Bounding box max for the cell
     cdef int layers                     # Layers to compute bounding box
     cdef IntArray nbrprocs              # List of neighboring processors
-    cdef public int size                # total number of particles in this cell
+    cdef public double size             # total number of particles in this cell
 
     ############################################################################
     # Member functions

--- a/pysph/base/nnps_base.pyx
+++ b/pysph/base/nnps_base.pyx
@@ -1080,7 +1080,7 @@ cdef class Cell:
         self.nbrprocs = IntArray(0)
 
         # current size of the cell
-        self.size = 0
+        self.size = 0.0
 
     #### Public protocol ################################################
     def get_centroid(self, Point pnt):

--- a/pysph/parallel/parallel_manager.pxd
+++ b/pysph/parallel/parallel_manager.pxd
@@ -49,6 +49,7 @@ cdef class ParticleArrayExchange:
     # list of load balancing props
     cdef public list lb_props
     cdef public int nprops
+    cdef public double lb_weight
 
     # Import/Export lists for particles
     cdef public UIntArray exportParticleGlobalids

--- a/pysph/parallel/parallel_manager.pyx
+++ b/pysph/parallel/parallel_manager.pyx
@@ -86,6 +86,12 @@ cdef class ParticleArrayExchange:
 
         self.lb_props = lb_props
         self.nprops = len( lb_props )
+        # If an lb_weight  constant is present in the array, this
+        # is the weight to use for the load balancing for those particles.
+        if 'lb_weight' in pa.constants:
+            self.lb_weight = pa.constants.get('lb_weight')[0]
+        else:
+            self.lb_weight = 1.0
 
         # exchange flags
         self.lb_exchange = True
@@ -717,6 +723,7 @@ cdef class ParallelManager:
         cdef int ncells_total = 0
         cdef int narrays = self.narrays
         cdef int layers = self.ghost_layers
+        cdef double lb_weight = self.pa_exchanges[pa_index].lb_weight
 
         # now bin the particles
         num_particles = indices.length
@@ -749,7 +756,7 @@ cdef class ParallelManager:
 
             # increment the size of the cells to reflect the added
             # particle. The size will be used to set the weights.
-            cell.size += 1
+            cell.size += lb_weight
 
         # update the total number of cells
         self.ncells_total = self.ncells_total + ncells_total

--- a/pysph/sph/scheme.py
+++ b/pysph/sph/scheme.py
@@ -520,6 +520,11 @@ class WCSPHScheme(Scheme):
         for pa in particles:
             self._ensure_properties(pa, props, clean)
             pa.set_output_arrays(output_props)
+            if pa.name in self.solids:
+                # This is the load balancing weight for the solid particles.
+                # They do less work so we reduce the weight.
+                if 'lb_weight' not in pa.constants:
+                    pa.add_constant('lb_weight', 0.1)
 
 
 class TVFScheme(Scheme):


### PR DESCRIPTION
These can be set per particle array and are used for parallel execution.
So for example, the solid particles take a lot less computation so
should not be given the same weight as fluid particles.  In this case,
simply add a constant called `lb_weight` to the solid particle arrays
and set the value to 0.1 for example. This will improve the load
balancing.  Each particle array can be given a different weight.
The WCSPH Scheme has been updated to set the weights.  The others
require some investigation.