### PR TITLE
SPLASH Interpolator

### DIFF
--- a/docs/source/reference/tools.rst
+++ b/docs/source/reference/tools.rst
@@ -35,6 +35,12 @@ This module provides a convenient class called
 scalar values from the points onto either a mesh or a collection of other
 points.  SPH interpolation is performed with a simple Shepard filtering.
 
+These is also a :py:class:`~interpolator.SplashInterpolator` which can be used
+just like :py:class:`~interpolator.Interpolator`.
+:py:class:`~interpolator.SplashInterpolator` may result in higher errors than
+:py:class:`~interpolator.Interpolator` but is expected to capture the finer
+details when smoothing length is not constant.
+
 .. automodule:: pysph.tools.interpolator
     :members:
     :undoc-members:

--- a/pysph/tools/tests/test_interpolator.py
+++ b/pysph/tools/tests/test_interpolator.py
@@ -13,7 +13,8 @@ except ImportError:
 import numpy as np
 
 # Local imports
-from pysph.tools.interpolator import get_nx_ny_nz, Interpolator
+from pysph.tools.interpolator import (get_nx_ny_nz, Interpolator,
+                                      SplashInterpolator)
 from pysph.base.nnps_base import DomainManager
 from pysph.base.utils import get_particle_array
 
@@ -338,6 +339,204 @@ class TestInterpolator(unittest.TestCase):
 
         # Then.
         self.assertRaises(RuntimeError, ip.interpolate, 'p', 1)
+
+
+class TestSplashInterpolator(unittest.TestCase):
+    def _make_2d_grid(self, name='fluid'):
+        n = 101
+        dx = 2.0/(n-1)
+        x, y = np.mgrid[-1.+dx/2:1.:dx, -1.+dx/2:1.:dx]
+        z = np.zeros_like(x)
+        x, y, z = x.ravel(), y.ravel(), z.ravel()
+        m = np.ones_like(x)
+        p = np.sin(x * np.pi)
+        h = np.ones_like(x)*2.*dx
+        u = np.cos(x * np.pi)
+        rho = np.ones_like(x)*m/(dx*dx)
+        pa = get_particle_array(name=name, x=x, y=y, z=z, h=h, m=m, p=p, u=u,
+                                rho=rho)
+        return pa
+
+    @property
+    def _domain(self):
+        x0 = 1.0
+        domain = DomainManager(
+            xmin=-x0, xmax=x0, ymin=-x0, ymax=x0,
+            periodic_in_x=True, periodic_in_y=True
+        )
+        return domain
+
+    def test_should_work_on_2d_data(self):
+        # Given
+        pa = self._make_2d_grid()
+
+        # When.
+        ip = SplashInterpolator([pa], num_points=1000,
+                                domain_manager=self._domain, normalize=True)
+        p = ip.interpolate('p')
+        u = ip.interpolate('u')
+
+        # Then.
+        expect = np.sin(ip.x * np.pi)
+        np.testing.assert_allclose(p, expect, rtol=5e-2)
+        expect = np.cos(ip.x * np.pi)
+        np.testing.assert_allclose(u, expect, rtol=5e-2)
+
+    def test_should_work_with_multiple_arrays(self):
+        # Given
+        pa1 = self._make_2d_grid()
+        pa2 = self._make_2d_grid('solid')
+        pa2.p[:] = 4.0
+        pa2.u[:] = 0.2
+
+        # When.
+        ip = SplashInterpolator([pa1, pa2], num_points=1000,
+                          domain_manager=self._domain, normalize=True)
+        p = ip.interpolate('p')
+        u = ip.interpolate('u')
+
+        # Then.
+        expect = (np.sin(ip.x * np.pi) + 4.0) * 0.5
+        np.testing.assert_allclose(p, expect, rtol=5e-2)
+        expect = (np.cos(ip.x * np.pi) + 0.2) * 0.5
+        np.testing.assert_allclose(u, expect, rtol=5e-2)
+
+    def test_should_work_with_ghost_particles(self):
+        # Given
+        pa = self._make_2d_grid()
+        # Make half the particles ghosts.
+        n = pa.get_number_of_particles()
+        pa.tag[int(n//2):] = 1
+        pa.align_particles()
+
+        # When.
+        ip = SplashInterpolator([pa], num_points=1000,
+                                domain_manager=self._domain, normalize=True)
+        p = ip.interpolate('p')
+        u = ip.interpolate('u')
+
+        # Then.
+        expect = np.sin(ip.x * np.pi)
+        np.testing.assert_allclose(p, expect, rtol=5e-2)
+        expect = np.cos(ip.x * np.pi)
+        np.testing.assert_allclose(u, expect, rtol=5e-2)
+
+    @unittest.expectedFailure
+    def test_should_work_with_changed_data(self):
+        # Since the given particle arrays is copied over to form a new master
+        # particle arrays in SplashInterpolator, changing the property of
+        # given pa hs no effect. So, this test is expected to fail.
+
+        # Given
+        pa = self._make_2d_grid()
+        ip = SplashInterpolator([pa], num_points=1000,
+                                domain_manager=self._domain)
+        p = ip.interpolate('p')
+
+        # When.
+        pa.p *= 2.0
+        ip.update()
+        p = ip.interpolate('p')
+
+        # Then.
+        expect = np.sin(ip.x * np.pi) * 2.0
+        np.testing.assert_allclose(p, expect, rtol=5e-2)
+
+    def test_should_be_able_to_update_particle_arrays(self):
+        # Given
+        pa = self._make_2d_grid()
+        pa_new = self._make_2d_grid()
+        pa_new.p[:] = np.cos(pa_new.x * np.pi)
+
+        ip = SplashInterpolator([pa], num_points=1000,
+                                domain_manager=self._domain, normalize=True)
+        p = ip.interpolate('p')
+
+        # When.
+        ip.update_particle_arrays([pa_new])
+        p = ip.interpolate('p')
+
+        # Then.
+        expect = np.cos(ip.x * np.pi)
+        np.testing.assert_allclose(p, expect, rtol=5e-2)
+
+    def test_should_correctly_update_domain(self):
+        # Given
+        pa = self._make_2d_grid()
+        ip = SplashInterpolator([pa], num_points=1000,
+                                domain_manager=self._domain, normalize=True)
+        p = ip.interpolate('p')
+
+        # When.
+        ip.set_domain((0.1, 1.0, 0.1, 1.0, 0.0, 0.0), (11, 11, 1))
+        p = ip.interpolate('p')
+
+        # Then.
+        expect = np.sin(ip.x * np.pi)
+        np.testing.assert_allclose(p, expect, atol=5e-2)
+
+    def test_should_work_when_arrays_have_different_props(self):
+        # Given
+        pa1 = self._make_2d_grid()
+        pa1.add_property('junk', default=2.0, type='int')
+        pa2 = self._make_2d_grid('solid')
+
+        # When.
+        ip = SplashInterpolator([pa1, pa2], num_points=1000,
+                          domain_manager=self._domain, normalize=True)
+        junk = ip.interpolate('junk')
+
+        # Then.
+        expect = np.ones_like(junk)*1.0
+        self.assertTrue(np.allclose(junk, expect))
+
+    def test_should_work_with_explicit_points_in_constructor(self):
+        # Given
+        pa = self._make_2d_grid()
+        x, y = np.random.random((2, 5, 5))
+        z = np.zeros_like(x)
+
+        # When.
+        ip = SplashInterpolator([pa], x=x, y=y, z=z,
+                                domain_manager=self._domain, normalize=True)
+        p = ip.interpolate('p')
+
+        # Then.
+        self.assertEqual(p.shape, x.shape)
+        expect = np.sin(ip.x * np.pi)
+        np.testing.assert_allclose(p, expect, rtol=5e-2)
+
+    def test_should_work_with_explicit_points_without_z(self):
+        # Given
+        pa = self._make_2d_grid()
+        x, y = np.random.random((2, 5, 5))
+
+        # When.
+        ip = SplashInterpolator([pa], x=x, y=y, domain_manager=self._domain,
+                                normalize=True)
+        p = ip.interpolate('p')
+
+        # Then.
+        self.assertEqual(p.shape, x.shape)
+        expect = np.sin(ip.x * np.pi)
+        print(np.max(np.abs((p - expect)/expect)))
+        np.testing.assert_allclose(p, expect, rtol=5e-2)
+
+    def test_that_set_interpolation_points_works(self):
+        # Given
+        pa = self._make_2d_grid()
+        ip = SplashInterpolator([pa], num_points=1000,
+                                domain_manager=self._domain, normalize=True)
+
+        # When.
+        x, y = np.random.random((2, 5, 5))
+        ip.set_interpolation_points(x=x, y=y)
+        p = ip.interpolate('p')
+
+        # Then.
+        self.assertEqual(p.shape, x.shape)
+        expect = np.sin(ip.x * np.pi)
+        np.testing.assert_allclose(p, expect, rtol=5e-2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
An example where this interpolator performs better than the existing interpolator:

Attempting to interpolate the central region marked by the square from the following solution onto a 1000x1000 grid.
![riemann_2d](https://user-images.githubusercontent.com/11260095/213921285-4032d7fe-cc55-4bd2-afeb-23c82d619faf.png)

### Results for Comparison

#### Existing `pysph.tools.interpolator.Interpolator`
![pysph-existing](https://user-images.githubusercontent.com/11260095/213921478-da112cec-d264-48ec-91f8-cb01913bd82e.png)

#### New `pysph.tools.interpolator.SplashInterpolator`
![pysph-splash-new](https://user-images.githubusercontent.com/11260095/213921493-f2602cea-ea8e-4134-b873-09e415d5ffc5.png)

#### [SPLASH](https://users.monash.edu.au/~dprice/splash/)
![original-splash](https://user-images.githubusercontent.com/11260095/213921576-434b6613-22f3-49ba-96c8-45cb5b3feb03.png)

