### PR TITLE
Add a simple `pysph cache` command.

### DIFF
--- a/pysph/tools/cli.py
+++ b/pysph/tools/cli.py
@@ -45,6 +45,11 @@ def cull_files(args):
     main(args)
 
 
+def manage_cache(args):
+    from pysph.tools.manage_cache import main
+    main(args)
+
+
 def main():
     parser = ArgumentParser(description=__doc__, add_help=False)
     parser.add_argument(
@@ -91,6 +96,13 @@ def main():
         add_help=False
     )
     cull.set_defaults(func=cull_files)
+
+    cache = subparsers.add_parser(
+        'cache',
+        help='Show cache directories or clear them',
+        add_help=False
+    )
+    cache.set_defaults(func=manage_cache)
 
     if (len(sys.argv) == 1 or (len(sys.argv) > 1 and
                                sys.argv[1] in ['-h', '--help'])):

--- a/pysph/tools/manage_cache.py
+++ b/pysph/tools/manage_cache.py
@@ -1,0 +1,75 @@
+"""Manage the PySPH and Compyle cache directories.
+
+These directories contain the generated sources and extension modules and can
+get quite big. The command allows you to see the path and size of these cache
+directories and also clear them out if they are too big.
+
+"""
+import argparse
+from pathlib import Path
+import shutil
+import sys
+
+
+def _get_cache_dirs():
+    home = Path('~').expanduser()
+    cc = home / '.compyle' / 'source'
+    pc = home / '.pysph' / 'source'
+    return (cc, pc)
+
+
+def _find_size(pth):
+    return sum(f.stat().st_size for f in pth.glob('**/*') if f.is_file())
+
+
+def show_cache():
+    cc, pc = _get_cache_dirs()
+    print("PySPH cache directories are at:")
+    GB = 2**30
+    print("{}  {:<.3g} GB".format(str(cc), _find_size(cc)/GB))
+    print("{}    {:<.3g} GB".format(str(pc), _find_size(pc)/GB))
+
+
+def clear_cache():
+    cc, pc = _get_cache_dirs()
+    print("Clearing cache in\n", cc, "\n", pc)
+    confirm = input('Are you sure? (y/N) ')
+    if confirm in ['y', 'Y']:
+        shutil.rmtree(cc)
+        shutil.rmtree(pc)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog='cache', description=__doc__, add_help=False
+    )
+
+    parser.add_argument(
+        "-h",
+        "--help",
+        action="store_true",
+        default=False,
+        dest="help",
+        help="show this help message and exit"
+    )
+
+    parser.add_argument(
+        "-c", "--clear",
+        action="store_true",
+        default=False,
+        help="Delete all the files in the cache directory."
+    )
+
+    if argv is not None and len(argv) > 0 and argv[0] in ['-h', '--help']:
+        parser.print_help()
+        sys.exit()
+
+    options, extra = parser.parse_known_args(argv)
+    if options.clear:
+        clear_cache()
+    else:
+        show_cache()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This will show the PySPH and Compyle cache directories and their sizes.
By passing `-c` or `--clear` one can also delete the generated
modules/sources there.