### PR TITLE
Fix build to use older PyOpenCL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies on Linux/MacOS
         run: |
           conda info
-          conda install -c conda-forge pocl pyopencl
+          conda install -c conda-forge pocl pyopencl==2021.2.11
           python -c 'import pyopencl as cl'
         if: ${{ runner.os != 'Windows' }}
       - name: Install dependencies

--- a/pysph/tools/mesh_tools.pyx
+++ b/pysph/tools/mesh_tools.pyx
@@ -4,9 +4,7 @@ from pysph.tools.geometry import remove_repeated_points
 import numpy as np
 from numpy.linalg import norm
 from cyarray.api import UIntArray
-cimport cython
 cimport numpy as np
-import meshio
 
 DTYPE = np.float64
 ctypedef np.float_t DTYPE_t


### PR DESCRIPTION
- Fix builds to use PyOpenCL 2021.2.11 for now.
- Also remove some unnecessary imports in mesh_tools.pyx.
- Thanks to @MiloniAtal  for finding the initial issue.