### PR TITLE
bug: mother group's pre and post ignored

### DIFF
--- a/pysph/sph/acceleration_eval_cython.mako
+++ b/pysph/sph/acceleration_eval_cython.mako
@@ -311,6 +311,10 @@ cdef class AccelerationEval:
         ## ---------------------
         ## ---- Subgroups start
         % if group.has_subgroups:
+        % if group.pre:
+        with profile_ctx("AccelerationEval.${group.name}.pre"):
+            ${indent(helper.get_pre_call(group), indent_lvl + 1)}
+        % endif
         % for sg_idx, sub_group in enumerate(group.data):
         ${indent("# Doing subgroup " + str(sg_idx), indent_lvl)}
         % if sub_group.condition is not None:
@@ -328,6 +332,23 @@ cdef class AccelerationEval:
         % endfor # (for sg_idx, sub_group in enumerate(group.data))
         ## ---- Subgroups done
         ## ---------------------
+        #######################################################################
+        ## Update NNPS locally if needed
+        #######################################################################
+        % if group.update_nnps:
+        # Updating NNPS.
+        with profile_ctx("Integrator.update_domain"):
+            nnps.update_domain()
+        with profile_ctx("nnps.update"):
+            nnps.update()
+        % endif
+        #######################################################################
+        ## Call any `post` functions
+        #######################################################################
+        % if group.post:
+        with profile_ctx("AccelerationEval.${group.name}.post"):
+            ${indent(helper.get_post_call(group), indent_lvl + 1)}
+        % endif
         % else:  # No subgroups
         ${indent(do_group(helper, group, indent_lvl), indent_lvl)}
         % endif  # (if group.has_subgroups)

--- a/pysph/sph/acceleration_eval_cython_helper.py
+++ b/pysph/sph/acceleration_eval_cython_helper.py
@@ -165,10 +165,12 @@ class AccelerationEvalCythonHelper(object):
         depends = ["pysph.base.nnps_base"]
         # Add pysph/base directory to inc_dirs for including spatial_hash.h
         # for SpatialHashNNPS
+        cython_inc = [dirname(dirname(dirname(realpath(__file__))))]
         extra_inc_dirs = [join(dirname(dirname(realpath(__file__))), 'base')]
         self._ext_mod = ExtModule(
             code, verbose=False, root=root, depends=depends,
-            extra_inc_dirs=extra_inc_dirs
+            extra_inc_dirs=extra_inc_dirs, 
+            cython_inc_dirs=cython_inc
         )
         self._module = self._ext_mod.load()
         return self._module

--- a/pysph/sph/acceleration_eval_gpu.mako
+++ b/pysph/sph/acceleration_eval_gpu.mako
@@ -103,6 +103,15 @@ ${helper.get_header()}
 ## Handle sub-groups.
 #######################################################################
 % if group.has_subgroups:
+#######################################################################
+## Call any `pre` functions
+#######################################################################
+% if group.pre:
+<% helper.call_pre(group) %>
+% endif
+#######################################################################
+## Loop over sub-groups
+#######################################################################
 % for sg_idx, sub_group in enumerate(group.data):
 // Subgroup ${sg_idx}
 % if sub_group.condition is not None:
@@ -110,6 +119,18 @@ ${helper.get_header()}
 % endif
 ${do_group(helper, g_idx, sg_idx, sub_group)}
 % endfor ## sg_idx
+#######################################################################
+## Update NNPS locally if needed
+#######################################################################
+% if group.update_nnps:
+<% helper.call_update_nnps(group) %>
+% endif
+#######################################################################
+## Call any `post` functions
+#######################################################################
+% if group.post:
+<% helper.call_post(group) %>
+% endif
 % else:
 ${do_group(helper, g_idx, -1, group)}
 % endif ## has_subgroups

--- a/pysph/sph/tests/test_acceleration_eval.py
+++ b/pysph/sph/tests/test_acceleration_eval.py
@@ -530,7 +530,7 @@ class TestAccelerationEval1D(unittest.TestCase):
         expect = np.asarray([7., 9., 11., 11., 11., 11., 11., 11., 9., 7.])
         self.assertListEqual(list(pa.u), list(expect))
 
-    def test_should_call_pre_post_functions_in_outer_group_of_nested_group(self):
+    def test_should_call_pre_post_in_mother_group_with_cython(self):
         # Given
         pa = self.pa
 
@@ -1052,7 +1052,7 @@ class TestAccelerationEval1DGPU(unittest.TestCase):
         self.assertListEqual(list(pa.u), list(expect))
 
 
-    def test_should_call_pre_post_functions_in_mother_group_of_nested_group_on_gpu(self):
+    def test_should_call_pre_post_in_mother_group_on_gpu(self):
         # Given
         pa = self.pa
 


### PR DESCRIPTION
If we have a mother group that contains subgroups, then that mother group's `pre`, `post` and `update_nnps` were getting ignored. This is fixed.