### PR TITLE
Dump XDMF

### DIFF
--- a/docs/source/reference/tools.rst
+++ b/docs/source/reference/tools.rst
@@ -21,6 +21,11 @@ PySPH or to generate new files.
 
 .. autofunction:: pysph.solver.utils.load_and_concatenate
 
+Dump XDMF
+~~~~~~~~~~~~~
+.. automodule:: pysph.tools.dump_xdmf
+    :members:
+    :undoc-members:
 
 Interpolator
 ------------

--- a/pysph/tools/cli.py
+++ b/pysph/tools/cli.py
@@ -23,6 +23,11 @@ def output_vtk(args):
     main(args)
 
 
+def dump_xdmf(args):
+    from pysph.tools.dump_xdmf import main
+    main(args)
+
+
 def _has_pysph_dir():
     init_py = join('pysph', '__init__.py')
     init_pyc = join('pysph', '__init__.pyc')
@@ -75,6 +80,12 @@ def main():
         add_help=False
     )
     vtk_out.set_defaults(func=output_vtk)
+
+    xdmf_out = subparsers.add_parser(
+        'dump_xdmf', help='Generate XDMF',
+        add_help=False
+    )
+    xdmf_out.set_defaults(func=dump_xdmf)
 
     tests = subparsers.add_parser(
         'test', help='Run entire PySPH test-suite',

--- a/pysph/tools/dump_xdmf.py
+++ b/pysph/tools/dump_xdmf.py
@@ -1,0 +1,149 @@
+""" Generate XDMF file(s) referencing the heavy data stored using HDF5 by
+PySPH.
+
+Separate xdmf file will be generated for each hdf5 file input. If directory is
+input, a single xdmf file will be generated assuming all the hdf5 files inside
+the directory as timeseris data.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import h5py
+from mako.template import Template
+
+from pysph.solver.utils import get_files
+
+
+def main(argv=None):
+    """ Main function to generate XDMF file(s) referencing the heavy data
+    stored using HDF5 by PySPH.
+    """
+
+    if argv is None:
+        argv = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(
+        prog='generate_xdmf', description=__doc__, add_help=False
+    )
+
+    parser.add_argument(
+        "-h", "--help", action="store_true", default=False, dest="help",
+        help="show this help message and exit"
+    )
+
+    parser.add_argument(
+        "inputfile", type=str, nargs='+',
+        help="list of input hdf5 file(s) or/and director(y/ies) with hdf5"
+             "file(s)."
+    )
+
+    parser.add_argument(
+        "-d", "--outdir", metavar="path/to/outdir", type=str,
+        default=Path(),
+        help="directory to output xdmf file(s), defaults to current working "
+             "directory"
+    )
+
+    parser.add_argument(
+        "--refer-absolute-path", action="store_false", dest='relative_path',
+        help="use absolute path(s) to reference heavy data in the generated"
+             " xdmf file"
+    )
+
+    parser.add_argument(
+        "--no-vectorize-velocity", action="store_false",
+        dest='vectorize_velocity',
+        help="reference u,v and w such that they are read as separate scalar "
+             "quantities through xdmf"
+    )
+
+    if len(argv) > 0 and argv[0] in ['-h', '--help']:
+        parser.print_help()
+        sys.exit()
+
+    options, extra = parser.parse_known_args(argv)
+    run(options)
+
+
+def run(options):
+    outdir = Path(options.outdir).absolute()
+    outdir.mkdir(parents=True, exist_ok=True)
+    for ifile in options.inputfile:
+        if Path(ifile).is_dir():
+            files = get_files(ifile, endswith='hdf5')
+            outfile = Path(ifile).name + '.xdmf'
+        else:
+            files = [Path(ifile).absolute()]
+            outfile = Path(ifile).stem + '.xdmf'
+
+        files2xdmf(files, outdir.joinpath(outfile),
+                   options.relative_path, options.vectorize_velocity)
+
+
+def files2xdmf(absolute_files, outfilename, refer_relative_path,
+               vectorize_velocity):
+    # Assuming output_props and strides does not change for the files in a
+    # folder, just obtain those from the first file.
+    particles_info = {}
+    n_particles = {}
+    stride = {}
+    fname = absolute_files[0]
+    with h5py.File(fname, 'r') as data:  # will fail here if not .hdf5 file
+        for pname in data['particles'].keys():
+            n_particles[pname] = []
+            output_props = []
+            for arrname, arr in data[f'particles/{pname}/arrays/'].items():
+                if arr.attrs['stored']:
+                    output_props.append(arrname)
+                stride[arrname] = arr.attrs.get('stride')
+            attr_type = {}
+            for var_name in output_props:
+                if stride[var_name] == 1:
+                    typ = 'Scalar'
+                elif stride[var_name] == 3:
+                    typ = 'Vector'
+                elif stride[var_name] == 9:
+                    typ = 'Tensor'
+                else:
+                    typ = 'Matrix'
+                attr_type[var_name] = typ
+
+                particles_info[pname] = {'output_props': output_props,
+                                         'stride': stride,
+                                         'attr_type': attr_type}
+
+    # time (and number of particles may) change for different files in a
+    # folder, so obtain that from each file.
+    times = []
+    for fname in absolute_files:
+        with h5py.File(fname, 'r') as data:  # will fail here if not .hdf5 file
+            times.append(data['solver_data'].attrs.get('t'))
+            for pname in data['particles'].keys():
+                for arrname, arr in data[f'particles/{pname}/arrays/'].items():
+                    if arr.attrs['stored']:
+                        n = int(arr.shape[0]/arr.attrs.get('stride'))
+                        n_particles[pname].append(n)
+                        break
+
+    template_file = Path(__file__).parent.absolute().joinpath(
+        'xdmf_template.mako')
+    xdmf_template = Template(filename=str(template_file))
+
+    if refer_relative_path:
+        outdir = Path(outfilename).parent
+        files = [Path(f).relative_to(outdir) for f in absolute_files]
+    else:
+        files = absolute_files
+
+    with open(outfilename, 'w') as xdmf_file:
+        print(xdmf_template.render(times=times, files=files,
+                                   particles_info=particles_info,
+                                   n_particles=n_particles,
+                                   vectorize_velocity=vectorize_velocity),
+              file=xdmf_file)
+
+
+if __name__ == '__main__':
+    main()

--- a/pysph/tools/tests/test_dump_xdmf.py
+++ b/pysph/tools/tests/test_dump_xdmf.py
@@ -1,0 +1,73 @@
+import shutil
+import unittest
+from pathlib import Path
+from tempfile import mkdtemp
+
+import numpy as np
+from pytest import importorskip
+
+from pysph.base.utils import get_particle_array
+from pysph.solver.output import dump
+from pysph.tools.dump_xdmf import main as dump_xdmf
+
+
+class TestDumpXDMF(unittest.TestCase):
+
+    def test_dump_xdmf(self, npoints=10, random_seed=0):
+        vtk = importorskip('vtk')
+        np.random.seed(random_seed)
+        tmp_dir = mkdtemp()
+        hdf5file = str(Path(tmp_dir) / 'test.hdf5')
+
+        # Assign rho as random data, make a particle array and dump it as hdf5.
+        self.rho = np.random.rand(npoints)
+        pa = get_particle_array(name='fluid',
+                                rho=self.rho,
+                                x=np.arange(npoints),
+                                y=np.zeros(npoints),
+                                z=np.zeros(npoints))
+        dump(hdf5file, [pa], {})
+
+        try:
+            # Generate XDMF for dumped hdf5 file.
+            dump_xdmf([hdf5file, '--outdir', tmp_dir])
+
+            # Retrieve data by reading xdmf file
+            xdmffile = Path(hdf5file).with_suffix('.xdmf')
+            reader = vtk.vtkXdmfReader()
+            reader.SetFileName(xdmffile)
+            reader.Update()
+            block = reader.GetOutput().GetBlock(0)
+            point_data = block.GetPointData()
+            array_data = {}
+            for i in range(point_data.GetNumberOfArrays()):
+                vtk_array = point_data.GetArray(i)
+                if vtk_array:
+                    array_name = vtk_array.GetName()
+                    array_data[array_name] = np.array(vtk_array)
+
+            # Check if retrieved data and generated data is same.
+            assert np.allclose(self.rho, array_data['rho'], atol=1e-14), \
+                "Expected %s,\n got %s" % (self.rho, array_data['rho'])
+
+            del reader
+            # Note: Ideally, the reader need not be deleted as reader.Update()
+            # itself will open the file, read its contents, and then close the
+            # file.
+            # Ref. https://discourse.vtk.org/t/does-a-python-reader-need-to-be-closed/7261/3 # noqa
+            #
+            # But shutil.rmtree(tmp_dir) still gives the following error on
+            # windows:
+            # """
+            # The process cannot access the file because it is being used by
+            # another process: 'C:\\Users\\RUNNER~1\\AppData\\Local\\
+            # Temp\\tmpqft4428c\\test.xdmf'
+            # """
+            # Deleting the reader avoids the error.
+
+        finally:
+            shutil.rmtree(tmp_dir)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pysph/tools/xdmf_template.mako
+++ b/pysph/tools/xdmf_template.mako
@@ -1,0 +1,67 @@
+<?xml version="1.0" ?>
+<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>
+<Xdmf Version="2.0">
+  <Domain>\
+    ${tempotral_collection(files, times, n_particles, particles_info, vectorize_velocity)}\
+  </Domain>
+</Xdmf>
+
+<%def name="tempotral_collection(files, times, n_particles, particles_info, vectorize_velocity)">
+    <Grid Name="temporal" GridType="Collection" CollectionType="Temporal" >
+    % for index, (file, time) in enumerate(zip(files,times)):
+      <Grid Name="spatial" GridType="Collection" CollectionType="Spatial" >
+        <Time Type="Single" Value="   ${time}" />\
+        ${spatial_collection(file, index, n_particles, particles_info, vectorize_velocity)}\
+      </Grid>
+    % endfor
+    </Grid>
+</%def>
+
+<%def name="spatial_collection(file, index, n_particles, particles_info, vectorize_velocity)">
+  % for pname, data in particles_info.items():
+        <Grid Name="${pname}" GridType="Uniform">\
+          ${topo_and_geom(file, pname, n_particles[pname][index])}\
+          ${variables_data(file, pname, n_particles[pname][index], data['output_props'],data['stride'], data['attr_type'], vectorize_velocity)}\
+        </Grid>
+  % endfor
+</%def>
+
+<%def name="topo_and_geom(file, pname, n_particles)">
+          <Topology TopologyType="Polyvertex" Dimensions="${n_particles}" NodesPerElement="1"/>
+          <Geometry Type="X_Y_Z">
+            <DataItem Format="HDF" Dimensions="${n_particles}" NumberType="Float">
+              ${file}:/particles/${pname}/arrays/x
+            </DataItem>
+            <DataItem Format="HDF" Dimensions="${n_particles}" NumberType="Float">
+              ${file}:/particles/${pname}/arrays/y
+            </DataItem>
+            <DataItem Format="HDF" Dimensions="${n_particles}" NumberType="Float">
+              ${file}:/particles/${pname}/arrays/z
+            </DataItem>
+          </Geometry>
+</%def>
+
+<%def name="variables_data(file, pname, n_particles, var_names, stride, attr_type, vectorize_velocity)">
+  % for var_name in var_names:
+          <Attribute Name="${var_name}" AttributeType="${attr_type[var_name]}" Center="Node">
+            <DataItem Format="HDF" Dimensions="${n_particles} ${stride[var_name]}" NumberType="float">
+              ${file}:/particles/${pname}/arrays/${var_name}
+            </DataItem>
+          </Attribute>
+  % endfor
+  % if vectorize_velocity:
+          <Attribute Name="V" AttributeType="Vector" Center="Node">
+            <DataItem Dimensions="${n_particles} 3" Function="JOIN($0, $1, $2)" ItemType="Function">
+              <DataItem Dimensions="${n_particles} 1" Format="HDF" NumberType="Float">
+                ${file}:/particles/${pname}/arrays/u
+              </DataItem>
+              <DataItem Dimensions="${n_particles} 1" Format="HDF" NumberType="Float">
+                ${file}:/particles/${pname}/arrays/v
+              </DataItem>
+              <DataItem Dimensions="${n_particles} 1" Format="HDF" NumberType="Float">
+                ${file}:/particles/${pname}/arrays/w
+              </DataItem>
+            </DataItem>
+          </Attribute>
+  % endif
+</%def>

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest>=3.0
 mock>=1.0
 h5py
+vtk

--- a/setup.py
+++ b/setup.py
@@ -684,7 +684,7 @@ def setup_package():
         'numpy', 'mako', 'cyarray', 'compyle>=0.8', 'Cython>=0.20',
         'setuptools>=42.0.0', 'pytools', 'Beaker'
     ]
-    tests_require = ['pytest>=3.0', 'h5py']
+    tests_require = ['pytest>=3.0', 'h5py', 'vtk']
     if sys.version_info[:2] == (2, 6):
         install_requires += [
             'ordereddict', 'importlib'


### PR DESCRIPTION
Improved https://github.com/pypr/pysph/pull/356

1. `generate_xdmf` is now `dump_xdmf`.
2. vectorize velocity is now default.
3. added a test case to check generated xdmf.
4. hdf5 files are are referred by relative paths in xdmf by default. 