### PR TITLE
Reuse interpolators instead of creating afresh.

### DIFF
--- a/pysph/examples/dam_break/dam_break_3d_lobovsky.py
+++ b/pysph/examples/dam_break/dam_break_3d_lobovsky.py
@@ -121,10 +121,14 @@ class DamBreak3D(Application):
 
         from mayavi import mlab
 
+        interp = None
         for sd, arrays1, arrays2 in iter_output(files, "fluid", "boundary"):
             t.append(sd["t"]*factor_x)
-            interp = Interpolator([arrays1, arrays2],
-                                  x=p_x, y=p_y, z=p_z, method="shepard")
+            if interp is None:
+                interp = Interpolator([arrays1, arrays2],
+                                      x=p_x, y=p_y, z=p_z, method="shepard")
+            else:
+                interp.update_particle_arrays([arrays1, arrays2])
             p0.append(interp.interpolate('p')*factor_y)
 
         fname = os.path.join(self.output_dir, 'results.npz')

--- a/pysph/examples/dam_break/db_2d_buchner.py
+++ b/pysph/examples/dam_break/db_2d_buchner.py
@@ -115,10 +115,14 @@ class DamBreak2DBuchner(DamBreak2D):
 
         t = []
         p0 = []
+        interp = None
         for sd, arrays1, arrays2 in iter_output(files, "fluid", "boundary"):
             t.append(sd["t"]*factor_x)
-            interp = Interpolator([arrays1, arrays2], x=[container_width],
-                                  y=[H*0.2], method=self.interp_method)
+            if interp is None:
+                interp = Interpolator([arrays1, arrays2], x=[container_width],
+                                      y=[H*0.2], method=self.interp_method)
+            else:
+                interp.update_particle_arrays([arrays1, arrays2])
             p0.append(interp.interpolate('p')*factor_y)
 
         plt.plot(t, p0, label="Computed")

--- a/pysph/examples/dam_break/db_3d_yeh.py
+++ b/pysph/examples/dam_break/db_3d_yeh.py
@@ -137,10 +137,14 @@ class DamBreak3D(Application):
         vp_y = 0.0
         vp_z = 0.026
 
+        interp = None
         for sd, arrays in iter_output(files, "fluid"):
             t.append(sd["t"])
-            interp = Interpolator([arrays],
-                                  x=vp_x, y=vp_y, z=vp_z, method="shepard")
+            if interp is None:
+                interp = Interpolator([arrays],
+                                      x=vp_x, y=vp_y, z=vp_z, method="shepard")
+            else:
+                interp.update_particle_arrays([arrays])
             u.append(interp.interpolate('u'))
 
         u = np.array(u)

--- a/pysph/examples/dam_break_3d.py
+++ b/pysph/examples/dam_break_3d.py
@@ -120,12 +120,16 @@ class DamBreak3D(Application):
         p_y = np.repeat(0, 2)
         p_z = np.array([0.021, 0.101])
 
+        interp = None
         for sd, arrays1, arrays2, arrays3 in iter_output(
                 files, "fluid", "obstacle", "boundary"
         ):
             t.append(sd["t"]*factor_x)
-            interp = Interpolator([arrays1, arrays2, arrays3],
-                                  x=p_x, y=p_y, z=p_z, method="shepard")
+            if interp is None:
+                interp = Interpolator([arrays1, arrays2, arrays3],
+                                      x=p_x, y=p_y, z=p_z, method="shepard")
+            else:
+                interp.update_particle_arrays([arrays1, arrays2, arrays3])
             p0.append(interp.interpolate('p')*factor_y)
 
         fname = os.path.join(self.output_dir, 'results.npz')

--- a/pysph/examples/shallow_water/okushiri_tsunami.py
+++ b/pysph/examples/shallow_water/okushiri_tsunami.py
@@ -415,13 +415,17 @@ class OkushiriTsunami(Application):
                                                y_loc_to_interpolate)):
             t_arr = []
             dw_arr = []
+            interp = None
             for fname in self.output_files:
                 data = load(fname)
                 fluid = data['arrays']['fluid']
                 t_arr.append(data['solver_data']['t'])
-                interp = Interpolator([fluid], kernel=kernel)
-                interp.set_interpolation_points(x_loc,
-                                                y_loc)
+                if interp is None:
+                    interp = Interpolator([fluid], kernel=kernel)
+                    interp.set_interpolation_points(x_loc,
+                                                    y_loc)
+                else:
+                    interp.update_particle_arrays([fluid])
                 dw_interp = interp.interpolate('dw')
                 dw_arr.append(dw_interp)
 

--- a/pysph/examples/shallow_water/thacker_basin.py
+++ b/pysph/examples/shallow_water/thacker_basin.py
@@ -254,13 +254,17 @@ class ThackerBasin(Application):
         y_loc_to_interpolate = 0.0
 
         kernel = CubicSpline(dim=2)
+        interp = None
         for fname in self.output_files:
             data = load(fname)
             fluid = data['arrays']['fluid']
             t_arr.append(data['solver_data']['t'])
-            interp = Interpolator([fluid], kernel=kernel)
-            interp.set_interpolation_points(x_loc_to_interpolate,
-                                            y_loc_to_interpolate)
+            if interp is None:
+                interp = Interpolator([fluid], kernel=kernel)
+                interp.set_interpolation_points(x_loc_to_interpolate,
+                                                y_loc_to_interpolate)
+            else:
+                interp.update_particle_arrays([fluid])
             u_interp = interp.interpolate('u')
             v_interp = interp.interpolate('v')
             dw_interp = interp.interpolate('dw')


### PR DESCRIPTION
Earlier this was not a problem but a recent PR has introduced group names, so each time the interpolator is constructed, it creates new Equation groups which have their own names and each name is unique, so this means the compilation is performed on each data file being processed. I have changed this for now to reuse the interpolator while post-processing.