### PR TITLE
Improve build config, work around issues.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 name: Tests
 
-on: pull_request
+on:
+  pull_request:
+  schedule:
+    # Run test at 0400 UTC on Saturday.
+    - cron: '0 4 * * 6'
+
 
 jobs:
   tests:
@@ -25,13 +30,15 @@ jobs:
       - name: Install dependencies on Linux/MacOS
         run: |
           conda info
-          conda install -c conda-forge pocl pyopencl==2021.2.11
+          conda install -c conda-forge pocl pyopencl
           python -c 'import pyopencl as cl'
         if: ${{ runner.os != 'Windows' }}
       - name: Install dependencies
         run: |
           conda info
-          conda install -c conda-forge numpy cython
+          conda install -c conda-forge numpy cython h5py
+          python -m pip install https://github.com/pypr/cyarray/zipball/master
+          python -m pip install https://github.com/pypr/compyle/zipball/master
           python -m pip install -r requirements.txt
           python -m pip install -e ".[dev]"
       - name: Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "Beaker",
     "Cython>=0.20",
-    "compyle",
+    "compyle>=0.8",
     "cyarray",
     "mako",
     "oldest-supported-numpy",

--- a/pysph/base/gpu_domain_manager.py
+++ b/pysph/base/gpu_domain_manager.py
@@ -6,7 +6,7 @@ from pysph.base.nnps_base import DomainManagerBase
 from compyle.config import get_config
 from compyle.array import Array, get_backend
 from compyle.parallel import Elementwise, Reduction, Scan
-from compyle.types import annotate, dtype_to_ctype
+from compyle.types import annotate, declare
 
 from pytools import memoize_method
 
@@ -162,8 +162,8 @@ class GPUDomainManager(DomainManagerBase):
     @memoize_method
     def _get_ghosts_reduction_kernel(self):
         @annotate
-        def map_func(i, periodic_in_x, periodic_in_y, periodic_in_z,
-                     x, y, z, xmin, ymin, zmin, xmax, ymax, zmax, cell_size):
+        def map_func(i, x, y, z, xmin, ymin, zmin, xmax, ymax, zmax, cell_size,
+                     periodic_in_x, periodic_in_y, periodic_in_z):
             x_copies, y_copies, z_copies = declare('int', 3)
 
             x_copies = 1
@@ -364,10 +364,10 @@ class GPUDomainManager(DomainManagerBase):
             y = pa_wrapper.pa.gpu.y
             z = pa_wrapper.pa.gpu.z
 
-            num_extra_particles = reduce_knl(periodic_in_x, periodic_in_y,
-                                             periodic_in_z, x, y, z, xmin,
-                                             ymin, zmin, xmax, ymax, zmax,
-                                             cell_size)
+            num_extra_particles = reduce_knl(x, y, z, xmin, ymin, zmin, xmax,
+                                             ymax, zmax, cell_size,
+                                             periodic_in_x, periodic_in_y,
+                                             periodic_in_z)
 
             num_extra_particles = int(num_extra_particles)
 

--- a/pysph/tools/binder.py
+++ b/pysph/tools/binder.py
@@ -141,8 +141,8 @@ def _write_readme_requrements(path):
                 Cython
                 h5py
                 meshio
-                https://github.com/pypr/cyarray/zipball/master
-                https://github.com/pypr/compyle/zipball/master
+                cyarray
+                compyle
                 https://github.com/pypr/pysph/zipball/master
                 ''')
             )

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
 pytest>=3.0
 mock>=1.0
-meshio
+h5py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 numpy
 setuptools>=42.0.0
 Cython>=0.20
-https://github.com/pypr/cyarray/zipball/master
-https://github.com/pypr/compyle/zipball/master
+cyarray
+compyle>=0.8
 mako
 pytools
 Beaker

--- a/setup.py
+++ b/setup.py
@@ -681,10 +681,10 @@ def setup_package():
 
     # The requirements.
     install_requires = [
-        'numpy', 'mako', 'cyarray', 'compyle', 'Cython>=0.20',
+        'numpy', 'mako', 'cyarray', 'compyle>=0.8', 'Cython>=0.20',
         'setuptools>=42.0.0', 'pytools', 'Beaker'
     ]
-    tests_require = ['pytest>=3.0', 'meshio']
+    tests_require = ['pytest>=3.0', 'h5py']
     if sys.version_info[:2] == (2, 6):
         install_requires += [
             'ordereddict', 'importlib'


### PR DESCRIPTION
- Work around PyOpenCL issue for now: https://github.com/inducer/pyopencl/issues/535
- Add a cron schedule to run the tests so we catch errors due to changes
  in upstream packages early.
- Always test with latest cyarray and compyle.
- Improve requirements, we don't need meshio as it is optional but
  should test with h5py.
- The requirements.txt does not need to run off master cyarray and
  compyle anymore.