### PR TITLE
No need to add the cython include always.

### DIFF
--- a/pysph/sph/acceleration_eval_cython_helper.py
+++ b/pysph/sph/acceleration_eval_cython_helper.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from os.path import dirname, join, expanduser, realpath
+import sys
 from textwrap import dedent
 
 from mako.template import Template
@@ -165,11 +166,15 @@ class AccelerationEvalCythonHelper(object):
         depends = ["pysph.base.nnps_base"]
         # Add pysph/base directory to inc_dirs for including spatial_hash.h
         # for SpatialHashNNPS
-        cython_inc = [dirname(dirname(dirname(realpath(__file__))))]
+        pysph_root = dirname(dirname(dirname(realpath(__file__))))
+        if pysph_root in sys.path:
+            cython_inc = None
+        else:
+            cython_inc = [pysph_root]
         extra_inc_dirs = [join(dirname(dirname(realpath(__file__))), 'base')]
         self._ext_mod = ExtModule(
             code, verbose=False, root=root, depends=depends,
-            extra_inc_dirs=extra_inc_dirs, 
+            extra_inc_dirs=extra_inc_dirs,
             cython_inc_dirs=cython_inc
         )
         self._module = self._ext_mod.load()


### PR DESCRIPTION
When the root is already in `sys.path` this is not necessary. Adding it is necessary when an editable installation is performed where the `pysph_root` is not in `sys.path`.