### PR TITLE
ci(actions): fix tests failing on windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,8 +42,8 @@ jobs:
           conda install -c conda-forge numpy cython h5py
           python -m pip install https://github.com/pypr/cyarray/zipball/master
           python -m pip install https://github.com/pypr/compyle/zipball/master
-          python -m pip install -r requirements.txt
-          python -m pip install -e ".[dev]"
+          python -m pip install -r requirements.txt -r requirements-test.txt
+          python setup.py develop
           python -m pip list
       # Cache auto-generated code. Cache key changes every month.
       # Thanks https://stackoverflow.com/a/60942437


### PR DESCRIPTION
- fixed by using `python setup.py develop` instead of `pip install -e .`

- cause ? : https://github.com/pypa/pip/issues/11467