### PR TITLE
Issues with play

### DIFF
--- a/pysph/tools/mayavi_viewer.py
+++ b/pysph/tools/mayavi_viewer.py
@@ -1201,7 +1201,6 @@ class MayaviViewer(HasTraits):
             else:
                 self.timer.Stop()
                 pc = nf
-                self.play = False
         elif pc < 0:
             if self.loop:
                 pc = nf

--- a/pysph/tools/mayavi_viewer.py
+++ b/pysph/tools/mayavi_viewer.py
@@ -771,7 +771,6 @@ class MayaviViewer(HasTraits):
                                      height=_pbcbh,
                                      tooltip='Previous File'),
                                 Item('play_pause_button',
-                                     enabled_when='file_count < _n_files',
                                      show_label=False,
                                      tooltip='Play/Pause',
                                      editor=ButtonEditor(
@@ -1165,6 +1164,9 @@ class MayaviViewer(HasTraits):
 
         if self.record:
             self._do_snap()
+
+        if self.play:
+            self._play_changed(self.play)
 
     def _loop_changed(self, value):
         if value and self.play:


### PR DESCRIPTION
commit https://github.com/pypr/pysph/commit/7a377d60297df3f4c4bb7518ef90da11128546e9 is reverted.

1. When play trait is set to true and the last file is reached, if the slider is dragged back, the play trait is still true, but the file count is not incremented automatically, i.e it actually stays paused. The reverted commit was actually intended to fix this.

2. In the reverted commit, play trait was set to false when the last file is reached. But it would be better to not change the play trait so that when more files are added and refresh button is pressed, it continues to play.

3. The issue mentioned in the first point is fixed.

3. The play/pause button is always enabled.